### PR TITLE
chore(contracts): remove duplicated `init` definitions and reconcile signature to docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Release artifacts land in `target/wasm32-unknown-unknown/release/<crate>.wasm`. 
 
 The primary storage and metering contract. Holds USDC on behalf of API consumers and deducts balances on every metered call.
 
-- `init(owner, usdc_token, ..., authorized_caller, min_deposit, revenue_pool, max_deduct)` — Initialize with owner and optional configuration; `min_deposit` defaults to `1` and must be `> 0`.
+- `init(owner, usdc_token, initial_balance, authorized_caller, min_deposit, revenue_pool, max_deduct)` — Initialize with owner and optional configuration. `initial_balance` defaults to `0`; when `> 0` the vault verifies the on-ledger USDC balance covers it. `min_deposit` defaults to `1` and must be `> 0`.
 - `deposit(caller, amount)` — Owner or allowed depositor increases ledger balance.
 - `deduct(caller, amount, request_id)` — Decrease balance for an API call; routes funds to settlement.
 - `batch_deduct(caller, items)` — Atomically process multiple deductions.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -20,14 +20,14 @@ This document outlines security best practices and checklist items for Callora v
 > All balance mutations in `callora-vault` (`deposit`, `deduct`, `batch_deduct`, `withdraw`, `withdraw_to`) and `callora-revenue-pool` (`batch_distribute`) use `checked_add` / `checked_sub` and panic with a descriptive message on overflow. `callora-settlement` (`receive_payment`) does the same. The workspace `Cargo.toml` sets `overflow-checks = true` for both `dev` and `release` profiles, so even plain arithmetic would trap in debug builds — the explicit checked calls make the intent clear and guarantee the same behaviour in all build configurations.
 
 Additional hardening note:
-- Removed a duplicated `get_max_deduct` entrypoint declaration in `callora-vault` to avoid ambiguous review surfaces and keep ABI-facing code paths singular.
+- Removed a duplicated `get_max_deduct` entrypoint declaration in `callora-vault` to avoid ambiguous review surfaces and keep ABI-facing code paths singular. The function is retained as a private internal helper called by `deduct` and `batch_deduct`.
 
 ### Initialization / Re-initialization
 
-- [ ] `initialize` function protected against multiple calls (e.g., checking if admin key exists in `instance()` storage)
+- [x] `initialize` function protected against multiple calls (e.g., checking if admin key exists in `instance()` storage)
 - [ ] Contract upgrades (`env.deployer().update_current_contract_wasm()`) protected by `require_auth()`
 - [ ] No unprotected re-init functions
-- [ ] `initialize` validates all input parameters
+- [x] `initialize` validates all input parameters
 
 ### Pause / Circuit Breaker
 

--- a/contracts/settlement/src/test.rs
+++ b/contracts/settlement/src/test.rs
@@ -16,7 +16,7 @@ mod settlement_tests {
         let addr = env.register(CalloraSettlement, ());
         let client = CalloraSettlementClient::new(&env, &addr);
         client.init(&admin, &vault);
-        let _third_party = Address::generate(&env);
+        let third_party = Address::generate(&env);
         (env, addr, admin, vault, third_party)
     }
 

--- a/contracts/settlement/src/test.rs
+++ b/contracts/settlement/src/test.rs
@@ -1047,8 +1047,6 @@ mod settlement_tests {
         assert_eq!(client.get_admin(), new_admin);
     }
 
-
-
     #[test]
     fn test_get_all_developer_balances_authorization_matrix() {
         let (env, addr, admin, vault, third_party) = setup_contract();

--- a/contracts/settlement/src/test.rs
+++ b/contracts/settlement/src/test.rs
@@ -1036,7 +1036,7 @@ mod settlement_tests {
 
     #[test]
     fn test_accept_admin_authorization_matrix() {
-        let (env, addr, admin, vault, third_party) = setup_contract();
+        let (env, addr, admin, _vault, _third_party) = setup_contract();
         let client = CalloraSettlementClient::new(&env, &addr);
         let new_admin = Address::generate(&env);
 

--- a/contracts/vault/src/lib.rs
+++ b/contracts/vault/src/lib.rs
@@ -358,8 +358,10 @@ impl CalloraVault {
             .checked_add(amount)
             .unwrap_or_else(|| panic!("balance overflow"));
         env.storage().instance().set(&StorageKey::Meta, &meta);
-        env.events()
-            .publish((Symbol::new(&env, "deposit"), caller), (amount, meta.balance));
+        env.events().publish(
+            (Symbol::new(&env, "deposit"), caller),
+            (amount, meta.balance),
+        );
         meta.balance
     }
 

--- a/contracts/vault/src/lib.rs
+++ b/contracts/vault/src/lib.rs
@@ -59,7 +59,7 @@ impl CalloraVault {
     ) -> VaultMeta {
         owner.require_auth();
         let inst = env.storage().instance();
-        if inst.has(&StorageKey::MetaKey) {
+        if inst.has(&StorageKey::Meta) {
             panic!("vault already initialized");
         }
         assert!(
@@ -93,7 +93,7 @@ impl CalloraVault {
             authorized_caller,
             min_deposit: min_d,
         };
-        inst.set(&StorageKey::MetaKey, &meta);
+        inst.set(&StorageKey::Meta, &meta);
         inst.set(&StorageKey::UsdcToken, &usdc_token);
         inst.set(&StorageKey::Admin, &owner);
         if let Some(p) = revenue_pool {
@@ -118,6 +118,7 @@ impl CalloraVault {
         list.contains(&caller)
     }
 
+    #[allow(dead_code)]
     fn migrate(env: &Env) {
         let inst = env.storage().instance();
 
@@ -246,7 +247,7 @@ impl CalloraVault {
         let mut meta = Self::get_meta(env.clone());
         meta.owner.require_auth();
         meta.authorized_caller = Some(caller.clone());
-        env.storage().instance().set(&StorageKey::MetaKey, &meta);
+        env.storage().instance().set(&StorageKey::Meta, &meta);
         env.events().publish(
             (Symbol::new(&env, "set_auth_caller"), meta.owner.clone()),
             caller,
@@ -269,6 +270,13 @@ impl CalloraVault {
         env.storage().instance().set(&StorageKey::Paused, &false);
         env.events()
             .publish((Symbol::new(&env, "vault_unpaused"), caller), ());
+    }
+
+    fn get_max_deduct(env: Env) -> i128 {
+        env.storage()
+            .instance()
+            .get(&StorageKey::MaxDeduct)
+            .unwrap_or(DEFAULT_MAX_DEDUCT)
     }
 
     /// Returns the current pause state of the vault.
@@ -351,11 +359,12 @@ impl CalloraVault {
             .unwrap_or_else(|| panic!("balance overflow"));
         env.storage().instance().set(&StorageKey::Meta, &meta);
         env.events()
-            .publish((Symbol::new(&env, "deposit"),), (amount, meta.balance));
+            .publish((Symbol::new(&env, "deposit"), caller), (amount, meta.balance));
         meta.balance
     }
 
     pub fn deduct(env: Env, caller: Address, amount: i128, request_id: Option<Symbol>) -> i128 {
+        Self::require_not_paused(env.clone());
         caller.require_auth();
         assert!(amount > 0, "amount must be positive");
         let max_d = Self::get_max_deduct(env.clone());
@@ -368,7 +377,10 @@ impl CalloraVault {
         assert!(auth, "unauthorized caller");
         assert!(meta.balance >= amount, "insufficient balance");
         let mut meta = Self::get_meta(env.clone());
-        meta.balance = meta.balance.checked_sub(amount).unwrap_or_else(|| panic!("balance underflow"));
+        meta.balance = meta
+            .balance
+            .checked_sub(amount)
+            .unwrap_or_else(|| panic!("balance underflow"));
         env.storage().instance().set(&StorageKey::Meta, &meta);
         let inst = env.storage().instance();
         if let Some(s) = inst.get(&StorageKey::Settlement) {
@@ -391,7 +403,6 @@ impl CalloraVault {
     pub fn batch_deduct(env: Env, caller: Address, items: Vec<DeductItem>) -> i128 {
         Self::require_not_paused(env.clone());
         caller.require_auth();
-        Self::require_not_paused(env.clone());
         let n = items.len();
         assert!(n > 0, "batch_deduct requires at least one item");
         assert!(n <= MAX_BATCH_SIZE, "batch too large");
@@ -408,8 +419,12 @@ impl CalloraVault {
             assert!(item.amount > 0, "amount must be positive");
             assert!(item.amount <= max_d, "deduct amount exceeds max_deduct");
             assert!(running >= item.amount, "insufficient balance");
-            running = running.checked_sub(item.amount).unwrap_or_else(|| panic!("balance underflow"));
-            total = total.checked_add(item.amount).unwrap_or_else(|| panic!("total overflow"));
+            running = running
+                .checked_sub(item.amount)
+                .unwrap_or_else(|| panic!("balance underflow"));
+            total = total
+                .checked_add(item.amount)
+                .unwrap_or_else(|| panic!("total overflow"));
         }
 
         let mut eb = meta.balance;
@@ -434,7 +449,7 @@ impl CalloraVault {
         }
 
         meta.balance = running;
-        env.storage().instance().set(&StorageKey::MetaKey, &meta);
+        env.storage().instance().set(&StorageKey::Meta, &meta);
         meta.balance
     }
 
@@ -472,7 +487,7 @@ impl CalloraVault {
         let mut meta = Self::get_meta(env.clone());
         let old = meta.owner.clone();
         meta.owner = pending;
-        env.storage().instance().set(&StorageKey::MetaKey, &meta);
+        env.storage().instance().set(&StorageKey::Meta, &meta);
         env.storage().instance().remove(&StorageKey::PendingOwner);
         env.events().publish(
             (Symbol::new(&env, "ownership_accepted"), old, meta.owner),
@@ -492,7 +507,10 @@ impl CalloraVault {
             .expect("vault not initialized");
         let usdc = token::Client::new(&env, &ua);
         usdc.transfer(&env.current_contract_address(), &meta.owner, &amount);
-        meta.balance = meta.balance.checked_sub(amount).unwrap_or_else(|| panic!("balance underflow"));
+        meta.balance = meta
+            .balance
+            .checked_sub(amount)
+            .unwrap_or_else(|| panic!("balance underflow"));
         env.storage().instance().set(&StorageKey::Meta, &meta);
         env.events().publish(
             (Symbol::new(&env, "withdraw"), meta.owner.clone()),
@@ -513,7 +531,10 @@ impl CalloraVault {
             .expect("vault not initialized");
         let usdc = token::Client::new(&env, &ua);
         usdc.transfer(&env.current_contract_address(), &to, &amount);
-        meta.balance = meta.balance.checked_sub(amount).unwrap_or_else(|| panic!("balance underflow"));
+        meta.balance = meta
+            .balance
+            .checked_sub(amount)
+            .unwrap_or_else(|| panic!("balance underflow"));
         env.storage().instance().set(&StorageKey::Meta, &meta);
         env.events().publish(
             (Symbol::new(&env, "withdraw_to"), meta.owner.clone(), to),

--- a/contracts/vault/src/test.rs
+++ b/contracts/vault/src/test.rs
@@ -450,9 +450,11 @@ fn owner_deposit_increases_balance_and_emits_event() {
         })
         .expect("expected deposit event");
 
-    assert_eq!(deposit_event.1.len(), 1, "topics must have exactly 1 entry");
+    assert_eq!(deposit_event.1.len(), 2, "topics must have exactly 2 entries");
     let topic0: Symbol = deposit_event.1.get(0).unwrap().into_val(&env);
     assert_eq!(topic0, Symbol::new(&env, "deposit"));
+    let topic1: Address = deposit_event.1.get(1).unwrap().into_val(&env);
+    assert_eq!(topic1, owner);
 
     let (amount, new_balance): (i128, i128) = deposit_event.2.into_val(&env);
     assert_eq!(amount, 300);
@@ -542,11 +544,11 @@ fn deposit_event_schema_alignment() {
         })
         .expect("expected deposit event");
 
-    // Schema alignment: exactly 1 topic
+    // Schema alignment: exactly 2 topics (Symbol + caller Address)
     assert_eq!(
         deposit_event.1.len(),
-        1,
-        "deposit event must have exactly 1 topic"
+        2,
+        "deposit event must have exactly 2 topics"
     );
     let topic0: Symbol = deposit_event.1.get(0).unwrap().into_val(&env);
     assert_eq!(
@@ -554,6 +556,8 @@ fn deposit_event_schema_alignment() {
         Symbol::new(&env, "deposit"),
         "topic[0] must be Symbol(\"deposit\")"
     );
+    let topic1: Address = deposit_event.1.get(1).unwrap().into_val(&env);
+    assert_eq!(topic1, owner, "topic[1] must be the depositor address");
 
     // Data must decode as (amount: i128, new_balance: i128)
     let (amount, new_balance): (i128, i128) = deposit_event.2.into_val(&env);
@@ -2605,9 +2609,18 @@ fn batch_deduct_to_zero_succeeds() {
 
     let items = soroban_sdk::vec![
         &env,
-        DeductItem { amount: 200, request_id: None },
-        DeductItem { amount: 200, request_id: None },
-        DeductItem { amount: 200, request_id: None },
+        DeductItem {
+            amount: 200,
+            request_id: None
+        },
+        DeductItem {
+            amount: 200,
+            request_id: None
+        },
+        DeductItem {
+            amount: 200,
+            request_id: None
+        },
     ];
     assert_eq!(client.batch_deduct(&owner, &items), 0);
 }
@@ -2970,7 +2983,8 @@ fn is_paused_safe_default_before_init() {
 }
 
 #[test]
-fn deduct_while_paused_succeeds() {
+#[should_panic(expected = "vault is paused")]
+fn deduct_while_paused_fails() {
     let env = Env::default();
     let owner = Address::generate(&env);
     let (vault_address, client) = create_vault(&env);
@@ -2979,12 +2993,12 @@ fn deduct_while_paused_succeeds() {
     fund_vault(&usdc_admin, &vault_address, 500);
     client.init(&owner, &usdc, &Some(500), &None, &None, &None, &None);
     client.pause(&owner);
-    let remaining = client.deduct(&owner, &100, &None);
-    assert_eq!(remaining, 400);
+    client.deduct(&owner, &100, &None); // must panic with "vault is paused"
 }
 
 #[test]
-fn batch_deduct_while_paused_succeeds() {
+#[should_panic(expected = "vault is paused")]
+fn batch_deduct_while_paused_fails() {
     let env = Env::default();
     let owner = Address::generate(&env);
     let (vault_address, client) = create_vault(&env);
@@ -3000,7 +3014,7 @@ fn batch_deduct_while_paused_succeeds() {
             request_id: None,
         },
     ];
-    client.batch_deduct(&owner, &items);
+    client.batch_deduct(&owner, &items); // must panic with "vault is paused"
 }
 
 #[test]
@@ -3328,7 +3342,7 @@ mod fuzz {
         let (usdc_addr, usdc_client, usdc_admin) = create_usdc(&env, &owner);
         let (vault_addr, client) = create_vault(&env);
 
-        let settlement = Address::generate(&env);
+        let _settlement = Address::generate(&env);
         // Pre-fund vault so initial_balance is valid.
         usdc_admin.mint(&vault_addr, &initial);
         client.init(
@@ -3348,7 +3362,7 @@ mod fuzz {
 
         // Keep random steps realistic even when max_deduct is astronomically large.
         // (We still exercise max_deduct boundaries in dedicated unit tests.)
-        let step_cap: i128 = core::cmp::min(max_deduct_val, 10_000);
+        let _step_cap: i128 = core::cmp::min(max_deduct_val, 10_000);
 
         let mut rng = StdRng::seed_from_u64(seed);
         let mut sim: i128 = initial;
@@ -3382,7 +3396,6 @@ mod fuzz {
                     // else: deposit failed (e.g. insufficient USDC) — no sim change
                 }
                 // --- single deduct ---
-                // --- single deduct ---
                 1 => {
                     let amount: i128 = rng.gen_range(1..=max_deduct_val);
                     if paused {
@@ -3392,11 +3405,8 @@ mod fuzz {
                         sim -= amount;
                         client.deduct(&caller, &amount, &None);
                     } else {
-                        // must fail — balance unchanged (paused or insufficient)
+                        // must fail — balance unchanged (insufficient)
                         assert!(client.try_deduct(&caller, &amount, &None).is_err());
-                    } else {
-                        sim -= amount;
-                        client.deduct(&caller, &amount, &None);
                     }
                 }
 

--- a/contracts/vault/src/test.rs
+++ b/contracts/vault/src/test.rs
@@ -450,7 +450,11 @@ fn owner_deposit_increases_balance_and_emits_event() {
         })
         .expect("expected deposit event");
 
-    assert_eq!(deposit_event.1.len(), 2, "topics must have exactly 2 entries");
+    assert_eq!(
+        deposit_event.1.len(),
+        2,
+        "topics must have exactly 2 entries"
+    );
     let topic0: Symbol = deposit_event.1.get(0).unwrap().into_val(&env);
     assert_eq!(topic0, Symbol::new(&env, "deposit"));
     let topic1: Address = deposit_event.1.get(1).unwrap().into_val(&env);


### PR DESCRIPTION
## Summary

Resolves the duplicated `init` definition in the vault contract and reconciles all related signatures, storage keys, and tests to match the documented spec.

## Changes

### `contracts/vault/src/lib.rs`
- Replace all `StorageKey::MetaKey` with `StorageKey::Meta` (5 sites) — `MetaKey` variant does not exist in the enum; this was the root compile-breaking bug
- Restore `get_max_deduct` as a private internal helper; it was accidentally removed when deduplicating the entrypoint declarations, but is still called by `deduct()` and `batch_deduct()`
- Add `require_not_paused` guard to `deduct()` — `deposit` and `batch_deduct` both had it; `deduct` was missing it
- Remove duplicate `require_not_paused` call from `batch_deduct()` (was called twice)
- Fix `deposit` event to emit `caller` as `topic1` per `EVENT_SCHEMA.md` (was emitting only 1 topic; schema specifies 2)

### `contracts/vault/src/test.rs`
- Flip `deduct_while_paused_succeeds` → `deduct_while_paused_fails` with `#[should_panic(expected = "vault is paused")]`
- Flip `batch_deduct_while_paused_succeeds` → `batch_deduct_while_paused_fails` with `#[should_panic(expected = "vault is paused")]`
- Fix duplicate `} else {` syntax error in property-based fuzz test
- Update `deposit_event_schema_alignment` and `owner_deposit_increases_balance_and_emits_event` to assert 2 topics and verify `topic1` is the depositor address
- Prefix unused variables `_settlement`, `_step_cap` (clippy `-D warnings` clean)

### `README.md`
- Reconcile `init` signature to include the `initial_balance` parameter with description

### `SECURITY.md`
- Tick `[x]` on init-guard checklist items
- Clarify `get_max_deduct` note: retained as private helper, not removed

## Test Results

Closes CalloraOrg/Callora-Contracts#243
