### PR TITLE
test: deduct when paused panics

### DIFF
--- a/contracts/vault/src/lib.rs
+++ b/contracts/vault/src/lib.rs
@@ -43,6 +43,7 @@ pub struct VaultMeta {
 pub enum StorageKey {
     Meta,
     AllowedDepositors,
+    Paused,
 }
 
 #[contract]
@@ -156,10 +157,34 @@ impl CalloraVault {
         meta.balance
     }
 
+    /// Pause the vault. Only the owner may call this.
+    pub fn pause(env: Env, caller: Address) {
+        caller.require_auth();
+        Self::require_owner(env.clone(), caller);
+        env.storage().instance().set(&StorageKey::Paused, &true);
+    }
+
+    /// Unpause the vault. Only the owner may call this.
+    pub fn unpause(env: Env, caller: Address) {
+        caller.require_auth();
+        Self::require_owner(env.clone(), caller);
+        env.storage().instance().set(&StorageKey::Paused, &false);
+    }
+
+    /// Return whether the vault is currently paused.
+    pub fn paused(env: Env) -> bool {
+        env.storage()
+            .instance()
+            .get(&StorageKey::Paused)
+            .unwrap_or(false)
+    }
+
     /// Deduct balance for an API call. Only owner/authorized caller in production.
+    /// Panics if the vault is paused.
     pub fn deduct(env: Env, caller: Address, amount: i128) -> i128 {
         caller.require_auth();
         Self::require_owner(env.clone(), caller);
+        assert!(!Self::paused(env.clone()), "vault is paused");
 
         let mut meta = Self::get_meta(env.clone());
         assert!(amount > 0, "amount must be positive");

--- a/contracts/vault/src/test.rs
+++ b/contracts/vault/src/test.rs
@@ -561,6 +561,20 @@ fn init_twice_panics_on_reinit() {
 }
 
 #[test]
+#[should_panic(expected = "vault is paused")]
+fn test_deduct_when_paused_panics() {
+    let env = Env::default();
+    let owner = Address::generate(&env);
+    let contract_id = env.register(CalloraVault, ());
+    let client = CalloraVaultClient::new(&env, &contract_id);
+
+    client.init(&owner, &Some(500));
+    env.mock_all_auths();
+    client.pause(&owner);
+    client.deduct(&owner, &100);
+}
+
+#[test]
 fn owner_unchanged_after_deposit_and_deduct() {
     let env = Env::default();
     let owner = Address::generate(&env);


### PR DESCRIPTION
## Summary

Closes #36. Adds a unit test that verifies calling `deduct` on a paused vault panics.

## Root Cause

The contract lacked a pause mechanism entirely. A minimal pause feature was
required as a prerequisite for the test.

## Changes

- Added `pause`, `unpause`, and `paused` functions to the vault contract
  (admin-only for state mutations, default unpaused).
- Added a pause guard at the top of `deduct` that asserts the vault is not
  paused.
- Added `test_deduct_when_paused_panics` test: inits vault with balance,
  pauses, calls deduct, expects panic with "vault is paused".

## Testing

- All 31 tests pass (`cargo test`).
- `cargo fmt --all -- --check` clean.
- `cargo clippy --all-targets --all-features -- -D warnings` clean.