### PR TITLE
test: init with None initial balance

### DIFF
--- a/contracts/vault/src/test.rs
+++ b/contracts/vault/src/test.rs
@@ -55,7 +55,6 @@ fn deposit_and_deduct() {
 
 #[test]
 fn init_none_balance() {
-fn batch_deduct_success() {
     let env = Env::default();
     let owner = Address::generate(&env);
     let contract_id = env.register(CalloraVault {}, ());
@@ -71,6 +70,15 @@ fn batch_deduct_success() {
     let meta = client.get_meta();
     assert_eq!(meta.owner, owner);
     assert_eq!(meta.balance, 0);
+}
+
+#[test]
+fn batch_deduct_success() {
+    let env = Env::default();
+    let owner = Address::generate(&env);
+    let contract_id = env.register(CalloraVault {}, ());
+    let client = CalloraVaultClient::new(&env, &contract_id);
+
     client.init(&owner, &Some(1000));
     let req1 = Symbol::new(&env, "req1");
     let req2 = Symbol::new(&env, "req2");


### PR DESCRIPTION
Fixes #10

Added a new unit test [init_none_balance](cci:1://file:///home/maryjane/Desktop/workspace/job/drip/Callora-Contracts/contracts/vault/src/test.rs:55:0-72:1) to verify that the vault correctly handles initialization with a `None` initial balance.

**Changes:**
- Implemented [init_none_balance](cci:1://file:///home/maryjane/Desktop/workspace/job/drip/Callora-Contracts/contracts/vault/src/test.rs:55:0-72:1) in [test.rs](cci:7://file:///home/maryjane/Desktop/workspace/job/drip/Callora-Contracts/contracts/vault/src/test.rs:0:0-0:0) to assert that initialization with `None` results in a zero balance and correct owner metadata.

**Verification:**
- Ran `cargo test --package callora-vault`
- `test test::init_none_balance ... ok`
Closes #10 - 