### PR TITLE
feat: add revenue pool contract and enhance vault functionality

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,3 +64,5 @@ jobs:
         run: |
           cd contracts/vault
           cargo build --target wasm32-unknown-unknown --release
+          cd ../revenue_pool
+          cargo build --target wasm32-unknown-unknown --release

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 resolver = "2"
-members = ["contracts/vault"]
+members = ["contracts/vault", "contracts/revenue_pool"]
 
 [workspace.dependencies]
 soroban-sdk = "22"

--- a/README.md
+++ b/README.md
@@ -10,14 +10,18 @@ Soroban smart contracts for the Callora API marketplace: prepaid vault (USDC) an
 ## What’s included
 
 - **`callora-vault`** contract:
-  - `init(owner, usdc_token, initial_balance, min_deposit)` — initialize vault for an owner; optional minimum deposit (0 = none)
-  - `get_meta()` — owner, current balance, and min_deposit
-  - `deposit(from, amount)` — increase balance (supports multiple authorized depositors; panics if amount < min_deposit)
-  - `deduct(caller, amount, request_id)` — decrease balance (e.g. per API call)
-  - `batch_deduct(caller, items)` — multiple deducts in one transaction (reverts entire batch if any would exceed balance)
-  - `withdraw(amount)` — owner-only; decreases balance (USDC transfer when integrated)
-  - `withdraw_to(to, amount)` — owner-only; withdraw to a designated address
-  - `balance()` — current balance
+  - `init(owner, usdc_token, initial_balance, min_deposit, revenue_pool, max_deduct)` — initialize vault; optional revenue pool (receives USDC on deduct), optional max single deduct cap
+  - `get_meta()`, `get_max_deduct()`, `get_revenue_pool()` — view config
+  - `deposit(from, amount)` — user transfers USDC to contract (transfer_from); increases ledger balance; amount must be ≥ min_deposit
+  - `deduct(caller, amount, request_id)` — decrease balance; amount ≤ max_deduct; if revenue_pool set, USDC is transferred to it
+  - `batch_deduct(caller, items)` — batch deduct with same rules; total USDC transferred to revenue_pool if set
+  - `withdraw(amount)` — owner-only; decreases balance and transfers USDC to owner
+  - `withdraw_to(to, amount)` — owner-only; decreases balance and transfers USDC to `to`
+  - `balance()` — current ledger balance
+- **`callora-revenue-pool`** contract (settlement):
+  - `init(admin, usdc_token)` — set admin and USDC token
+  - `distribute(caller, to, amount)` — admin sends USDC from this contract to a developer
+  - Flow: vault deduct → vault transfers USDC to revenue pool → admin calls `distribute(to, amount)`
 
 Events are emitted for init, deposit, deduct, withdraw, and withdraw_to. See [EVENT_SCHEMA.md](EVENT_SCHEMA.md) for indexer/frontend use. Approximate gas/cost notes: [BENCHMARKS.md](BENCHMARKS.md). Upgrade and migration: [UPGRADE.md](UPGRADE.md).
 
@@ -59,10 +63,15 @@ callora-contracts/
 ├── EVENT_SCHEMA.md         # Event names, topics, and payload types
 ├── UPGRADE.md              # Vault upgrade and migration path
 ├── contracts/
-│   └── vault/
+│   ├── vault/
+│   │   ├── Cargo.toml
+│   │   └── src/
+│   │       ├── lib.rs      # Contract logic
+│   │       └── test.rs     # Unit tests
+│   └── revenue_pool/
 │       ├── Cargo.toml
 │       └── src/
-│           ├── lib.rs      # Contract logic
+│           ├── lib.rs      # Settlement contract
 │           └── test.rs     # Unit tests
 └── README.md
 ```

--- a/contracts/revenue_pool/Cargo.toml
+++ b/contracts/revenue_pool/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "callora-revenue-pool"
+version = "0.0.1"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+doctest = false
+
+[dependencies]
+soroban-sdk = { workspace = true }
+
+[dev-dependencies]
+soroban-sdk = { workspace = true, features = ["testutils"] }

--- a/contracts/revenue_pool/src/lib.rs
+++ b/contracts/revenue_pool/src/lib.rs
@@ -1,0 +1,125 @@
+#![no_std]
+
+use soroban_sdk::{contract, contractimpl, token, Address, Env, Symbol};
+
+/// Revenue settlement contract: receives USDC from vault deducts and distributes to developers.
+///
+/// Flow: vault deduct → vault transfers USDC to this contract → admin calls distribute(to, amount).
+const ADMIN_KEY: &str = "admin";
+const USDC_KEY: &str = "usdc";
+
+#[contract]
+pub struct RevenuePool;
+
+#[contractimpl]
+impl RevenuePool {
+    /// Initialize the revenue pool with an admin and the USDC token address.
+    ///
+    /// # Arguments
+    /// * `admin` – Address that may call `distribute`. Typically backend or multisig.
+    /// * `usdc_token` – Stellar USDC (or wrapped USDC) token contract address.
+    pub fn init(env: Env, admin: Address, usdc_token: Address) {
+        admin.require_auth();
+        if env.storage().instance().has(&Symbol::new(&env, ADMIN_KEY)) {
+            panic!("revenue pool already initialized");
+        }
+        env.storage()
+            .instance()
+            .set(&Symbol::new(&env, ADMIN_KEY), &admin);
+        env.storage()
+            .instance()
+            .set(&Symbol::new(&env, USDC_KEY), &usdc_token);
+
+        env.events()
+            .publish((Symbol::new(&env, "init"), admin), usdc_token);
+    }
+
+    /// Return the current admin address.
+    pub fn get_admin(env: Env) -> Address {
+        env.storage()
+            .instance()
+            .get(&Symbol::new(&env, ADMIN_KEY))
+            .unwrap_or_else(|| panic!("revenue pool not initialized"))
+    }
+
+    /// Replace the current admin. Only the existing admin may call this.
+    pub fn set_admin(env: Env, caller: Address, new_admin: Address) {
+        caller.require_auth();
+        let current = Self::get_admin(env.clone());
+        if caller != current {
+            panic!("unauthorized: caller is not admin");
+        }
+        env.storage()
+            .instance()
+            .set(&Symbol::new(&env, ADMIN_KEY), &new_admin);
+    }
+
+    /// Placeholder: record that payment was received (e.g. from vault).
+    /// In practice, USDC is received when the vault (or any address) transfers tokens
+    /// to this contract's address; no separate "receive" call is required.
+    ///
+    /// This function can be used to emit an event for indexers when the backend
+    /// wants to log that a payment was credited from the vault.
+    ///
+    /// # Arguments
+    /// * `caller` – Must be admin (or could be extended to allow vault to call).
+    /// * `amount` – Amount received (for event logging).
+    /// * `from_vault` – Optional; true if the source was the vault.
+    pub fn receive_payment(env: Env, caller: Address, amount: i128, from_vault: bool) {
+        caller.require_auth();
+        let _admin = Self::get_admin(env.clone());
+        env.events().publish(
+            (Symbol::new(&env, "receive_payment"), caller),
+            (amount, from_vault),
+        );
+    }
+
+    /// Distribute USDC from this contract to a developer wallet.
+    ///
+    /// Only the admin may call. Transfers USDC from this contract to `to`.
+    ///
+    /// # Arguments
+    /// * `caller` – Must be the current admin.
+    /// * `to` – Developer address to receive USDC.
+    /// * `amount` – Amount in token base units (e.g. USDC stroops).
+    pub fn distribute(env: Env, caller: Address, to: Address, amount: i128) {
+        caller.require_auth();
+        let admin = Self::get_admin(env.clone());
+        if caller != admin {
+            panic!("unauthorized: caller is not admin");
+        }
+        if amount <= 0 {
+            panic!("amount must be positive");
+        }
+
+        let usdc_address: Address = env
+            .storage()
+            .instance()
+            .get(&Symbol::new(&env, USDC_KEY))
+            .unwrap_or_else(|| panic!("revenue pool not initialized"));
+        let usdc = token::Client::new(&env, &usdc_address);
+
+        let contract_address = env.current_contract_address();
+        if usdc.balance(&contract_address) < amount {
+            panic!("insufficient USDC balance");
+        }
+
+        usdc.transfer(&contract_address, &to, &amount);
+        env.events()
+            .publish((Symbol::new(&env, "distribute"), to), amount);
+    }
+
+    /// Return this contract's USDC balance (for testing and dashboards).
+    pub fn balance(env: Env) -> i128 {
+        let usdc_address: Address = env
+            .storage()
+            .instance()
+            .get(&Symbol::new(&env, USDC_KEY))
+            .unwrap_or_else(|| panic!("revenue pool not initialized"));
+        let usdc = token::Client::new(&env, &usdc_address);
+        usdc.balance(&env.current_contract_address())
+    }
+}
+
+#[cfg(test)]
+mod test;

--- a/contracts/revenue_pool/src/test.rs
+++ b/contracts/revenue_pool/src/test.rs
@@ -1,0 +1,147 @@
+extern crate std;
+
+use super::*;
+use soroban_sdk::testutils::{Address as _, Events as _};
+use soroban_sdk::token;
+
+fn create_usdc<'a>(
+    env: &'a Env,
+    admin: &Address,
+) -> (Address, token::Client<'a>, token::StellarAssetClient<'a>) {
+    let contract_address = env.register_stellar_asset_contract_v2(admin.clone());
+    let address = contract_address.address();
+    let client = token::Client::new(env, &address);
+    let admin_client = token::StellarAssetClient::new(env, &address);
+    (address, client, admin_client)
+}
+
+fn create_pool(env: &Env) -> (Address, RevenuePoolClient<'_>) {
+    let address = env.register(RevenuePool, ());
+    let client = RevenuePoolClient::new(env, &address);
+    (address, client)
+}
+
+fn fund_pool(usdc_admin_client: &token::StellarAssetClient, pool_address: &Address, amount: i128) {
+    usdc_admin_client.mint(pool_address, &amount);
+}
+
+#[test]
+fn init_success() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let (_pool_addr, client) = create_pool(&env);
+    let (usdc, _, _) = create_usdc(&env, &admin);
+
+    client.init(&admin, &usdc);
+    assert_eq!(client.get_admin(), admin);
+    assert_eq!(client.balance(), 0);
+}
+
+#[test]
+#[should_panic(expected = "revenue pool already initialized")]
+fn init_double_panics() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let (_, client) = create_pool(&env);
+    let (usdc, _, _) = create_usdc(&env, &admin);
+
+    client.init(&admin, &usdc);
+    client.init(&admin, &usdc);
+}
+
+#[test]
+fn distribute_success() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let developer = Address::generate(&env);
+    let (pool_addr, client) = create_pool(&env);
+    let (usdc_address, usdc_client, usdc_admin) = create_usdc(&env, &admin);
+
+    client.init(&admin, &usdc_address);
+    fund_pool(&usdc_admin, &pool_addr, 1_000);
+    client.distribute(&admin, &developer, &400);
+
+    assert_eq!(usdc_client.balance(&pool_addr), 600);
+    assert_eq!(usdc_client.balance(&developer), 400);
+}
+
+#[test]
+#[should_panic(expected = "amount must be positive")]
+fn distribute_zero_panics() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let developer = Address::generate(&env);
+    let (_, client) = create_pool(&env);
+    let (usdc, _, _) = create_usdc(&env, &admin);
+
+    client.init(&admin, &usdc);
+    client.distribute(&admin, &developer, &0);
+}
+
+#[test]
+#[should_panic(expected = "insufficient USDC balance")]
+fn distribute_excess_panics() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let developer = Address::generate(&env);
+    let (pool_addr, client) = create_pool(&env);
+    let (usdc_address, _, usdc_admin) = create_usdc(&env, &admin);
+
+    client.init(&admin, &usdc_address);
+    fund_pool(&usdc_admin, &pool_addr, 100);
+    client.distribute(&admin, &developer, &101);
+}
+
+#[test]
+#[should_panic(expected = "unauthorized: caller is not admin")]
+fn distribute_unauthorized_panics() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let attacker = Address::generate(&env);
+    let developer = Address::generate(&env);
+    let (pool_addr, client) = create_pool(&env);
+    let (usdc_address, _, usdc_admin) = create_usdc(&env, &admin);
+
+    client.init(&admin, &usdc_address);
+    fund_pool(&usdc_admin, &pool_addr, 500);
+    client.distribute(&attacker, &developer, &100);
+}
+
+#[test]
+fn set_admin_transfers_control() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let new_admin = Address::generate(&env);
+    let developer = Address::generate(&env);
+    let (pool_addr, client) = create_pool(&env);
+    let (usdc_address, usdc_client, usdc_admin) = create_usdc(&env, &admin);
+
+    client.init(&admin, &usdc_address);
+    fund_pool(&usdc_admin, &pool_addr, 300);
+    client.set_admin(&admin, &new_admin);
+    assert_eq!(client.get_admin(), new_admin);
+
+    client.distribute(&new_admin, &developer, &100);
+    assert_eq!(usdc_client.balance(&developer), 100);
+}
+
+#[test]
+fn receive_payment_emits_event() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let (_, client) = create_pool(&env);
+    let (usdc, _, _) = create_usdc(&env, &admin);
+
+    client.init(&admin, &usdc);
+    client.receive_payment(&admin, &500, &true);
+    let events = env.events().all();
+    assert!(!events.is_empty());
+}

--- a/contracts/vault/STORAGE.md
+++ b/contracts/vault/STORAGE.md
@@ -12,7 +12,11 @@ The Callora Vault contract uses Soroban's instance storage to persist contract s
 
 | Key | Type | Description | Usage |
 |-----|------|-------------|-------|
-| `Symbol("meta")` | `VaultMeta` | Primary vault metadata containing owner and balance | Core vault state |
+| `Symbol("meta")` | `VaultMeta` | Primary vault metadata (owner, balance, min_deposit) | Core vault state |
+| `Symbol("usdc")` | `Address` | USDC token contract address | Token transfers |
+| `Symbol("admin")` | `Address` | Admin (e.g. backend) for distribute | Access control |
+| `Symbol("revenue_pool")` | `Option<Address>` | Optional settlement contract; receives USDC on deduct | Deduct flow |
+| `Symbol("max_deduct")` | `i128` | Maximum amount per single deduct (configurable at init) | Deduct limit |
 
 ### Data Structures
 

--- a/contracts/vault/src/lib.rs
+++ b/contracts/vault/src/lib.rs
@@ -22,6 +22,11 @@ pub struct VaultMeta {
 const META_KEY: &str = "meta";
 const USDC_KEY: &str = "usdc";
 const ADMIN_KEY: &str = "admin";
+const REVENUE_POOL_KEY: &str = "revenue_pool";
+const MAX_DEDUCT_KEY: &str = "max_deduct";
+
+/// Default maximum single deduct amount when not set at init (no cap).
+pub const DEFAULT_MAX_DEDUCT: i128 = i128::MAX;
 
 #[contracttype]
 #[derive(Clone, Debug, PartialEq)]
@@ -36,20 +41,38 @@ pub struct CalloraVault;
 #[contractimpl]
 impl CalloraVault {
     /// Initialize vault for an owner with optional initial balance and minimum deposit.
+    /// If initial_balance > 0, the contract must already hold at least that much USDC (e.g. deployer transferred in first).
     /// Emits an "init" event with the owner address and initial balance.
+    ///
+    /// # Arguments
+    /// * `revenue_pool` – Optional address to receive USDC on each deduct (e.g. settlement contract). If None, USDC stays in vault.
+    /// * `max_deduct` – Optional cap per single deduct; if None, uses DEFAULT_MAX_DEDUCT (no cap).
     pub fn init(
         env: Env,
         owner: Address,
         usdc_token: Address,
         initial_balance: Option<i128>,
         min_deposit: Option<i128>,
+        revenue_pool: Option<Address>,
+        max_deduct: Option<i128>,
     ) -> VaultMeta {
         owner.require_auth();
         if env.storage().instance().has(&Symbol::new(&env, META_KEY)) {
             panic!("vault already initialized");
         }
         let balance = initial_balance.unwrap_or(0);
+        if balance > 0 {
+            let usdc = token::Client::new(&env, &usdc_token);
+            let contract_balance = usdc.balance(&env.current_contract_address());
+            if contract_balance < balance {
+                panic!("insufficient USDC in contract for initial_balance");
+            }
+        }
         let min_deposit_val = min_deposit.unwrap_or(0);
+        let max_deduct_val = max_deduct.unwrap_or(DEFAULT_MAX_DEDUCT);
+        if max_deduct_val <= 0 {
+            panic!("max_deduct must be positive");
+        }
         let meta = VaultMeta {
             owner: owner.clone(),
             balance,
@@ -64,8 +87,13 @@ impl CalloraVault {
         env.storage()
             .instance()
             .set(&Symbol::new(&env, ADMIN_KEY), &owner);
+        env.storage()
+            .instance()
+            .set(&Symbol::new(&env, REVENUE_POOL_KEY), &revenue_pool);
+        env.storage()
+            .instance()
+            .set(&Symbol::new(&env, MAX_DEDUCT_KEY), &max_deduct_val);
 
-        // Emit event: topics = (init, owner), data = balance
         env.events()
             .publish((Symbol::new(&env, "init"), owner), balance);
 
@@ -90,6 +118,22 @@ impl CalloraVault {
         env.storage()
             .instance()
             .set(&Symbol::new(&env, ADMIN_KEY), &new_admin);
+    }
+
+    /// Return the maximum allowed amount for a single deduct (configurable at init).
+    pub fn get_max_deduct(env: Env) -> i128 {
+        env.storage()
+            .instance()
+            .get(&Symbol::new(&env, MAX_DEDUCT_KEY))
+            .unwrap_or_else(|| panic!("vault not initialized"))
+    }
+
+    /// Return the revenue pool address if set (receives USDC on deduct).
+    pub fn get_revenue_pool(env: Env) -> Option<Address> {
+        env.storage()
+            .instance()
+            .get(&Symbol::new(&env, REVENUE_POOL_KEY))
+            .unwrap_or(None)
     }
 
     /// Distribute accumulated USDC to a single developer address.
@@ -155,7 +199,8 @@ impl CalloraVault {
             .unwrap_or_else(|| panic!("vault not initialized"))
     }
 
-    /// Deposit increases balance. Supports multiple depositors: any authorized user can deposit.
+    /// Deposit: user transfers USDC to the contract; contract increases internal balance.
+    /// Caller must have authorized the transfer (token transfer_from). Supports multiple depositors.
     /// Emits a "deposit" event with the depositor address and amount.
     pub fn deposit(env: Env, from: Address, amount: i128) -> i128 {
         from.require_auth();
@@ -167,28 +212,64 @@ impl CalloraVault {
             amount,
             meta.min_deposit
         );
+
+        let usdc_address: Address = env
+            .storage()
+            .instance()
+            .get(&Symbol::new(&env, USDC_KEY))
+            .unwrap_or_else(|| panic!("vault not initialized"));
+        let usdc = token::Client::new(&env, &usdc_address);
+        usdc.transfer_from(
+            &env.current_contract_address(),
+            &from,
+            &env.current_contract_address(),
+            &amount,
+        );
+
         meta.balance += amount;
         env.storage()
             .instance()
             .set(&Symbol::new(&env, META_KEY), &meta);
 
-        // Emit event: topics = (deposit, from), data = amount
         env.events()
             .publish((Symbol::new(&env, "deposit"), from), amount);
 
         meta.balance
     }
 
-    /// Deduct balance for an API call. Callable by authorized caller (e.g. backend/deployer).
+    /// Deduct balance for an API call. Callable by authorized caller (e.g. backend).
+    /// Amount must not exceed max single deduct (see init / get_max_deduct).
+    /// If revenue pool is set, USDC is transferred to it; otherwise it remains in the vault.
     /// Emits a "deduct" event with caller, optional request_id, amount, and new balance.
     pub fn deduct(env: Env, caller: Address, amount: i128, request_id: Option<Symbol>) -> i128 {
         caller.require_auth();
+        let max_deduct = Self::get_max_deduct(env.clone());
+        assert!(amount > 0, "amount must be positive");
+        assert!(amount <= max_deduct, "deduct amount exceeds max_deduct");
+
         let mut meta = Self::get_meta(env.clone());
         assert!(meta.balance >= amount, "insufficient balance");
+
+        let usdc_address: Address = env
+            .storage()
+            .instance()
+            .get(&Symbol::new(&env, USDC_KEY))
+            .unwrap_or_else(|| panic!("vault not initialized"));
+        let revenue_pool: Option<Address> = env
+            .storage()
+            .instance()
+            .get(&Symbol::new(&env, REVENUE_POOL_KEY))
+            .unwrap_or(None);
+
         meta.balance -= amount;
         env.storage()
             .instance()
             .set(&Symbol::new(&env, META_KEY), &meta);
+
+        if let Some(to) = revenue_pool {
+            let usdc = token::Client::new(&env, &usdc_address);
+            usdc.transfer(&env.current_contract_address(), &to, &amount);
+        }
 
         let topics = match &request_id {
             Some(rid) => (Symbol::new(&env, "deduct"), caller.clone(), rid.clone()),
@@ -203,23 +284,40 @@ impl CalloraVault {
     }
 
     /// Batch deduct: multiple (amount, optional request_id) in one transaction.
-    /// Reverts the entire batch if any single deduct would exceed balance.
-    /// Emits one "deduct" event per item (same shape as single deduct).
+    /// Each amount must not exceed max_deduct. Reverts entire batch if any check fails.
+    /// If revenue pool is set, total deducted USDC is transferred to it once.
+    /// Emits one "deduct" event per item.
     pub fn batch_deduct(env: Env, caller: Address, items: Vec<DeductItem>) -> i128 {
         caller.require_auth();
+        let max_deduct = Self::get_max_deduct(env.clone());
         let mut meta = Self::get_meta(env.clone());
         let n = items.len();
         assert!(n > 0, "batch_deduct requires at least one item");
 
-        // Validate: running balance must never go negative
+        let mut total_deduct = 0i128;
         let mut running = meta.balance;
         for item in items.iter() {
             assert!(item.amount > 0, "amount must be positive");
+            assert!(
+                item.amount <= max_deduct,
+                "deduct amount exceeds max_deduct"
+            );
             assert!(running >= item.amount, "insufficient balance");
             running -= item.amount;
+            total_deduct += item.amount;
         }
 
-        // Apply all deductions and emit one event per deduct
+        let usdc_address: Address = env
+            .storage()
+            .instance()
+            .get(&Symbol::new(&env, USDC_KEY))
+            .unwrap_or_else(|| panic!("vault not initialized"));
+        let revenue_pool: Option<Address> = env
+            .storage()
+            .instance()
+            .get(&Symbol::new(&env, REVENUE_POOL_KEY))
+            .unwrap_or(None);
+
         let mut balance = meta.balance;
         for item in items.iter() {
             balance -= item.amount;
@@ -238,16 +336,32 @@ impl CalloraVault {
         env.storage()
             .instance()
             .set(&Symbol::new(&env, META_KEY), &meta);
+
+        if total_deduct > 0 {
+            if let Some(to) = revenue_pool {
+                let usdc = token::Client::new(&env, &usdc_address);
+                usdc.transfer(&env.current_contract_address(), &to, &total_deduct);
+            }
+        }
+
         meta.balance
     }
 
-    /// Withdraw from vault. Callable only by the vault owner; reduces balance.
-    /// When USDC is integrated, funds will be transferred to the owner.
+    /// Withdraw from vault. Callable only by the vault owner; reduces balance and transfers USDC to owner.
     pub fn withdraw(env: Env, amount: i128) -> i128 {
         let mut meta = Self::get_meta(env.clone());
         meta.owner.require_auth();
         assert!(amount > 0, "amount must be positive");
         assert!(meta.balance >= amount, "insufficient balance");
+
+        let usdc_address: Address = env
+            .storage()
+            .instance()
+            .get(&Symbol::new(&env, USDC_KEY))
+            .unwrap_or_else(|| panic!("vault not initialized"));
+        let usdc = token::Client::new(&env, &usdc_address);
+        usdc.transfer(&env.current_contract_address(), &meta.owner, &amount);
+
         meta.balance -= amount;
         env.storage()
             .instance()
@@ -260,13 +374,21 @@ impl CalloraVault {
         meta.balance
     }
 
-    /// Withdraw from vault to a designated address. Owner-only.
-    /// When USDC is integrated, funds will be transferred to `to`.
+    /// Withdraw from vault to a designated address. Owner-only; transfers USDC to `to`.
     pub fn withdraw_to(env: Env, to: Address, amount: i128) -> i128 {
         let mut meta = Self::get_meta(env.clone());
         meta.owner.require_auth();
         assert!(amount > 0, "amount must be positive");
         assert!(meta.balance >= amount, "insufficient balance");
+
+        let usdc_address: Address = env
+            .storage()
+            .instance()
+            .get(&Symbol::new(&env, USDC_KEY))
+            .unwrap_or_else(|| panic!("vault not initialized"));
+        let usdc = token::Client::new(&env, &usdc_address);
+        usdc.transfer(&env.current_contract_address(), &to, &amount);
+
         meta.balance -= amount;
         env.storage()
             .instance()

--- a/contracts/vault/src/test.rs
+++ b/contracts/vault/src/test.rs
@@ -22,12 +22,27 @@ fn create_vault(env: &Env) -> (Address, CalloraVaultClient<'_>) {
 }
 
 fn fund_vault(
-    _env: &Env,
     usdc_admin_client: &token::StellarAssetClient,
     vault_address: &Address,
     amount: i128,
 ) {
     usdc_admin_client.mint(vault_address, &amount);
+}
+
+fn fund_user(usdc_admin_client: &token::StellarAssetClient, user: &Address, amount: i128) {
+    usdc_admin_client.mint(user, &amount);
+}
+
+/// Approve spender to transfer amount from from (for deposit tests; from must have auth).
+fn approve_spend(
+    _env: &Env,
+    usdc_client: &token::Client,
+    from: &Address,
+    spender: &Address,
+    amount: i128,
+) {
+    // expiration_ledger 0 = no expiration in Stellar Asset Contract
+    usdc_client.approve(from, spender, &amount, &0u32);
 }
 
 /// Logs approximate CPU/instruction and fee for init, deposit, deduct, and balance.
@@ -45,7 +60,7 @@ fn vault_operation_costs() {
 
     env.mock_all_auths();
 
-    client.init(&owner, &usdc, &Some(0), &None);
+    client.init(&owner, &usdc, &Some(0), &None, &None, &None);
     let res = env.cost_estimate().resources();
     let fee = env.cost_estimate().fee();
     std::println!(
@@ -88,17 +103,14 @@ fn init_and_balance() {
     let owner = Address::generate(&env);
     let contract_id = env.register(CalloraVault {}, ());
 
-    // Initialize via client so events are captured and auth can be mocked
     let client = CalloraVaultClient::new(&env, &contract_id);
-    let (usdc, _, _) = create_usdc(&env, &owner);
+    let (usdc, _, usdc_admin) = create_usdc(&env, &owner);
     env.mock_all_auths();
-    client.init(&owner, &usdc, &Some(1000), &None);
+    fund_vault(&usdc_admin, &contract_id, 1000);
+    client.init(&owner, &usdc, &Some(1000), &None, &None, &None);
     let _events = env.events().all();
 
-    // Verify balance through client
     assert_eq!(client.balance(), 1000);
-
-    // Note: event emission for `init` is validated in other tests.
 }
 
 #[test]
@@ -108,9 +120,12 @@ fn deposit_and_deduct() {
     let contract_id = env.register(CalloraVault {}, ());
     let client = CalloraVaultClient::new(&env, &contract_id);
 
-    let (usdc, _, _) = create_usdc(&env, &owner);
+    let (usdc, usdc_client, usdc_admin) = create_usdc(&env, &owner);
     env.mock_all_auths();
-    client.init(&owner, &usdc, &Some(100), &None);
+    fund_vault(&usdc_admin, &contract_id, 100);
+    client.init(&owner, &usdc, &Some(100), &None, &None, &None);
+    fund_user(&usdc_admin, &owner, 200);
+    approve_spend(&env, &usdc_client, &owner, &contract_id, 200);
     client.deposit(&owner, &200);
     assert_eq!(client.balance(), 300);
     client.deduct(&owner, &50, &None);
@@ -127,34 +142,32 @@ fn balance_and_meta_consistency() {
     let client = CalloraVaultClient::new(&env, &contract_id);
 
     env.mock_all_auths();
-    // Initialize vault with initial balance
-    let (usdc_address, _, _) = create_usdc(&env, &owner);
-    client.init(&owner, &usdc_address, &Some(500), &None);
+    let (usdc_address, usdc_client, usdc_admin) = create_usdc(&env, &owner);
+    fund_vault(&usdc_admin, &contract_id, 500);
+    client.init(&owner, &usdc_address, &Some(500), &None, &None, &None);
 
-    // Verify consistency after initialization
     let meta = client.get_meta();
     let balance = client.balance();
     assert_eq!(meta.balance, balance, "balance mismatch after init");
     assert_eq!(meta.owner, owner, "owner changed after init");
     assert_eq!(balance, 500, "incorrect balance after init");
 
-    // Deposit and verify consistency
+    fund_user(&usdc_admin, &owner, 425);
+    approve_spend(&env, &usdc_client, &owner, &contract_id, 425);
     client.deposit(&owner, &300);
     let meta = client.get_meta();
     let balance = client.balance();
     assert_eq!(meta.balance, balance, "balance mismatch after deposit");
-    assert_eq!(meta.owner, owner, "owner changed after deposit");
     assert_eq!(balance, 800, "incorrect balance after deposit");
 
-    // Deduct and verify consistency
     client.deduct(&owner, &150, &None);
     let meta = client.get_meta();
     let balance = client.balance();
     assert_eq!(meta.balance, balance, "balance mismatch after deduct");
-    assert_eq!(meta.owner, owner, "owner changed after deduct");
     assert_eq!(balance, 650, "incorrect balance after deduct");
 
-    // Perform multiple operations and verify final state
+    fund_user(&usdc_admin, &owner, 125);
+    approve_spend(&env, &usdc_client, &owner, &contract_id, 125);
     client.deposit(&owner, &100);
     client.deduct(&owner, &50, &None);
     client.deposit(&owner, &25);
@@ -164,7 +177,6 @@ fn balance_and_meta_consistency() {
         meta.balance, balance,
         "balance mismatch after multiple operations"
     );
-    assert_eq!(meta.owner, owner, "owner changed after multiple operations");
     assert_eq!(balance, 725, "incorrect final balance");
 }
 
@@ -176,16 +188,15 @@ fn deduct_exact_balance_and_panic() {
     let contract_id = env.register(CalloraVault {}, ());
     let client = CalloraVaultClient::new(&env, &contract_id);
 
-    let (usdc_address, _, _) = create_usdc(&env, &owner);
+    let (usdc_address, _, usdc_admin) = create_usdc(&env, &owner);
     env.mock_all_auths();
-    client.init(&owner, &usdc_address, &Some(100), &None);
+    fund_vault(&usdc_admin, &contract_id, 100);
+    client.init(&owner, &usdc_address, &Some(100), &None, &None, &None);
     assert_eq!(client.balance(), 100);
 
-    // Deduct exact balance
     client.deduct(&owner, &100, &None);
     assert_eq!(client.balance(), 0);
 
-    // Further deduct should panic
     client.deduct(&owner, &1, &None);
 }
 
@@ -197,9 +208,10 @@ fn deduct_event_emission() {
     let contract_id = env.register(CalloraVault {}, ());
     let client = CalloraVaultClient::new(&env, &contract_id);
 
-    let (usdc_address, _, _) = create_usdc(&env, &owner);
+    let (usdc_address, _, usdc_admin) = create_usdc(&env, &owner);
     env.mock_all_auths();
-    client.init(&owner, &usdc_address, &Some(1000), &None);
+    fund_vault(&usdc_admin, &contract_id, 1000);
+    client.init(&owner, &usdc_address, &Some(1000), &None, &None, &None);
     let req_id = Symbol::new(&env, "req123");
 
     // Call client directly to avoid re-entry panic inside as_contract
@@ -232,7 +244,7 @@ fn test_init_success() {
     let (_, vault) = create_vault(&env);
     let (usdc_address, _, _) = create_usdc(&env, &owner);
 
-    let meta = vault.init(&owner, &usdc_address, &None, &None);
+    let meta = vault.init(&owner, &usdc_address, &None, &None, &None, &None);
 
     assert_eq!(meta.owner, owner);
     assert_eq!(meta.balance, 0);
@@ -248,8 +260,8 @@ fn test_init_double_panics() {
     let (_, vault) = create_vault(&env);
     let (usdc_address, _, _) = create_usdc(&env, &owner);
 
-    vault.init(&owner, &usdc_address, &None, &None);
-    vault.init(&owner, &usdc_address, &None, &None);
+    vault.init(&owner, &usdc_address, &None, &None, &None, &None);
+    vault.init(&owner, &usdc_address, &None, &None, &None, &None);
 }
 
 #[test]
@@ -262,8 +274,8 @@ fn test_distribute_success() {
     let (vault_address, vault) = create_vault(&env);
     let (usdc_address, usdc_client, usdc_admin_client) = create_usdc(&env, &admin);
 
-    vault.init(&admin, &usdc_address, &None, &None);
-    fund_vault(&env, &usdc_admin_client, &vault_address, 1_000);
+    fund_vault(&usdc_admin_client, &vault_address, 1_000);
+    vault.init(&admin, &usdc_address, &None, &None, &None, &None);
     vault.distribute(&admin, &developer, &400);
 
     assert_eq!(usdc_client.balance(&vault_address), 600);
@@ -281,8 +293,8 @@ fn test_distribute_excess_panics() {
     let (vault_address, vault) = create_vault(&env);
     let (usdc_address, _, usdc_admin_client) = create_usdc(&env, &admin);
 
-    vault.init(&admin, &usdc_address, &None, &None);
-    fund_vault(&env, &usdc_admin_client, &vault_address, 100);
+    fund_vault(&usdc_admin_client, &vault_address, 100);
+    vault.init(&admin, &usdc_address, &None, &None, &None, &None);
     vault.distribute(&admin, &developer, &101);
 }
 
@@ -297,7 +309,7 @@ fn test_distribute_zero_panics() {
     let (_, vault) = create_vault(&env);
     let (usdc_address, _, _) = create_usdc(&env, &admin);
 
-    vault.init(&admin, &usdc_address, &None, &None);
+    vault.init(&admin, &usdc_address, &None, &None, &None, &None);
     vault.distribute(&admin, &developer, &0);
 }
 
@@ -312,7 +324,7 @@ fn test_distribute_negative_panics() {
     let (_, vault) = create_vault(&env);
     let (usdc_address, _, _) = create_usdc(&env, &admin);
 
-    vault.init(&admin, &usdc_address, &None, &None);
+    vault.init(&admin, &usdc_address, &None, &None, &None, &None);
     vault.distribute(&admin, &developer, &-1);
 }
 
@@ -328,8 +340,8 @@ fn test_distribute_unauthorized_panics() {
     let (vault_address, vault) = create_vault(&env);
     let (usdc_address, _, usdc_admin_client) = create_usdc(&env, &admin);
 
-    vault.init(&admin, &usdc_address, &None, &None);
-    fund_vault(&env, &usdc_admin_client, &vault_address, 1_000);
+    fund_vault(&usdc_admin_client, &vault_address, 1_000);
+    vault.init(&admin, &usdc_address, &None, &None, &None, &None);
     vault.distribute(&attacker, &developer, &500);
 }
 
@@ -343,8 +355,8 @@ fn test_distribute_full_balance() {
     let (vault_address, vault) = create_vault(&env);
     let (usdc_address, usdc_client, usdc_admin_client) = create_usdc(&env, &admin);
 
-    vault.init(&admin, &usdc_address, &None, &None);
-    fund_vault(&env, &usdc_admin_client, &vault_address, 777);
+    fund_vault(&usdc_admin_client, &vault_address, 777);
+    vault.init(&admin, &usdc_address, &None, &None, &None, &None);
     vault.distribute(&admin, &developer, &777);
 
     assert_eq!(usdc_client.balance(&vault_address), 0);
@@ -362,8 +374,8 @@ fn test_distribute_multiple_times() {
     let (vault_address, vault) = create_vault(&env);
     let (usdc_address, usdc_client, usdc_admin_client) = create_usdc(&env, &admin);
 
-    vault.init(&admin, &usdc_address, &None, &None);
-    fund_vault(&env, &usdc_admin_client, &vault_address, 1_000);
+    fund_vault(&usdc_admin_client, &vault_address, 1_000);
+    vault.init(&admin, &usdc_address, &None, &None, &None, &None);
     vault.distribute(&admin, &dev_a, &300);
     vault.distribute(&admin, &dev_b, &200);
 
@@ -383,8 +395,8 @@ fn test_set_admin_transfers_control() {
     let (vault_address, vault) = create_vault(&env);
     let (usdc_address, usdc_client, usdc_admin_client) = create_usdc(&env, &original_admin);
 
-    vault.init(&original_admin, &usdc_address, &None, &None);
-    fund_vault(&env, &usdc_admin_client, &vault_address, 500);
+    fund_vault(&usdc_admin_client, &vault_address, 500);
+    vault.init(&original_admin, &usdc_address, &None, &None, &None, &None);
     vault.set_admin(&original_admin, &new_admin);
 
     assert_eq!(vault.get_admin(), new_admin);
@@ -405,8 +417,8 @@ fn test_old_admin_cannot_distribute_after_transfer() {
     let (vault_address, vault) = create_vault(&env);
     let (usdc_address, _, usdc_admin_client) = create_usdc(&env, &original_admin);
 
-    vault.init(&original_admin, &usdc_address, &None, &None);
-    fund_vault(&env, &usdc_admin_client, &vault_address, 500);
+    fund_vault(&usdc_admin_client, &vault_address, 500);
+    vault.init(&original_admin, &usdc_address, &None, &None, &None, &None);
     vault.set_admin(&original_admin, &new_admin);
     vault.distribute(&original_admin, &developer, &100);
 }
@@ -417,10 +429,12 @@ fn test_deposit_and_balance() {
     env.mock_all_auths();
 
     let owner = Address::generate(&env);
-    let (_, vault) = create_vault(&env);
-    let (usdc_address, _, _) = create_usdc(&env, &owner);
+    let (vault_address, vault) = create_vault(&env);
+    let (usdc_address, usdc_client, usdc_admin) = create_usdc(&env, &owner);
 
-    vault.init(&owner, &usdc_address, &Some(0), &None);
+    vault.init(&owner, &usdc_address, &Some(0), &None, &None, &None);
+    fund_user(&usdc_admin, &owner, 250);
+    approve_spend(&env, &usdc_client, &owner, &vault_address, 250);
     vault.deposit(&owner, &200);
     assert_eq!(vault.balance(), 200);
     vault.deposit(&owner, &50);
@@ -433,12 +447,38 @@ fn test_deduct_success() {
     env.mock_all_auths();
 
     let owner = Address::generate(&env);
-    let (_, vault) = create_vault(&env);
-    let (usdc_address, _, _) = create_usdc(&env, &owner);
+    let (vault_address, vault) = create_vault(&env);
+    let (usdc_address, _, usdc_admin) = create_usdc(&env, &owner);
 
-    vault.init(&owner, &usdc_address, &Some(300), &None);
+    fund_vault(&usdc_admin, &vault_address, 300);
+    vault.init(&owner, &usdc_address, &Some(300), &None, &None, &None);
     vault.deduct(&owner, &100, &None);
     assert_eq!(vault.balance(), 200);
+}
+
+#[test]
+#[should_panic(expected = "deduct amount exceeds max_deduct")]
+fn test_deduct_above_max_deduct_panics() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let owner = Address::generate(&env);
+    let (vault_address, vault) = create_vault(&env);
+    let (usdc_address, _, usdc_admin) = create_usdc(&env, &owner);
+
+    fund_vault(&usdc_admin, &vault_address, 10_000);
+    vault.init(
+        &owner,
+        &usdc_address,
+        &Some(10_000),
+        &None,
+        &None,
+        &Some(100),
+    );
+    assert_eq!(vault.get_max_deduct(), 100);
+    vault.deduct(&owner, &100, &None);
+    assert_eq!(vault.balance(), 9_900);
+    vault.deduct(&owner, &101, &None);
 }
 
 #[test]
@@ -448,10 +488,11 @@ fn test_deduct_excess_panics() {
     env.mock_all_auths();
 
     let owner = Address::generate(&env);
-    let (_, vault) = create_vault(&env);
-    let (usdc_address, _, _) = create_usdc(&env, &owner);
+    let (vault_address, vault) = create_vault(&env);
+    let (usdc_address, _, usdc_admin) = create_usdc(&env, &owner);
 
-    vault.init(&owner, &usdc_address, &Some(50), &None);
+    fund_vault(&usdc_admin, &vault_address, 50);
+    vault.init(&owner, &usdc_address, &Some(50), &None, &None, &None);
     vault.deduct(&owner, &100, &None);
 }
 
@@ -461,10 +502,11 @@ fn test_get_meta_returns_correct_values() {
     env.mock_all_auths();
 
     let owner = Address::generate(&env);
-    let (_, vault) = create_vault(&env);
-    let (usdc_address, _, _) = create_usdc(&env, &owner);
+    let (vault_address, vault) = create_vault(&env);
+    let (usdc_address, _, usdc_admin) = create_usdc(&env, &owner);
 
-    vault.init(&owner, &usdc_address, &Some(999), &None);
+    fund_vault(&usdc_admin, &vault_address, 999);
+    vault.init(&owner, &usdc_address, &Some(999), &None, &None, &None);
     let meta = vault.get_meta();
     assert_eq!(meta.owner, owner);
     assert_eq!(meta.balance, 999);
@@ -476,28 +518,44 @@ fn test_multiple_depositors() {
     let owner = Address::generate(&env);
     let contract_id = env.register(CalloraVault {}, ());
     let client = CalloraVaultClient::new(&env, &contract_id);
-    let (usdc_address, _, _) = create_usdc(&env, &owner);
+    let (usdc_address, usdc_client, usdc_admin) = create_usdc(&env, &owner);
     env.mock_all_auths();
 
     let dep1 = Address::generate(&env);
     let dep2 = Address::generate(&env);
+    fund_user(&usdc_admin, &dep1, 100);
+    fund_user(&usdc_admin, &dep2, 200);
+    approve_spend(&env, &usdc_client, &dep1, &contract_id, 100);
+    approve_spend(&env, &usdc_client, &dep2, &contract_id, 200);
 
-    // Use as_contract to call the functions directly and capture events
-    let contract_events = env.as_contract(&contract_id, || {
-        CalloraVault::init(env.clone(), owner.clone(), usdc_address.clone(), None, None);
+    let all_events = env.as_contract(&contract_id, || {
+        CalloraVault::init(
+            env.clone(),
+            owner.clone(),
+            usdc_address.clone(),
+            None,
+            None,
+            None,
+            None,
+        );
         CalloraVault::deposit(env.clone(), dep1.clone(), 100);
         CalloraVault::deposit(env.clone(), dep2.clone(), 200);
 
         env.events().all()
     });
+    let contract_events: std::vec::Vec<_> =
+        all_events.iter().filter(|e| e.0 == contract_id).collect();
 
     assert_eq!(client.balance(), 300);
 
-    // Verify events: init + 2 deposits
-    assert_eq!(contract_events.len(), 3);
+    assert_eq!(
+        contract_events.len(),
+        3,
+        "vault should emit init + 2 deposits"
+    );
 
     // Event 1: Init event
-    let event0 = contract_events.get(0).unwrap();
+    let event0 = contract_events.first().unwrap();
     let topic0_0: Symbol = event0.1.get(0).unwrap().into_val(&env);
     assert_eq!(topic0_0, Symbol::new(&env, "init"));
 
@@ -526,10 +584,11 @@ fn batch_deduct_success() {
     let owner = Address::generate(&env);
     let contract_id = env.register(CalloraVault {}, ());
     let client = CalloraVaultClient::new(&env, &contract_id);
-    let (usdc_address, _, _) = create_usdc(&env, &owner);
+    let (usdc_address, _, usdc_admin) = create_usdc(&env, &owner);
 
     env.mock_all_auths();
-    client.init(&owner, &usdc_address, &Some(1000), &None);
+    fund_vault(&usdc_admin, &contract_id, 1000);
+    client.init(&owner, &usdc_address, &Some(1000), &None, &None, &None);
     let req1 = Symbol::new(&env, "req1");
     let req2 = Symbol::new(&env, "req2");
     let items = vec![
@@ -561,10 +620,11 @@ fn batch_deduct_reverts_entire_batch() {
     let owner = Address::generate(&env);
     let contract_id = env.register(CalloraVault {}, ());
     let client = CalloraVaultClient::new(&env, &contract_id);
-    let (usdc_address, _, _) = create_usdc(&env, &owner);
+    let (usdc_address, _, usdc_admin) = create_usdc(&env, &owner);
 
     env.mock_all_auths();
-    client.init(&owner, &usdc_address, &Some(100), &None);
+    fund_vault(&usdc_admin, &contract_id, 100);
+    client.init(&owner, &usdc_address, &Some(100), &None, &None, &None);
     let items = vec![
         &env,
         DeductItem {
@@ -587,10 +647,11 @@ fn withdraw_owner_success() {
     let owner = Address::generate(&env);
     let contract_id = env.register(CalloraVault {}, ());
     let client = CalloraVaultClient::new(&env, &contract_id);
-    let (usdc_address, _, _) = create_usdc(&env, &owner);
+    let (usdc_address, _, usdc_admin) = create_usdc(&env, &owner);
 
     env.mock_all_auths();
-    client.init(&owner, &usdc_address, &Some(500), &None);
+    fund_vault(&usdc_admin, &contract_id, 500);
+    client.init(&owner, &usdc_address, &Some(500), &None, &None, &None);
     let new_balance = client.withdraw(&200);
     assert_eq!(new_balance, 300);
     assert_eq!(client.balance(), 300);
@@ -602,10 +663,11 @@ fn withdraw_exact_balance() {
     let owner = Address::generate(&env);
     let contract_id = env.register(CalloraVault {}, ());
     let client = CalloraVaultClient::new(&env, &contract_id);
-    let (usdc_address, _, _) = create_usdc(&env, &owner);
+    let (usdc_address, _, usdc_admin) = create_usdc(&env, &owner);
 
     env.mock_all_auths();
-    client.init(&owner, &usdc_address, &Some(100), &None);
+    fund_vault(&usdc_admin, &contract_id, 100);
+    client.init(&owner, &usdc_address, &Some(100), &None, &None, &None);
     let new_balance = client.withdraw(&100);
     assert_eq!(new_balance, 0);
     assert_eq!(client.balance(), 0);
@@ -618,10 +680,11 @@ fn withdraw_exceeds_balance_fails() {
     let owner = Address::generate(&env);
     let contract_id = env.register(CalloraVault {}, ());
     let client = CalloraVaultClient::new(&env, &contract_id);
-    let (usdc_address, _, _) = create_usdc(&env, &owner);
+    let (usdc_address, _, usdc_admin) = create_usdc(&env, &owner);
 
     env.mock_all_auths();
-    client.init(&owner, &usdc_address, &Some(50), &None);
+    fund_vault(&usdc_admin, &contract_id, 50);
+    client.init(&owner, &usdc_address, &Some(50), &None, &None, &None);
     client.withdraw(&100);
 }
 
@@ -632,10 +695,11 @@ fn withdraw_to_success() {
     let to = Address::generate(&env);
     let contract_id = env.register(CalloraVault {}, ());
     let client = CalloraVaultClient::new(&env, &contract_id);
-    let (usdc_address, _, _) = create_usdc(&env, &owner);
+    let (usdc_address, _, usdc_admin) = create_usdc(&env, &owner);
 
     env.mock_all_auths();
-    client.init(&owner, &usdc_address, &Some(500), &None);
+    fund_vault(&usdc_admin, &contract_id, 500);
+    client.init(&owner, &usdc_address, &Some(500), &None, &None, &None);
     let new_balance = client.withdraw_to(&to, &150);
     assert_eq!(new_balance, 350);
     assert_eq!(client.balance(), 350);
@@ -648,22 +712,29 @@ fn withdraw_without_auth_fails() {
     let owner = Address::generate(&env);
     let contract_id = env.register(CalloraVault {}, ());
     let client = CalloraVaultClient::new(&env, &contract_id);
-    let (usdc_address, _, _) = create_usdc(&env, &owner);
+    let (usdc_address, _, usdc_admin) = create_usdc(&env, &owner);
 
-    // Mock auth ONLY for init
+    fund_vault(&usdc_admin, &contract_id, 100);
     env.mock_auths(&[soroban_sdk::testutils::MockAuth {
         address: &owner,
         invoke: &soroban_sdk::testutils::MockAuthInvoke {
             contract: &contract_id,
             fn_name: "init",
-            args: (&owner, &usdc_address, Some(100i128), Option::<i128>::None).into_val(&env),
+            args: (
+                &owner,
+                &usdc_address,
+                Some(100i128),
+                Option::<i128>::None,
+                Option::<Address>::None,
+                Option::<i128>::None,
+            )
+                .into_val(&env),
             sub_invokes: &[],
         },
     }]);
 
-    client.init(&owner, &usdc_address, &Some(100), &None);
+    client.init(&owner, &usdc_address, &Some(100), &None, &None, &None);
 
-    // This should now panic because owner.require_auth() is called in withdraw but not mocked here
     client.withdraw(&50);
 }
 
@@ -676,7 +747,8 @@ fn init_already_initialized_panics() {
     let client = CalloraVaultClient::new(&env, &contract_id);
 
     env.mock_all_auths();
-    let (usdc_address, _, _) = create_usdc(&env, &owner);
-    client.init(&owner, &usdc_address, &Some(100), &None);
-    client.init(&owner, &usdc_address, &Some(200), &None); // Should panic
+    let (usdc_address, _, usdc_admin) = create_usdc(&env, &owner);
+    fund_vault(&usdc_admin, &contract_id, 100);
+    client.init(&owner, &usdc_address, &Some(100), &None, &None, &None);
+    client.init(&owner, &usdc_address, &Some(200), &None, &None, &None);
 }


### PR DESCRIPTION
## Summary

Implements three issues: USDC-backed vault deposits/deducts (#4), optional max single deduct (#19), and the revenue settlement contract skeleton (#15).

## Changes

### 1. USDC token integration (Issue #4)

- **Deposit:** `deposit(from, amount)` uses `transfer_from` so the user sends USDC to the vault; ledger balance increases. Caller must approve the vault (token allowance).
- **Deduct:** Ledger balance decreases; if a revenue pool is set at init, that amount of USDC is transferred to it in the same call.
- **Withdraw / withdraw_to:** In addition to updating the ledger, USDC is transferred to the owner or `to`.
- **Init:** If `initial_balance > 0`, the contract must already hold at least that much USDC (e.g. deployer funded it first).

### 2. Max single deduct (Issue #19)

- Added `DEFAULT_MAX_DEDUCT` constant (`i128::MAX` when no cap).
- Optional `max_deduct` at init; enforced in `deduct` and `batch_deduct` (each item must be `<= max_deduct`).
- New getter: `get_max_deduct()`.
- Test: `test_deduct_above_max_deduct_panics` ensures deduct above cap panics.

### 3. Revenue settlement contract (Issue #15)

- New crate: `contracts/revenue_pool` (`callora-revenue-pool`).
- **init(admin, usdc_token)** — set admin and USDC token.
- **distribute(caller, to, amount)** — admin-only; sends USDC from this contract to a developer.
- **receive_payment(caller, amount, from_vault)** — optional; emits an event for indexers when the vault sends USDC to this contract.
- **balance()** — returns this contract’s USDC balance.
- Flow: vault deduct → vault transfers USDC to revenue pool → admin calls `distribute(to, amount)`.

### 4. Vault init and storage

- New init parameters: `revenue_pool: Option<Address>`, `max_deduct: Option<i128>` (after existing args).
- New getters: `get_revenue_pool()`, `get_max_deduct()`.

## Testing

- **Vault:** 31 tests (30 run + 1 ignored). Deposit tests mint USDC to users and call `approve` before `deposit`.
- **Revenue pool:** 8 tests.
- `cargo fmt --all`, `cargo clippy --all-targets --all-features -- -D warnings`, and `cargo test` pass.
- CI builds both `vault` and `revenue_pool` WASM.

## Documentation

- README updated for new vault behaviour and revenue pool; project layout includes `revenue_pool`.
- STORAGE.md updated with `revenue_pool`, `max_deduct`, and related keys.