### PR TITLE
feat: batch revenue distribution

### DIFF
--- a/contracts/revenue_pool/src/test.rs
+++ b/contracts/revenue_pool/src/test.rs
@@ -2,7 +2,7 @@ extern crate std;
 
 use super::*;
 use soroban_sdk::testutils::{Address as _, Events as _};
-use soroban_sdk::token;
+use soroban_sdk::{token, vec};
 
 fn create_usdc<'a>(
     env: &'a Env,
@@ -144,4 +144,78 @@ fn receive_payment_emits_event() {
     client.receive_payment(&admin, &500, &true);
     let events = env.events().all();
     assert!(!events.is_empty());
+}
+
+#[test]
+fn batch_distribute_success() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let dev1 = Address::generate(&env);
+    let dev2 = Address::generate(&env);
+    let (pool_addr, client) = create_pool(&env);
+    let (usdc_address, usdc_client, usdc_admin) = create_usdc(&env, &admin);
+
+    client.init(&admin, &usdc_address);
+    fund_pool(&usdc_admin, &pool_addr, 1_000);
+
+    let payments = vec![&env, (dev1.clone(), 300), (dev2.clone(), 500)];
+    client.batch_distribute(&admin, &payments);
+
+    assert_eq!(usdc_client.balance(&pool_addr), 200);
+    assert_eq!(usdc_client.balance(&dev1), 300);
+    assert_eq!(usdc_client.balance(&dev2), 500);
+}
+
+#[test]
+#[should_panic(expected = "amount must be positive")]
+fn batch_distribute_zero_panics() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let dev1 = Address::generate(&env);
+    let dev2 = Address::generate(&env);
+    let (_, client) = create_pool(&env);
+    let (usdc_address, _, _) = create_usdc(&env, &admin);
+
+    client.init(&admin, &usdc_address);
+
+    let payments = vec![&env, (dev1.clone(), 300), (dev2.clone(), 0)];
+    client.batch_distribute(&admin, &payments);
+}
+
+#[test]
+#[should_panic(expected = "insufficient USDC balance")]
+fn batch_distribute_insufficient_balance_panics() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let dev1 = Address::generate(&env);
+    let dev2 = Address::generate(&env);
+    let (pool_addr, client) = create_pool(&env);
+    let (usdc_address, _, usdc_admin) = create_usdc(&env, &admin);
+
+    client.init(&admin, &usdc_address);
+    fund_pool(&usdc_admin, &pool_addr, 400);
+
+    let payments = vec![&env, (dev1.clone(), 300), (dev2.clone(), 200)];
+    client.batch_distribute(&admin, &payments);
+}
+
+#[test]
+#[should_panic(expected = "unauthorized: caller is not admin")]
+fn batch_distribute_unauthorized_panics() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let attacker = Address::generate(&env);
+    let dev1 = Address::generate(&env);
+    let (pool_addr, client) = create_pool(&env);
+    let (usdc_address, _, usdc_admin) = create_usdc(&env, &admin);
+
+    client.init(&admin, &usdc_address);
+    fund_pool(&usdc_admin, &pool_addr, 1000);
+
+    let payments = vec![&env, (dev1.clone(), 300)];
+    client.batch_distribute(&attacker, &payments);
 }


### PR DESCRIPTION
# Description

Closes #38

This PR introduces the `batch_distribute` function to the `RevenuePool` contract, enabling the admin to distribute USDC to multiple developers in a single transaction. This significantly reduces the transaction count and overhead for periodic payouts. 

The execution is fully atomic: it pre-calculates the total required USDC and reverts the entire transaction if the contract has insufficient balance or if any individual payment amount is invalid.

## Changes Proposed

* **Added `batch_distribute` function** to `lib.rs`:
    * Accepts a `Vec<(Address, i128)>` of payments.
    * Iterates through the payments to validate amounts (must be strictly positive) and sum the total required balance.
    * Verifies the contract holds enough USDC before initiating any transfers.
    * Loops through and transfers USDC to each developer, emitting a `batch_distribute` event for each successful transfer.
* **Updated Imports:** Added `Vec` from `soroban_sdk` in `lib.rs` and the `vec` macro in `test.rs`.

## Testing & Security

Maintained the strict >95% test coverage requirement by adding the following test cases in `test.rs`:
* `batch_distribute_success`: Verifies correct balances for all parties after a valid batch distribution.
* `batch_distribute_zero_panics`: Ensures the transaction reverts if any payment in the batch is 0 or negative.
* `batch_distribute_insufficient_balance_panics`: Ensures the entire transaction reverts if the total batch amount exceeds the contract's current balance.
* `batch_distribute_unauthorized_panics`: Confirms only the initialized admin address can trigger the batch distribution.

<img width="1165" height="374" alt="test3" src="https://github.com/user-attachments/assets/2d543306-c028-46df-af08-a3869a07dee3" />
