### PR TITLE
feat: Implement initialization event for Vault contract

### DIFF
--- a/contracts/vault/Cargo.toml
+++ b/contracts/vault/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 publish = false
 
 [lib]
-crate-type = ["cdylib"]
+crate-type = ["cdylib", "rlib"]
 doctest = false
 
 [dependencies]

--- a/contracts/vault/src/lib.rs
+++ b/contracts/vault/src/lib.rs
@@ -15,10 +15,18 @@ pub struct CalloraVault;
 #[contractimpl]
 impl CalloraVault {
     /// Initialize vault for an owner with optional initial balance.
+    /// Emits an "init" event with the owner address and initial balance.
     pub fn init(env: Env, owner: Address, initial_balance: Option<i128>) -> VaultMeta {
         let balance = initial_balance.unwrap_or(0);
-        let meta = VaultMeta { owner, balance };
+        let meta = VaultMeta { owner: owner.clone(), balance };
         env.storage().instance().set(&Symbol::new(&env, "meta"), &meta);
+
+        // Emit event: topics = (init, owner), data = balance
+        env.events().publish(
+            (Symbol::new(&env, "init"), owner),
+            balance,
+        );
+
         meta
     }
 

--- a/contracts/vault/src/test.rs
+++ b/contracts/vault/src/test.rs
@@ -1,22 +1,49 @@
+extern crate std;
+
 use super::*;
-use soroban_sdk::testutils::Address as _;
+use soroban_sdk::testutils::{Address as _, Events as _};
+use soroban_sdk::{IntoVal, Symbol};
 
 #[test]
 fn init_and_balance() {
     let env = Env::default();
     let owner = Address::generate(&env);
-    let contract_id = env.register_contract(None, CalloraVault {});
-    let client = CalloraVaultClient::new(&env, &contract_id);
+    let contract_id = env.register(CalloraVault {}, ());
 
-    client.init(&owner, &Some(1000));
+    // Call init directly inside as_contract so events are captured
+    let events = env.as_contract(&contract_id, || {
+        CalloraVault::init(env.clone(), owner.clone(), Some(1000));
+        env.events().all()
+    });
+
+    // Verify balance through client
+    let client = CalloraVaultClient::new(&env, &contract_id);
     assert_eq!(client.balance(), 1000);
+
+    // Verify "init" event was emitted
+    let last_event = events.last().expect("expected at least one event");
+
+    // Contract ID matches
+    assert_eq!(last_event.0, contract_id);
+
+    // Topic 0 = Symbol("init"), Topic 1 = owner address
+    let topics = &last_event.1;
+    assert_eq!(topics.len(), 2);
+    let topic0: Symbol = topics.get(0).unwrap().into_val(&env);
+    let topic1: Address = topics.get(1).unwrap().into_val(&env);
+    assert_eq!(topic0, Symbol::new(&env, "init"));
+    assert_eq!(topic1, owner);
+
+    // Data = initial balance as i128
+    let data: i128 = last_event.2.into_val(&env);
+    assert_eq!(data, 1000);
 }
 
 #[test]
 fn deposit_and_deduct() {
     let env = Env::default();
     let owner = Address::generate(&env);
-    let contract_id = env.register_contract(None, CalloraVault {});
+    let contract_id = env.register(CalloraVault {}, ());
     let client = CalloraVaultClient::new(&env, &contract_id);
 
     client.init(&owner, &Some(100));


### PR DESCRIPTION
<h2>Summary</h2>
<p>This PR adds on-chain transparency for the initialization process by emitting a Soroban event. This allows indexers and frontend applications to track when a vault is created, who the owner is, and what the initial balance setup was.</p>
<p>The implementation handles the specific event-capturing requirements of Soroban SDK v22 by utilizing <code>env.as_contract</code> in the test suite to ensure events are correctly recorded and verified.</p>
<hr>
<h2>Changes</h2>
<h3> Event Emission</h3>
<ul>
<li>Implemented <code>env.events().publish</code> in the <code>init</code> function to broadcast vault creation on-chain.</li>
<li><strong>Topic Structure</strong> — Set topics to <code>(Symbol("init"), owner)</code> for efficient indexer filtering.</li>
<li><strong>Data Payload</strong> — Included the initial <code>balance</code> as the event data for full context on creation.</li>
</ul>
<h3> Test Suite</h3>
<ul>
<li>Updated <code>test.rs</code> with robust event verification using <code>as_contract</code> context to correctly capture and assert Soroban SDK v22 events.</li>
</ul>
<h3> SDK Compatibility &amp; Fixes</h3>
<ul>
<li>Resolved deprecation warnings for <code>env.logger()</code> and <code>env.register_contract()</code>.</li>
<li>Correctly restored <code>#![no_std]</code> and fixed the <code>init</code> return type to maintain contract standards.</li>
</ul>
<hr>
<h2>Checklist</h2>
<ul>
<li>[x] Event emission via <code>env.events().publish</code> in <code>init</code></li>
<li>[x] Topic structure set to <code>(Symbol("init"), owner)</code> for filtering</li>
<li>[x] Initial <code>balance</code> included as event data payload</li>
<li>[x] Test updated with <code>as_contract</code> event verification</li>
<li>[x] Deprecation warnings resolved for <code>env.logger()</code> and <code>env.register_contract()</code></li>

<img width="882" height="395" alt="Screenshot 2026-02-20 010228" src="https://github.com/user-attachments/assets/f2c69be1-f8bc-45f5-9d35-a0b2e608a8b2" />

closes #7 