### PR TITLE
feat: Add event schema documentation and implement batch deduct functionality

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,66 @@
+name: CI
+
+on:
+  push:
+    branches: [main, master, develop, 'feature/**']
+  pull_request:
+    branches: [main, master, develop]
+
+jobs:
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt, clippy
+
+      - name: Cache cargo
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock', '**/Cargo.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
+
+      - name: Check format
+        run: cargo fmt --all -- --check
+
+      - name: Clippy
+        run: cargo clippy --all-targets --all-features -- -D warnings
+
+      - name: Test
+        run: cargo test
+
+  build:
+    name: Build (release)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+
+      - name: Cache cargo
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock', '**/Cargo.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
+
+      - name: Build WASM
+        run: |
+          cd contracts/vault
+          cargo build --target wasm32-unknown-unknown --release

--- a/EVENT_SCHEMA.md
+++ b/EVENT_SCHEMA.md
@@ -1,0 +1,72 @@
+# Event Schema (Vault Contract)
+
+Events emitted by the Callora vault contract for indexers and frontends. All topic/data types refer to Soroban/Stellar XDR values.
+
+## Contract: Callora Vault
+
+### `init`
+
+Emitted when the vault is initialized.
+
+| Field   | Location | Type   | Description           |
+|---------|----------|--------|-----------------------|
+| topic 0 | topics   | Symbol | `"init"`              |
+| topic 1 | topics   | Address| vault owner           |
+| data    | data     | i128   | initial balance       |
+
+---
+
+### `deposit`
+
+Emitted when balance is increased via `deposit(amount)`.
+
+| Field   | Location | Type   | Description   |
+|---------|----------|--------|---------------|
+| topic 0 | topics   | Symbol | `"deposit"`   |
+| data    | data     | (i128, i128) | (amount, new_balance) |
+
+---
+
+### `deduct`
+
+Emitted on each deduction: single `deduct(amount)` or each item in `batch_deduct(items)`.
+
+| Field   | Location | Type   | Description   |
+|---------|----------|--------|---------------|
+| topic 0 | topics   | Symbol | `"deduct"`    |
+| topic 1 | topics   | Symbol | optional request_id (empty symbol if none) |
+| data    | data     | (i128, i128) | (amount, new_balance) |
+
+---
+
+### `withdraw`
+
+Emitted when the owner withdraws via `withdraw(amount)`.
+
+| Field   | Location | Type   | Description   |
+|---------|----------|--------|---------------|
+| topic 0 | topics   | Symbol | `"withdraw"`  |
+| topic 1 | topics   | Address| vault owner   |
+| data    | data     | (i128, i128) | (amount, new_balance) |
+
+---
+
+### `withdraw_to`
+
+Emitted when the owner withdraws to a designated address via `withdraw_to(to, amount)`.
+
+| Field   | Location | Type   | Description   |
+|---------|----------|--------|---------------|
+| topic 0 | topics   | Symbol | `"withdraw_to"` |
+| topic 1 | topics   | Address| vault owner   |
+| topic 2 | topics   | Address| recipient `to` |
+| data    | data     | (i128, i128) | (amount, new_balance) |
+
+---
+
+## Not yet implemented
+
+- **OwnershipTransfer**: not present in current vault; would list old_owner, new_owner.
+- **Pause**: not present in current vault; would indicate pause state change.
+
+Settlement or other contracts in this repo will have their events documented here as they are added.

--- a/README.md
+++ b/README.md
@@ -14,9 +14,12 @@ Soroban smart contracts for the Callora API marketplace: prepaid vault (USDC) an
   - `get_meta()` — owner and current balance
   - `deposit(amount)` — increase balance
   - `deduct(amount)` — decrease balance (e.g. per API call)
+  - `batch_deduct(items)` — multiple deducts in one transaction (reverts entire batch if any would exceed balance)
+  - `withdraw(amount)` — owner-only; decreases balance (USDC transfer when integrated)
+  - `withdraw_to(to, amount)` — owner-only; withdraw to a designated address
   - `balance()` — current balance
 
-Production use would add: USDC asset, auth (only backend or owner can deduct), and events.
+Events are emitted for init, deposit, deduct, withdraw, and withdraw_to. See [EVENT_SCHEMA.md](EVENT_SCHEMA.md) for indexer/frontend use.
 
 ## Local setup
 
@@ -45,7 +48,10 @@ Production use would add: USDC asset, auth (only backend or owner can deduct), a
 
 ```
 callora-contracts/
+├── .github/workflows/
+│   └── ci.yml              # CI: fmt, clippy, test, WASM build
 ├── Cargo.toml              # Workspace and release profile
+├── EVENT_SCHEMA.md         # Event names, topics, and payload types
 ├── contracts/
 │   └── vault/
 │       ├── Cargo.toml

--- a/contracts/vault/src/lib.rs
+++ b/contracts/vault/src/lib.rs
@@ -1,6 +1,14 @@
 #![no_std]
 
-use soroban_sdk::{contract, contractimpl, contracttype, Address, Env, Symbol};
+use soroban_sdk::{contract, contractimpl, contracttype, Address, Env, Symbol, Vec};
+
+/// Single item for batch deduct: amount and optional request id for idempotency/tracking.
+#[contracttype]
+#[derive(Clone)]
+pub struct DeductItem {
+    pub amount: i128,
+    pub request_id: Option<Symbol>,
+}
 
 #[contracttype]
 #[derive(Clone)]
@@ -18,14 +26,17 @@ impl CalloraVault {
     /// Emits an "init" event with the owner address and initial balance.
     pub fn init(env: Env, owner: Address, initial_balance: Option<i128>) -> VaultMeta {
         let balance = initial_balance.unwrap_or(0);
-        let meta = VaultMeta { owner: owner.clone(), balance };
-        env.storage().instance().set(&Symbol::new(&env, "meta"), &meta);
+        let meta = VaultMeta {
+            owner: owner.clone(),
+            balance,
+        };
+        env.storage()
+            .instance()
+            .set(&Symbol::new(&env, "meta"), &meta);
 
         // Emit event: topics = (init, owner), data = balance
-        env.events().publish(
-            (Symbol::new(&env, "init"), owner),
-            balance,
-        );
+        env.events()
+            .publish((Symbol::new(&env, "init"), owner), balance);
 
         meta
     }
@@ -39,19 +50,107 @@ impl CalloraVault {
     }
 
     /// Deposit increases balance. Callable by owner or designated depositor.
+    /// Emits a "deposit" event with amount and new balance.
     pub fn deposit(env: Env, amount: i128) -> i128 {
         let mut meta = Self::get_meta(env.clone());
         meta.balance += amount;
-        env.storage().instance().set(&Symbol::new(&env, "meta"), &meta);
+        env.storage()
+            .instance()
+            .set(&Symbol::new(&env, "meta"), &meta);
+
+        env.events()
+            .publish((Symbol::new(&env, "deposit"),), (amount, meta.balance));
         meta.balance
     }
 
     /// Deduct balance for an API call. Only backend/authorized caller in production.
+    /// Emits a "deduct" event with amount and new balance.
     pub fn deduct(env: Env, amount: i128) -> i128 {
         let mut meta = Self::get_meta(env.clone());
         assert!(meta.balance >= amount, "insufficient balance");
         meta.balance -= amount;
-        env.storage().instance().set(&Symbol::new(&env, "meta"), &meta);
+        env.storage()
+            .instance()
+            .set(&Symbol::new(&env, "meta"), &meta);
+
+        env.events()
+            .publish((Symbol::new(&env, "deduct"),), (amount, meta.balance));
+        meta.balance
+    }
+
+    /// Batch deduct: multiple (amount, optional request_id) in one transaction.
+    /// Reverts the entire batch if any single deduct would exceed balance.
+    /// Emits one "deduct" event per item (same shape as single deduct).
+    pub fn batch_deduct(env: Env, items: Vec<DeductItem>) -> i128 {
+        let mut meta = Self::get_meta(env.clone());
+        let n = items.len();
+        assert!(n > 0, "batch_deduct requires at least one item");
+
+        // Validate: running balance must never go negative
+        let mut running = meta.balance;
+        for item in items.iter() {
+            assert!(item.amount > 0, "amount must be positive");
+            assert!(running >= item.amount, "insufficient balance");
+            running -= item.amount;
+        }
+
+        // Apply all deductions and emit one event per deduct
+        let mut balance = meta.balance;
+        for item in items.iter() {
+            balance -= item.amount;
+            let topics = match &item.request_id {
+                Some(rid) => (Symbol::new(&env, "deduct"), rid.clone()),
+                None => (Symbol::new(&env, "deduct"), Symbol::new(&env, "")),
+            };
+            env.events().publish(topics, (item.amount, balance));
+        }
+
+        meta.balance = balance;
+        env.storage()
+            .instance()
+            .set(&Symbol::new(&env, "meta"), &meta);
+        meta.balance
+    }
+
+    /// Withdraw from vault. Callable only by the vault owner; reduces balance.
+    /// When USDC is integrated, funds will be transferred to the owner.
+    pub fn withdraw(env: Env, amount: i128) -> i128 {
+        let mut meta = Self::get_meta(env.clone());
+        meta.owner.require_auth();
+        assert!(amount > 0, "amount must be positive");
+        assert!(meta.balance >= amount, "insufficient balance");
+        meta.balance -= amount;
+        env.storage()
+            .instance()
+            .set(&Symbol::new(&env, "meta"), &meta);
+
+        env.events().publish(
+            (Symbol::new(&env, "withdraw"), meta.owner.clone()),
+            (amount, meta.balance),
+        );
+        meta.balance
+    }
+
+    /// Withdraw from vault to a designated address. Owner-only.
+    /// When USDC is integrated, funds will be transferred to `to`.
+    pub fn withdraw_to(env: Env, to: Address, amount: i128) -> i128 {
+        let mut meta = Self::get_meta(env.clone());
+        meta.owner.require_auth();
+        assert!(amount > 0, "amount must be positive");
+        assert!(meta.balance >= amount, "insufficient balance");
+        meta.balance -= amount;
+        env.storage()
+            .instance()
+            .set(&Symbol::new(&env, "meta"), &meta);
+
+        env.events().publish(
+            (
+                Symbol::new(&env, "withdraw_to"),
+                meta.owner.clone(),
+                to.clone(),
+            ),
+            (amount, meta.balance),
+        );
         meta.balance
     }
 

--- a/contracts/vault/src/test.rs
+++ b/contracts/vault/src/test.rs
@@ -2,7 +2,7 @@ extern crate std;
 
 use super::*;
 use soroban_sdk::testutils::{Address as _, Events as _};
-use soroban_sdk::{IntoVal, Symbol};
+use soroban_sdk::{vec, IntoVal, Symbol};
 
 #[test]
 fn init_and_balance() {
@@ -51,4 +51,126 @@ fn deposit_and_deduct() {
     assert_eq!(client.balance(), 300);
     client.deduct(&50);
     assert_eq!(client.balance(), 250);
+}
+
+#[test]
+fn batch_deduct_success() {
+    let env = Env::default();
+    let owner = Address::generate(&env);
+    let contract_id = env.register(CalloraVault {}, ());
+    let client = CalloraVaultClient::new(&env, &contract_id);
+
+    client.init(&owner, &Some(1000));
+    let req1 = Symbol::new(&env, "req1");
+    let req2 = Symbol::new(&env, "req2");
+    let items = vec![
+        &env,
+        DeductItem {
+            amount: 100,
+            request_id: Some(req1.clone()),
+        },
+        DeductItem {
+            amount: 200,
+            request_id: Some(req2.clone()),
+        },
+        DeductItem {
+            amount: 50,
+            request_id: None,
+        },
+    ];
+    let new_balance = client.batch_deduct(&items);
+    assert_eq!(new_balance, 650);
+    assert_eq!(client.balance(), 650);
+}
+
+#[test]
+#[should_panic(expected = "insufficient balance")]
+fn batch_deduct_reverts_entire_batch() {
+    let env = Env::default();
+    let owner = Address::generate(&env);
+    let contract_id = env.register(CalloraVault {}, ());
+    let client = CalloraVaultClient::new(&env, &contract_id);
+
+    client.init(&owner, &Some(100));
+    let items = vec![
+        &env,
+        DeductItem {
+            amount: 60,
+            request_id: None,
+        },
+        DeductItem {
+            amount: 60,
+            request_id: None,
+        }, // total 120 > 100
+    ];
+    client.batch_deduct(&items);
+}
+
+#[test]
+fn withdraw_owner_success() {
+    let env = Env::default();
+    let owner = Address::generate(&env);
+    let contract_id = env.register(CalloraVault {}, ());
+    let client = CalloraVaultClient::new(&env, &contract_id);
+
+    client.init(&owner, &Some(500));
+    env.mock_all_auths();
+    let new_balance = client.withdraw(&200);
+    assert_eq!(new_balance, 300);
+    assert_eq!(client.balance(), 300);
+}
+
+#[test]
+fn withdraw_exact_balance() {
+    let env = Env::default();
+    let owner = Address::generate(&env);
+    let contract_id = env.register(CalloraVault {}, ());
+    let client = CalloraVaultClient::new(&env, &contract_id);
+
+    client.init(&owner, &Some(100));
+    env.mock_all_auths();
+    let new_balance = client.withdraw(&100);
+    assert_eq!(new_balance, 0);
+    assert_eq!(client.balance(), 0);
+}
+
+#[test]
+#[should_panic(expected = "insufficient balance")]
+fn withdraw_exceeds_balance_fails() {
+    let env = Env::default();
+    let owner = Address::generate(&env);
+    let contract_id = env.register(CalloraVault {}, ());
+    let client = CalloraVaultClient::new(&env, &contract_id);
+
+    client.init(&owner, &Some(50));
+    env.mock_all_auths();
+    client.withdraw(&100);
+}
+
+#[test]
+fn withdraw_to_success() {
+    let env = Env::default();
+    let owner = Address::generate(&env);
+    let to = Address::generate(&env);
+    let contract_id = env.register(CalloraVault {}, ());
+    let client = CalloraVaultClient::new(&env, &contract_id);
+
+    client.init(&owner, &Some(500));
+    env.mock_all_auths();
+    let new_balance = client.withdraw_to(&to, &150);
+    assert_eq!(new_balance, 350);
+    assert_eq!(client.balance(), 350);
+}
+
+#[test]
+#[should_panic]
+fn withdraw_without_auth_fails() {
+    // Without mock_all_auths, invoker is not the owner, so require_auth(owner) fails.
+    let env = Env::default();
+    let owner = Address::generate(&env);
+    let contract_id = env.register(CalloraVault {}, ());
+    let client = CalloraVaultClient::new(&env, &contract_id);
+
+    client.init(&owner, &Some(100));
+    client.withdraw(&50);
 }


### PR DESCRIPTION
## Summary
Implements batch deduct (#23), owner withdraw (#25), event schema docs (#41), and adds CI/CD.

## Changes

### Batch deduct (#23)
- Added `DeductItem` (amount, optional request_id) and `batch_deduct(items)`.
- Multiple deducts in one transaction; full batch reverts if any would exceed balance.
- One "deduct" event per item (same shape as single deduct).
- Tests: batch success, batch revert on insufficient balance.

### Owner withdraw (#25)
- `withdraw(amount)` — owner-only via `require_auth`, reduces balance, emits event.
- `withdraw_to(to, amount)` — owner-only, designates recipient for future USDC transfer.
- Tests: owner withdraw, exact balance, over-withdraw fails, withdraw_to, non-owner fails without auth.

### Event schema (#41)
- Added `EVENT_SCHEMA.md`: init, deposit, deduct, withdraw, withdraw_to (topics + payload types).
- Emit events for deposit and single deduct for consistency.

### CI/CD
- `.github/workflows/ci.yml`: fmt check, clippy, `cargo test`, WASM build (release).
- Runs on push/PR to main, master, develop, feature/**.

### Other
- README updated with new contract methods and link to EVENT_SCHEMA.
- All tests passing (9); fmt and clippy clean.