### PR TITLE
feat: add benchmarks and upgrade documentation for Callora Vault operations

### DIFF
--- a/BENCHMARKS.md
+++ b/BENCHMARKS.md
@@ -1,0 +1,34 @@
+# Vault Operation Gas / Cost Notes
+
+Approximate resource usage for Callora Vault operations to guide integration and capacity planning. Soroban uses resource metering (CPU instructions, ledger reads/writes, events). Exact numbers depend on network fee configuration and should be validated on testnet or via `soroban contract invoke` simulation.
+
+## Relative Cost (typical order)
+
+| Operation    | Relative cost | Notes |
+|-------------|---------------|--------|
+| `balance()` | Lowest        | Single instance read, no writes, no event. |
+| `get_meta()`| Low           | Same as balance (reads full meta). |
+| `deposit`   | Medium        | One read, one write, one event. |
+| `deduct`    | Medium        | One read, one write, one event. |
+| `withdraw`  | Medium        | One read, one write, one event. |
+| `withdraw_to` | Medium      | One read, one write, one event. |
+| `batch_deduct` | Medium–High | One read, one write, N events (one per item). |
+| `init`      | Highest       | First write (create instance), one event; requires auth. |
+
+## Obtaining Exact Numbers
+
+- **Testnet**: Deploy the vault and invoke each operation; inspect transaction meta for instructions and fee.
+- **CLI**: Use `soroban contract invoke` with `--simulate` (or equivalent) and check returned resource/fee info.
+- **Test env**: Run the optional benchmark test: `cargo test --ignored vault_operation_costs -- --nocapture`. This logs CPU/instruction and fee estimates per operation when invocation cost metering is enabled in the test environment.
+
+## Fee Configuration
+
+Soroban fees are configured per network (e.g. Pubnet). They are applied to:
+
+- CPU instructions (per increment)
+- Ledger entry reads and writes
+- Event size
+- Transaction size
+- Rent for persistent/temporary storage
+
+See [Stellar documentation](https://developers.stellar.org/docs) for current fee parameters.

--- a/README.md
+++ b/README.md
@@ -10,16 +10,16 @@ Soroban smart contracts for the Callora API marketplace: prepaid vault (USDC) an
 ## What’s included
 
 - **`callora-vault`** contract:
-  - `init(owner, initial_balance)` — initialize vault for an owner
-  - `get_meta()` — owner and current balance
-  - `deposit(amount)` — increase balance
-  - `deduct(amount)` — decrease balance (e.g. per API call)
-  - `batch_deduct(items)` — multiple deducts in one transaction (reverts entire batch if any would exceed balance)
+  - `init(owner, initial_balance, min_deposit)` — initialize vault for an owner; optional minimum deposit (0 = none)
+  - `get_meta()` — owner, current balance, and min_deposit
+  - `deposit(amount)` — increase balance (panics if amount < min_deposit)
+  - `deduct(caller, amount, request_id)` — decrease balance (e.g. per API call)
+  - `batch_deduct(caller, items)` — multiple deducts in one transaction (reverts entire batch if any would exceed balance)
   - `withdraw(amount)` — owner-only; decreases balance (USDC transfer when integrated)
   - `withdraw_to(to, amount)` — owner-only; withdraw to a designated address
   - `balance()` — current balance
 
-Events are emitted for init, deposit, deduct, withdraw, and withdraw_to. See [EVENT_SCHEMA.md](EVENT_SCHEMA.md) for indexer/frontend use.
+Events are emitted for init, deposit, deduct, withdraw, and withdraw_to. See [EVENT_SCHEMA.md](EVENT_SCHEMA.md) for indexer/frontend use. Approximate gas/cost notes: [BENCHMARKS.md](BENCHMARKS.md). Upgrade and migration: [UPGRADE.md](UPGRADE.md).
 
 ## Local setup
 
@@ -44,6 +44,10 @@ Events are emitted for init, deposit, deduct, withdraw, and withdraw_to. See [EV
 
    Or use `soroban contract build` if you use the Soroban CLI workflow.
 
+## Development
+
+Use one branch per issue or feature (e.g. `test/minimum-deposit-rejected`, `docs/vault-gas-notes`) to keep PRs small and reduce merge conflicts. Run `cargo fmt`, `cargo clippy --all-targets --all-features -- -D warnings`, and `cargo test` before pushing.
+
 ## Project layout
 
 ```
@@ -51,7 +55,9 @@ callora-contracts/
 ├── .github/workflows/
 │   └── ci.yml              # CI: fmt, clippy, test, WASM build
 ├── Cargo.toml              # Workspace and release profile
+├── BENCHMARKS.md           # Vault operation gas/cost notes
 ├── EVENT_SCHEMA.md         # Event names, topics, and payload types
+├── UPGRADE.md              # Vault upgrade and migration path
 ├── contracts/
 │   └── vault/
 │       ├── Cargo.toml

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,0 +1,55 @@
+# Vault Upgrade and Migration Path
+
+This document describes how the Callora Vault is deployed, how its state is stored, and how to migrate to a new contract if needed. Soroban contract upgradeability is limited: you cannot replace the code of an existing contract instance in place. Migration is done by deploying a new contract and moving state and traffic to it.
+
+## Current Deploy Model
+
+- **One contract WASM**: The vault is built as a single Soroban contract (`callora-vault`). Build with:
+  ```bash
+  cd contracts/vault && cargo build --target wasm32-unknown-unknown --release
+  ```
+- **One instance per vault**: Each vault is a separate contract instance created by deploying the same WASM and calling `init(owner, initial_balance, min_deposit)` once. The instance ID is the “vault address” used by the backend and frontend.
+- **No in-place upgrades**: There is no built-in mechanism to change the code of an existing instance. To change behavior, you deploy a new contract (new WASM or new instance) and migrate.
+
+## Storage Layout
+
+The vault uses **instance storage** with a single key:
+
+| Key   | Type       | Description                          |
+|-------|------------|--------------------------------------|
+| `meta`| `VaultMeta`| Owner, balance, and min_deposit      |
+
+`VaultMeta` layout is documented in [contracts/vault/STORAGE.md](contracts/vault/STORAGE.md). Any migration must read this layout so existing state can be exported and re-imported.
+
+## Migration Strategy: Deploy New Contract and Redirect
+
+When you need to move to a new vault (e.g. new code or new instance):
+
+1. **Export state from the old vault**
+   - Read `get_meta()` from the current contract instance (owner, balance, min_deposit).
+   - Optionally export event history or audit data for your records (from indexer/archives).
+
+2. **Deploy the new contract**
+   - Build and deploy the new WASM (or deploy a new instance of the same WASM).
+   - Call `init(owner, Some(current_balance), Some(min_deposit))` with the exported owner and, if desired, the same balance and min_deposit.  
+   - If you are not moving balance on-chain automatically, you may init with `initial_balance: Some(0)` and treat the old vault as “drained” and the new one as the new ledger.
+
+3. **Move balance (if applicable)**
+   - If the old vault holds real assets (e.g. USDC), you must transfer them off the old vault (e.g. via owner `withdraw` or integration-specific flows) and then fund the new vault (e.g. deposit or token transfer). The current vault contract does not hold token balances; it tracks an internal balance. When token integration is added, migration would include withdrawing from the old vault and depositing into the new one.
+
+4. **Redirect users and backend**
+   - Point the backend (and any frontend) to the new contract instance ID for that vault.
+   - Retire or deprecate the old instance (no further calls).
+
+## Versioning and Compatibility
+
+- **Storage compatibility**: New contract versions that add or change fields in `VaultMeta` (or add new keys) are not backward compatible with existing instance data. Migration must either:
+  - Deploy a new instance and init with the desired state (recommended), or
+  - Use a migration contract/tool that reads the old layout and writes the new one (advanced).
+- **Interface compatibility**: Keep `init`, `deposit`, `deduct`, `balance`, `withdraw`, and `withdraw_to` semantics stable for the same instance ID, or treat a new instance as a new vault and migrate as above.
+
+## Summary
+
+- **Deploy**: One WASM, one `init` per vault instance.
+- **Storage**: Single `meta` key; see STORAGE.md for layout.
+- **Upgrade**: No in-place code upgrade; deploy a new contract/instance, export state, re-init and move balance as needed, then redirect traffic to the new instance.

--- a/contracts/vault/STORAGE.md
+++ b/contracts/vault/STORAGE.md
@@ -22,14 +22,16 @@ The Callora Vault contract uses Soroban's instance storage to persist contract s
 #[contracttype]
 #[derive(Clone)]
 pub struct VaultMeta {
-    pub owner: Address,    // Vault owner address
-    pub balance: i128,      // Current balance (in smallest units, e.g., USDC cents)
+    pub owner: Address,      // Vault owner address
+    pub balance: i128,       // Current balance (in smallest units, e.g., USDC cents)
+    pub min_deposit: i128,   // Minimum amount per deposit; 0 means no minimum
 }
 ```
 
 **Fields:**
 - `owner`: `Address` - The address that owns the vault and can perform operations
 - `balance`: `i128` - Current vault balance, can be positive or zero
+- `min_deposit`: `i128` - Minimum amount required per deposit; deposits below this panic (0 = no minimum)
 
 ## Storage Operations
 

--- a/contracts/vault/src/test.rs
+++ b/contracts/vault/src/test.rs
@@ -4,6 +4,56 @@ use super::*;
 use soroban_sdk::testutils::{Address as _, Events as _};
 use soroban_sdk::{vec, IntoVal, Symbol};
 
+/// Logs approximate CPU/instruction and fee for init, deposit, deduct, and balance.
+/// Run with: cargo test --ignored vault_operation_costs -- --nocapture
+/// Requires invocation cost metering; may panic on default test env.
+#[test]
+#[ignore]
+fn vault_operation_costs() {
+    let env = Env::default();
+    let owner = Address::generate(&env);
+    let contract_id = env.register(CalloraVault {}, ());
+    let client = CalloraVaultClient::new(&env, &contract_id);
+
+    env.mock_all_auths();
+
+    client.init(&owner, &Some(0), &None);
+    let res = env.cost_estimate().resources();
+    let fee = env.cost_estimate().fee();
+    std::println!(
+        "init: instructions={} fee_total={}",
+        res.instructions,
+        fee.total
+    );
+
+    client.deposit(&100);
+    let res = env.cost_estimate().resources();
+    let fee = env.cost_estimate().fee();
+    std::println!(
+        "deposit: instructions={} fee_total={}",
+        res.instructions,
+        fee.total
+    );
+
+    client.deduct(&owner, &50, &None);
+    let res = env.cost_estimate().resources();
+    let fee = env.cost_estimate().fee();
+    std::println!(
+        "deduct: instructions={} fee_total={}",
+        res.instructions,
+        fee.total
+    );
+
+    let _ = client.balance();
+    let res = env.cost_estimate().resources();
+    let fee = env.cost_estimate().fee();
+    std::println!(
+        "balance: instructions={} fee_total={}",
+        res.instructions,
+        fee.total
+    );
+}
+
 #[test]
 fn init_and_balance() {
     let env = Env::default();
@@ -13,7 +63,7 @@ fn init_and_balance() {
     // Call init directly inside as_contract so events are captured
     env.mock_all_auths();
     let events = env.as_contract(&contract_id, || {
-        CalloraVault::init(env.clone(), owner.clone(), Some(1000));
+        CalloraVault::init(env.clone(), owner.clone(), Some(1000), None);
         env.events().all()
     });
 
@@ -48,7 +98,7 @@ fn deposit_and_deduct() {
     let client = CalloraVaultClient::new(&env, &contract_id);
 
     env.mock_all_auths();
-    client.init(&owner, &Some(100));
+    client.init(&owner, &Some(100), &None);
     client.deposit(&200);
     assert_eq!(client.balance(), 300);
     env.mock_all_auths();
@@ -65,8 +115,9 @@ fn balance_and_meta_consistency() {
     let contract_id = env.register(CalloraVault {}, ());
     let client = CalloraVaultClient::new(&env, &contract_id);
 
+    env.mock_all_auths();
     // Initialize vault with initial balance
-    client.init(&owner, &Some(500));
+    client.init(&owner, &Some(500), &None);
 
     // Verify consistency after initialization
     let meta = client.get_meta();
@@ -84,7 +135,7 @@ fn balance_and_meta_consistency() {
     assert_eq!(balance, 800, "incorrect balance after deposit");
 
     // Deduct and verify consistency
-    client.deduct(&150);
+    client.deduct(&owner, &150, &None);
     let meta = client.get_meta();
     let balance = client.balance();
     assert_eq!(meta.balance, balance, "balance mismatch after deduct");
@@ -93,7 +144,7 @@ fn balance_and_meta_consistency() {
 
     // Perform multiple operations and verify final state
     client.deposit(&100);
-    client.deduct(&50);
+    client.deduct(&owner, &50, &None);
     client.deposit(&25);
     let meta = client.get_meta();
     let balance = client.balance();
@@ -113,15 +164,16 @@ fn deduct_exact_balance_and_panic() {
     let contract_id = env.register(CalloraVault {}, ());
     let client = CalloraVaultClient::new(&env, &contract_id);
 
-    client.init(&owner, &Some(100));
+    env.mock_all_auths();
+    client.init(&owner, &Some(100), &None);
     assert_eq!(client.balance(), 100);
 
     // Deduct exact balance
-    client.deduct(&100);
+    client.deduct(&owner, &100, &None);
     assert_eq!(client.balance(), 0);
 
     // Further deduct should panic
-    client.deduct(&1);
+    client.deduct(&owner, &1, &None);
 }
 
 #[test]
@@ -132,7 +184,8 @@ fn deduct_event_emission() {
     let contract_id = env.register(CalloraVault {}, ());
     let client = CalloraVaultClient::new(&env, &contract_id);
 
-    client.init(&owner, &Some(1000));
+    env.mock_all_auths();
+    client.init(&owner, &Some(1000), &None);
 
     env.mock_all_auths();
     let req_id = Symbol::new(&env, "req123");
@@ -166,7 +219,7 @@ fn batch_deduct_success() {
     let client = CalloraVaultClient::new(&env, &contract_id);
 
     env.mock_all_auths();
-    client.init(&owner, &Some(1000));
+    client.init(&owner, &Some(1000), &None);
     let req1 = Symbol::new(&env, "req1");
     let req2 = Symbol::new(&env, "req2");
     let items = vec![
@@ -200,7 +253,7 @@ fn batch_deduct_reverts_entire_batch() {
     let client = CalloraVaultClient::new(&env, &contract_id);
 
     env.mock_all_auths();
-    client.init(&owner, &Some(100));
+    client.init(&owner, &Some(100), &None);
     let items = vec![
         &env,
         DeductItem {
@@ -225,7 +278,7 @@ fn withdraw_owner_success() {
     let client = CalloraVaultClient::new(&env, &contract_id);
 
     env.mock_all_auths();
-    client.init(&owner, &Some(500));
+    client.init(&owner, &Some(500), &None);
     let new_balance = client.withdraw(&200);
     assert_eq!(new_balance, 300);
     assert_eq!(client.balance(), 300);
@@ -239,7 +292,7 @@ fn withdraw_exact_balance() {
     let client = CalloraVaultClient::new(&env, &contract_id);
 
     env.mock_all_auths();
-    client.init(&owner, &Some(100));
+    client.init(&owner, &Some(100), &None);
     let new_balance = client.withdraw(&100);
     assert_eq!(new_balance, 0);
     assert_eq!(client.balance(), 0);
@@ -254,7 +307,7 @@ fn withdraw_exceeds_balance_fails() {
     let client = CalloraVaultClient::new(&env, &contract_id);
 
     env.mock_all_auths();
-    client.init(&owner, &Some(50));
+    client.init(&owner, &Some(50), &None);
     client.withdraw(&100);
 }
 
@@ -267,7 +320,7 @@ fn withdraw_to_success() {
     let client = CalloraVaultClient::new(&env, &contract_id);
 
     env.mock_all_auths();
-    client.init(&owner, &Some(500));
+    client.init(&owner, &Some(500), &None);
     let new_balance = client.withdraw_to(&to, &150);
     assert_eq!(new_balance, 350);
     assert_eq!(client.balance(), 350);
@@ -284,7 +337,7 @@ fn withdraw_without_auth_fails() {
     // However mock_all_auths applies to the whole test unless explicitly managed.
     // Instead, we can just mock_all_auths, init, then clear mock auths.
     env.mock_all_auths();
-    client.init(&owner, &Some(100));
+    client.init(&owner, &Some(100), &None);
     // Clear mocks so withdraw fails.
     // Wait, Soroban testutils doesn't have an easy way to clear auths in older versions...
     // Actually, we can just drop the mock_auths or not use mock_all_auths and use mock_auths explicitly.
@@ -299,12 +352,12 @@ fn withdraw_without_auth_fails() {
         invoke: &soroban_sdk::testutils::MockAuthInvoke {
             contract: &contract_id,
             fn_name: "init",
-            args: (&owner, Some(100i128)).into_val(&env),
+            args: (&owner, Some(100i128), None::<i128>).into_val(&env),
             sub_invokes: &[],
         },
     }]);
 
-    client.init(&owner, &Some(100));
+    client.init(&owner, &Some(100), &None);
 
     // This will fail because withdraw requires auth which is not mocked for this call
     client.withdraw(&50);
@@ -319,6 +372,77 @@ fn init_already_initialized_panics() {
     let client = CalloraVaultClient::new(&env, &contract_id);
 
     env.mock_all_auths();
-    client.init(&owner, &Some(100));
-    client.init(&owner, &Some(200)); // Should panic
+    client.init(&owner, &Some(100), &None);
+    client.init(&owner, &Some(200), &None); // Should panic
+}
+
+/// Test that deposit below the configured minimum panics.
+/// init with min_deposit 10; call deposit(5); expect panic.
+#[test]
+#[should_panic(expected = "deposit below minimum")]
+fn minimum_deposit_rejected() {
+    let env = Env::default();
+    let owner = Address::generate(&env);
+    let contract_id = env.register(CalloraVault {}, ());
+    let client = CalloraVaultClient::new(&env, &contract_id);
+
+    env.mock_all_auths();
+    client.init(&owner, &Some(0), &Some(10)); // min_deposit = 10
+    assert_eq!(client.balance(), 0);
+    client.deposit(&5); // below minimum -> panic
+}
+
+#[test]
+fn withdraw_event_payload() {
+    let env = Env::default();
+    let owner = Address::generate(&env);
+    let contract_id = env.register(CalloraVault {}, ());
+    let client = CalloraVaultClient::new(&env, &contract_id);
+
+    env.mock_all_auths();
+    client.init(&owner, &Some(500), &None);
+    client.withdraw(&200);
+
+    let events = env.events().all();
+    let last_event = events.last().unwrap();
+    assert_eq!(last_event.0, contract_id);
+
+    let topics = &last_event.1;
+    assert_eq!(topics.len(), 2);
+    let topic0: Symbol = topics.get(0).unwrap().into_val(&env);
+    assert_eq!(topic0, Symbol::new(&env, "withdraw"));
+    let topic_owner: Address = topics.get(1).unwrap().into_val(&env);
+    assert_eq!(topic_owner, owner);
+
+    let data: (i128, i128) = last_event.2.into_val(&env);
+    assert_eq!(data, (200, 300));
+}
+
+#[test]
+fn withdraw_to_event_payload() {
+    let env = Env::default();
+    let owner = Address::generate(&env);
+    let to = Address::generate(&env);
+    let contract_id = env.register(CalloraVault {}, ());
+    let client = CalloraVaultClient::new(&env, &contract_id);
+
+    env.mock_all_auths();
+    client.init(&owner, &Some(500), &None);
+    client.withdraw_to(&to, &150);
+
+    let events = env.events().all();
+    let last_event = events.last().unwrap();
+    assert_eq!(last_event.0, contract_id);
+
+    let topics = &last_event.1;
+    assert_eq!(topics.len(), 3);
+    let topic0: Symbol = topics.get(0).unwrap().into_val(&env);
+    assert_eq!(topic0, Symbol::new(&env, "withdraw_to"));
+    let topic_owner: Address = topics.get(1).unwrap().into_val(&env);
+    assert_eq!(topic_owner, owner);
+    let topic_to: Address = topics.get(2).unwrap().into_val(&env);
+    assert_eq!(topic_to, to);
+
+    let data: (i128, i128) = last_event.2.into_val(&env);
+    assert_eq!(data, (150, 350));
 }


### PR DESCRIPTION
## Summary
Implements four issues: minimum deposit test + feature, vault gas/cost notes, withdraw event tests, and upgrade path documentation. CI passes (fmt, clippy, test, WASM build).

## Changes

### #44 – Minimum deposit rejected
- Added `min_deposit` to `VaultMeta` and `init(owner, initial_balance, min_deposit: Option<i128>)` (default `None` → 0).
- `deposit(amount)` panics with "deposit below minimum" when `amount < min_deposit`.
- New test: init with `min_deposit = 10`, `deposit(5)` → expect panic.
- Updated all existing tests to pass the new `init` parameter and fixed missing `env.mock_all_auths()` / deduct caller args where needed.

### #47 – Gas / cost notes for vault operations
- **BENCHMARKS.md**: relative cost table (balance lowest, init highest), how to get exact numbers (testnet, CLI, test env).
- Optional benchmark test `vault_operation_costs` (ignored by default): logs `cost_estimate().resources()` and `.fee()` for init, deposit, deduct, balance. Run: `cargo test --ignored vault_operation_costs -- --nocapture`.

### #27 – Emit withdraw event
- Withdraw events were already emitted; no contract change.
- New tests: `withdraw_event_payload` and `withdraw_to_event_payload` assert event topics and data (owner, amount, destination, new balance).

### #50 – Upgrade path documentation
- **UPGRADE.md**: deploy model, storage layout reference, migration steps (export state → deploy new contract → move balance → redirect traffic), versioning notes.
- **STORAGE.md**: added `min_deposit` to `VaultMeta`.
- **README**: links to BENCHMARKS.md and UPGRADE.md; doc and development note for smaller PRs to reduce merge conflicts.

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test` (16 passed, 1 ignored)
- `cargo build --target wasm32-unknown-unknown --release` in `contracts/vault`