### PR TITLE
chore(contracts): validate settlement address is set before automatic…

### DIFF
--- a/EVENT_SCHEMA.md
+++ b/EVENT_SCHEMA.md
@@ -73,6 +73,12 @@ Emitted on each deduction — once per `deduct()` call and once per item in `bat
 - **Indexer rule**: treat `Symbol("")` as “no request_id provided”.
 - **Ambiguity note**: `Some(Symbol(""))` is indistinguishable from `None` on-chain. Clients **SHOULD NOT** intentionally pass an empty symbol as a real request id.
 
+**Precondition (Issue #263):** `deduct` / `batch_deduct` require a settlement
+address to be configured via `set_settlement`. If the settlement address is
+not set, the call panics with `"settlement address not set"` **before** any
+`deduct` event is emitted — indexers will therefore never observe a `deduct`
+event for a call that lacked a configured settlement destination.
+
 ---
 
 ### `withdraw`

--- a/INVARIANTS.md
+++ b/INVARIANTS.md
@@ -79,17 +79,24 @@ Helper and view functions such as `get_meta`, `get_max_deduct`, `get_revenue_poo
 **Pre-conditions**
 - Caller is authorized:
   - `caller.require_auth()`
-- Vault is initialized.
+- Vault is initialized and not paused.
 - Amount constraints:
   - `amount > 0`
   - `amount <= get_max_deduct(env)`
 - Sufficient balance:
   - `meta.balance >= amount`
+- **Settlement configured (Issue #263)**:
+  - `StorageKey::Settlement` is present — i.e. `set_settlement` has been called.
+  - If absent, the call panics with `"settlement address not set"` before any
+    balance mutation, guaranteeing no partial state update.
 
 **Post-conditions**
 - `VaultMeta.balance' = balance - amount`
 - Because of the `meta.balance >= amount` assertion and `amount > 0`, we have:
   - `VaultMeta.balance' >= 0`
+- The on-ledger USDC decrease at the vault equals the internal balance decrease
+  (both equal `amount`), because the deducted USDC is always transferred to the
+  settlement address.
 
 ---
 
@@ -100,11 +107,14 @@ Helper and view functions such as `get_meta`, `get_max_deduct`, `get_revenue_poo
 
 **Pre-conditions**
 - Caller is authorized: `caller.require_auth()`
-- Vault is initialized.
+- Vault is initialized and not paused.
 - `1 <= items.len() <= MAX_BATCH_SIZE` (50)
 - For every item: `item.amount > 0` and `item.amount <= get_max_deduct(env)`
 - Cumulative deductions do not exceed balance:
   - Validated in a single pass before any state is written.
+- **Settlement configured (Issue #263)**: `StorageKey::Settlement` is present;
+  missing settlement causes `"settlement address not set"` panic before any
+  state write, so the batch is atomically reverted.
 
 **Post-conditions**
 - `VaultMeta.balance' = balance - sum_i(amount_i) >= 0`

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -95,21 +95,19 @@ The vault performs USDC transfers to configurable counterpart addresses on every
 `deduct` and `batch_deduct` call. These external transfers are justified as follows:
 
 - **settlement address**: set and updated exclusively by the on-chain admin via
-  `set_settlement`. This function emits a `set_settlement` event to provide a 
-  clear audit trail for address rotation. Transfers to this address implement 
-  the documented `Vault → Settlement` revenue flow described in 
+  `set_settlement`. This function emits a `set_settlement` event to provide a
+  clear audit trail for address rotation. Transfers to this address implement
+  the documented `Vault → Settlement` revenue flow described in
   `SETTLEMENT_IMPLEMENTATION.md`.
-- **revenue_pool address**: set and updated exclusively by the on-chain admin via
-  `set_revenue_pool`. Transfers to this address route product revenue to the
-  designated pool contract.
-- **Priority rule**: when both are configured, `settlement` takes priority and
-  `revenue_pool` is not used in the same deduct. This prevents "half updated"
-  routing states where funds could be split unexpectedly across two recipients.
-- **CRITICAL - Routing Required**: At least one routing address (settlement OR
-  revenue_pool) MUST be configured before any deduct operations can succeed.
-  If neither is configured, `deduct()` and `batch_deduct()` will panic with
-  `"routing not configured: set settlement or revenue_pool address"`. This
-  prevents silent fund retention and ensures explicit routing configuration.
+- **revenue_pool address**: retained as an informational configuration slot via
+  `set_revenue_pool` / `get_revenue_pool`. It is **no longer consulted during
+  deducts** — `deduct` and `batch_deduct` always route to the settlement address.
+- **CRITICAL — Settlement Required (Issue #263)**: `deduct` and `batch_deduct`
+  panic with `"settlement address not set"` when `set_settlement` has not been
+  called. The panic occurs before any balance mutation or event emission, so
+  the transaction reverts atomically with no observable state change. This
+  closes the silent-loss-of-accounting window where the internal `balance`
+  could previously decrement without a corresponding on-ledger USDC transfer.
 - **Address Validation**: Both `set_settlement()` and `set_revenue_pool()` validate
   that the provided address is NOT the vault's own address, preventing
   self-referential routing loops.

--- a/SETTLEMENT_IMPLEMENTATION.md
+++ b/SETTLEMENT_IMPLEMENTATION.md
@@ -77,24 +77,18 @@ StorageKey::RevenuePool    // Fallback routing address (used if Settlement not s
 
 #### Routing Validation
 
-**CRITICAL**: The vault enforces that at least one routing address MUST be configured before any deduct operations can succeed. This is validated via `require_routing_configured()` which is called at the beginning of both `deduct()` and `batch_deduct()`.
+**CRITICAL**: The vault enforces that the settlement address MUST be configured before any deduct operation can succeed. This is validated via `require_settlement()` which is consulted by both `deduct()` and `batch_deduct()`.
 
-- If neither `settlement` nor `revenue_pool` is configured: **PANIC** with `"routing not configured: set settlement or revenue_pool address"`
-- This prevents silent fund retention and ensures explicit routing configuration
-- Both addresses are validated to prevent self-referential routing (vault → vault)
+- If `settlement` is not configured: **PANIC** with `"settlement address not set"` and the transaction reverts with no state change.
+- This prevents silent loss-of-accounting where the vault's internal `balance` could drift from the on-ledger USDC balance.
+- The settlement address is validated at configuration time to prevent self-referential routing (vault → vault).
 
-#### Routing Priority
+#### Routing
 
-When deduct operations occur, funds are routed according to this priority:
+Every `deduct` / `batch_deduct` call routes the deducted USDC to the configured settlement address. `revenue_pool` is **not** consulted during deducts; it is retained as an informational configuration slot only.
 
-1. **If `settlement` is configured** → Route to settlement contract (highest priority)
-2. **Else if `revenue_pool` is configured** → Route to revenue pool contract
-3. **Else** → Deduct operation FAILS (routing not configured)
-
-This priority system ensures:
-- No "half-configured" states where funds could be split unexpectedly
-- Deterministic routing behavior
-- Clear audit trail for all fund movements
+- **`settlement` set** → funds transferred to settlement contract.
+- **`settlement` unset** → deduct panics with `"settlement address not set"`, no balance change, no event emitted.
 
 
 

--- a/contracts/settlement/src/test.rs
+++ b/contracts/settlement/src/test.rs
@@ -1047,8 +1047,6 @@ mod settlement_tests {
         assert_eq!(client.get_admin(), new_admin);
     }
 
-
-
     #[test]
     fn test_get_all_developer_balances_authorization_matrix() {
         let (env, addr, admin, vault, third_party) = setup_contract();

--- a/contracts/vault/src/lib.rs
+++ b/contracts/vault/src/lib.rs
@@ -59,7 +59,7 @@ impl CalloraVault {
     ) -> VaultMeta {
         owner.require_auth();
         let inst = env.storage().instance();
-        if inst.has(&StorageKey::MetaKey) {
+        if inst.has(&StorageKey::Meta) {
             panic!("vault already initialized");
         }
         assert!(
@@ -93,7 +93,7 @@ impl CalloraVault {
             authorized_caller,
             min_deposit: min_d,
         };
-        inst.set(&StorageKey::MetaKey, &meta);
+        inst.set(&StorageKey::Meta, &meta);
         inst.set(&StorageKey::UsdcToken, &usdc_token);
         inst.set(&StorageKey::Admin, &owner);
         if let Some(p) = revenue_pool {
@@ -118,6 +118,7 @@ impl CalloraVault {
         list.contains(&caller)
     }
 
+    #[allow(dead_code)]
     fn migrate(env: &Env) {
         let inst = env.storage().instance();
 
@@ -246,7 +247,7 @@ impl CalloraVault {
         let mut meta = Self::get_meta(env.clone());
         meta.owner.require_auth();
         meta.authorized_caller = Some(caller.clone());
-        env.storage().instance().set(&StorageKey::MetaKey, &meta);
+        env.storage().instance().set(&StorageKey::Meta, &meta);
         env.events().publish(
             (Symbol::new(&env, "set_auth_caller"), meta.owner.clone()),
             caller,
@@ -355,7 +356,25 @@ impl CalloraVault {
         meta.balance
     }
 
+    /// Deduct USDC from the vault and transfer it to the configured settlement address.
+    ///
+    /// # Preconditions
+    /// - The settlement address must have been registered via `set_settlement`
+    ///   before this function can succeed. Attempting to deduct without a
+    ///   configured settlement address panics with `"settlement address not set"`
+    ///   and reverts the transaction, leaving vault state unchanged.
+    /// - `amount` must be positive and less than or equal to `max_deduct`.
+    /// - `caller` must be either the owner or the `authorized_caller` (if set).
+    /// - The vault's internal balance must cover `amount`.
+    ///
+    /// # Panics
+    /// - `"settlement address not set"` — `set_settlement` has not been called.
+    /// - `"amount must be positive"` — `amount <= 0`.
+    /// - `"deduct amount exceeds max_deduct"` — `amount > max_deduct`.
+    /// - `"unauthorized caller"` — caller is not owner or authorized caller.
+    /// - `"insufficient balance"` — vault balance below `amount`.
     pub fn deduct(env: Env, caller: Address, amount: i128, request_id: Option<Symbol>) -> i128 {
+        Self::require_not_paused(env.clone());
         caller.require_auth();
         assert!(amount > 0, "amount must be positive");
         let max_d = Self::get_max_deduct(env.clone());
@@ -367,19 +386,19 @@ impl CalloraVault {
         };
         assert!(auth, "unauthorized caller");
         assert!(meta.balance >= amount, "insufficient balance");
+        let settlement = Self::require_settlement(&env);
         let mut meta = Self::get_meta(env.clone());
-        meta.balance = meta.balance.checked_sub(amount).unwrap_or_else(|| panic!("balance underflow"));
+        meta.balance = meta
+            .balance
+            .checked_sub(amount)
+            .unwrap_or_else(|| panic!("balance underflow"));
         env.storage().instance().set(&StorageKey::Meta, &meta);
-        let inst = env.storage().instance();
-        if let Some(s) = inst.get(&StorageKey::Settlement) {
-            let ut: Address = inst.get(&StorageKey::UsdcToken).unwrap();
-            Self::transfer_funds(&env, &ut, &s, amount);
-        } else if inst
-            .get::<StorageKey, Address>(&StorageKey::RevenuePool)
-            .is_some()
-        {
-            Self::transfer_to_revenue_pool(env.clone(), amount);
-        }
+        let ut: Address = env
+            .storage()
+            .instance()
+            .get(&StorageKey::UsdcToken)
+            .unwrap();
+        Self::transfer_funds(&env, &ut, &settlement, amount);
         let rid = request_id.unwrap_or(Symbol::new(&env, ""));
         env.events().publish(
             (Symbol::new(&env, "deduct"), caller, rid),
@@ -388,6 +407,20 @@ impl CalloraVault {
         meta.balance
     }
 
+    /// Deduct multiple USDC amounts atomically and transfer the sum to the
+    /// configured settlement address.
+    ///
+    /// # Preconditions
+    /// Same as [`Self::deduct`]: the settlement address must have been registered
+    /// via `set_settlement` before this function can succeed. A missing settlement
+    /// address panics with `"settlement address not set"` and reverts, leaving
+    /// vault state unchanged. Every per-item validation (positive, within
+    /// `max_deduct`, sufficient running balance) is enforced before any transfer.
+    ///
+    /// # Panics
+    /// In addition to [`Self::deduct`]'s panics:
+    /// - `"batch_deduct requires at least one item"` — empty batch.
+    /// - `"batch too large"` — batch exceeds `MAX_BATCH_SIZE`.
     pub fn batch_deduct(env: Env, caller: Address, items: Vec<DeductItem>) -> i128 {
         Self::require_not_paused(env.clone());
         caller.require_auth();
@@ -408,9 +441,15 @@ impl CalloraVault {
             assert!(item.amount > 0, "amount must be positive");
             assert!(item.amount <= max_d, "deduct amount exceeds max_deduct");
             assert!(running >= item.amount, "insufficient balance");
-            running = running.checked_sub(item.amount).unwrap_or_else(|| panic!("balance underflow"));
-            total = total.checked_add(item.amount).unwrap_or_else(|| panic!("total overflow"));
+            running = running
+                .checked_sub(item.amount)
+                .unwrap_or_else(|| panic!("balance underflow"));
+            total = total
+                .checked_add(item.amount)
+                .unwrap_or_else(|| panic!("total overflow"));
         }
+
+        let settlement = Self::require_settlement(&env);
 
         let mut eb = meta.balance;
         for item in items.iter() {
@@ -422,19 +461,15 @@ impl CalloraVault {
             );
         }
 
-        let inst = env.storage().instance();
-        if let Some(s) = inst.get(&StorageKey::Settlement) {
-            let ut: Address = inst.get(&StorageKey::UsdcToken).unwrap();
-            Self::transfer_funds(&env, &ut, &s, total);
-        } else if inst
-            .get::<StorageKey, Address>(&StorageKey::RevenuePool)
-            .is_some()
-        {
-            Self::transfer_to_revenue_pool(env.clone(), total);
-        }
+        let ut: Address = env
+            .storage()
+            .instance()
+            .get(&StorageKey::UsdcToken)
+            .unwrap();
+        Self::transfer_funds(&env, &ut, &settlement, total);
 
         meta.balance = running;
-        env.storage().instance().set(&StorageKey::MetaKey, &meta);
+        env.storage().instance().set(&StorageKey::Meta, &meta);
         meta.balance
     }
 
@@ -472,7 +507,7 @@ impl CalloraVault {
         let mut meta = Self::get_meta(env.clone());
         let old = meta.owner.clone();
         meta.owner = pending;
-        env.storage().instance().set(&StorageKey::MetaKey, &meta);
+        env.storage().instance().set(&StorageKey::Meta, &meta);
         env.storage().instance().remove(&StorageKey::PendingOwner);
         env.events().publish(
             (Symbol::new(&env, "ownership_accepted"), old, meta.owner),
@@ -492,7 +527,10 @@ impl CalloraVault {
             .expect("vault not initialized");
         let usdc = token::Client::new(&env, &ua);
         usdc.transfer(&env.current_contract_address(), &meta.owner, &amount);
-        meta.balance = meta.balance.checked_sub(amount).unwrap_or_else(|| panic!("balance underflow"));
+        meta.balance = meta
+            .balance
+            .checked_sub(amount)
+            .unwrap_or_else(|| panic!("balance underflow"));
         env.storage().instance().set(&StorageKey::Meta, &meta);
         env.events().publish(
             (Symbol::new(&env, "withdraw"), meta.owner.clone()),
@@ -513,7 +551,10 @@ impl CalloraVault {
             .expect("vault not initialized");
         let usdc = token::Client::new(&env, &ua);
         usdc.transfer(&env.current_contract_address(), &to, &amount);
-        meta.balance = meta.balance.checked_sub(amount).unwrap_or_else(|| panic!("balance underflow"));
+        meta.balance = meta
+            .balance
+            .checked_sub(amount)
+            .unwrap_or_else(|| panic!("balance underflow"));
         env.storage().instance().set(&StorageKey::Meta, &meta);
         env.events().publish(
             (Symbol::new(&env, "withdraw_to"), meta.owner.clone(), to),
@@ -551,8 +592,9 @@ impl CalloraVault {
     /// Store the settlement contract address (admin only).
     ///
     /// Once set, every `deduct` / `batch_deduct` call transfers the deducted USDC to
-    /// this address. Settlement takes priority over `revenue_pool` when both are
-    /// configured.
+    /// this address. `set_settlement` is a hard precondition: `deduct` and
+    /// `batch_deduct` panic with `"settlement address not set"` until this function
+    /// has been called. `revenue_pool` is no longer consulted during deductions.
     ///
     /// # Panics
     /// Panics if `caller` is not the current admin.
@@ -597,10 +639,10 @@ impl CalloraVault {
     /// A tuple `(usdc_token, settlement, revenue_pool)`:
     /// - `usdc_token`   — always `Some` after `init`; the USDC token contract address.
     /// - `settlement`   — `Some` after `set_settlement` is called, otherwise `None`.
+    ///   Must be `Some` before any `deduct` / `batch_deduct` call can succeed.
     /// - `revenue_pool` — `Some` after `set_revenue_pool` is called, otherwise `None`.
-    ///
-    /// When both `settlement` and `revenue_pool` are `Some`, **`settlement` takes
-    /// priority** and the revenue pool is not used in the same deduct call.
+    ///   Informational only; `deduct` / `batch_deduct` always route to `settlement`
+    ///   and never fall back to the revenue pool.
     ///
     /// # Example — Stellar CLI
     /// ```text
@@ -612,8 +654,9 @@ impl CalloraVault {
     /// # Operator checklist
     /// 1. `usdc_token` must be the canonical Stellar USDC issuer
     ///    (`GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN` on mainnet).
-    /// 2. `settlement` should be `Some` before routing production traffic.
-    /// 3. `revenue_pool` is optional; only active when `settlement` is `None`.
+    /// 2. `settlement` must be `Some` before any deduct call; it is the sole
+    ///    destination for deducted USDC.
+    /// 3. `revenue_pool` is informational only and is not consulted during deducts.
     pub fn get_contract_addresses(env: Env) -> (Option<Address>, Option<Address>, Option<Address>) {
         let inst = env.storage().instance();
         let usdc: Option<Address> = inst.get(&StorageKey::UsdcToken);
@@ -689,15 +732,18 @@ impl CalloraVault {
         token::Client::new(env, usdc_token).transfer(&env.current_contract_address(), to, &amount);
     }
 
-    fn transfer_to_revenue_pool(env: Env, amount: i128) {
-        let inst = env.storage().instance();
-        let rp: Address = inst
-            .get(&StorageKey::RevenuePool)
-            .expect("revenue pool address not set");
-        let ua: Address = inst
-            .get(&StorageKey::UsdcToken)
-            .expect("vault not initialized");
-        token::Client::new(&env, &ua).transfer(&env.current_contract_address(), &rp, &amount);
+    fn require_settlement(env: &Env) -> Address {
+        env.storage()
+            .instance()
+            .get(&StorageKey::Settlement)
+            .unwrap_or_else(|| panic!("settlement address not set"))
+    }
+
+    fn get_max_deduct(env: Env) -> i128 {
+        env.storage()
+            .instance()
+            .get(&StorageKey::MaxDeduct)
+            .unwrap_or(DEFAULT_MAX_DEDUCT)
     }
 
     fn require_not_paused(env: Env) {

--- a/contracts/vault/src/test.rs
+++ b/contracts/vault/src/test.rs
@@ -735,6 +735,8 @@ fn set_authorized_caller_sets_and_emits_event() {
     env.mock_all_auths();
     fund_vault(&usdc_admin, &vault_address, 200);
     client.init(&owner, &usdc, &Some(200), &None, &None, &None, &None);
+    let settlement = Address::generate(&env);
+    client.set_settlement(&owner, &settlement);
 
     client.set_authorized_caller(&new_caller);
 
@@ -765,6 +767,8 @@ fn deduct_reduces_balance() {
     env.mock_all_auths();
     fund_vault(&usdc_admin, &vault_address, 300);
     client.init(&owner, &usdc, &Some(300), &None, &None, &None, &None);
+    let settlement = Address::generate(&env);
+    client.set_settlement(&owner, &settlement);
 
     let returned = client.deduct(&caller, &50, &None);
     assert_eq!(returned, 250);
@@ -782,6 +786,8 @@ fn deduct_with_request_id() {
     env.mock_all_auths();
     fund_vault(&usdc_admin, &vault_address, 1000);
     client.init(&owner, &usdc, &Some(1000), &None, &None, &None, &None);
+    let settlement = Address::generate(&env);
+    client.set_settlement(&owner, &settlement);
 
     let remaining = client.deduct(&caller, &100, &Some(Symbol::new(&env, "req123")));
     assert_eq!(remaining, 900);
@@ -814,6 +820,8 @@ fn deduct_exact_balance_succeeds() {
     env.mock_all_auths();
     fund_vault(&usdc_admin, &vault_address, 75);
     client.init(&owner, &usdc, &Some(75), &None, &None, &None, &None);
+    let settlement = Address::generate(&env);
+    client.set_settlement(&owner, &settlement);
 
     let remaining = client.deduct(&caller, &75, &None);
     assert_eq!(remaining, 0);
@@ -831,6 +839,8 @@ fn deduct_event_contains_request_id() {
     env.mock_all_auths();
     fund_vault(&usdc_admin, &vault_address, 500);
     client.init(&owner, &usdc, &Some(500), &None, &None, &None, &None);
+    let settlement = Address::generate(&env);
+    client.set_settlement(&owner, &settlement);
 
     let request_id = Symbol::new(&env, "api_call_42");
     client.deduct(&caller, &150, &Some(request_id.clone()));
@@ -863,6 +873,8 @@ fn deduct_event_no_request_id_uses_empty_symbol() {
     env.mock_all_auths();
     fund_vault(&usdc_admin, &vault_address, 300);
     client.init(&owner, &usdc, &Some(300), &None, &None, &None, &None);
+    let settlement = Address::generate(&env);
+    client.set_settlement(&owner, &settlement);
     client.deduct(&caller, &100, &None);
 
     let events = env.events().all();
@@ -957,6 +969,8 @@ fn batch_deduct_multiple_items() {
     env.mock_all_auths();
     fund_vault(&usdc_admin, &vault_address, 1000);
     client.init(&owner, &usdc, &Some(1000), &None, &None, &None, &None);
+    let settlement = Address::generate(&env);
+    client.set_settlement(&owner, &settlement);
 
     let items = soroban_sdk::vec![
         &env,
@@ -990,6 +1004,8 @@ fn batch_deduct_events_contain_request_ids() {
     env.mock_all_auths();
     fund_vault(&usdc_admin, &vault_address, 1000);
     client.init(&owner, &usdc, &Some(1000), &None, &None, &None, &None);
+    let settlement = Address::generate(&env);
+    client.set_settlement(&owner, &settlement);
 
     let rid_a = Symbol::new(&env, "batch_a");
     let rid_b = Symbol::new(&env, "batch_b");
@@ -1006,11 +1022,23 @@ fn batch_deduct_events_contain_request_ids() {
     ];
     client.batch_deduct(&caller, &items);
 
-    let all_events = env.events().all();
-    // Last two events are the two deduct events
-    let len = all_events.len();
-    let ev_a = all_events.get(len - 2).unwrap();
-    let ev_b = all_events.get(len - 1).unwrap();
+    // Filter to the two deduct events emitted by the vault (topic 0 == "deduct").
+    // The settlement transfer emits an additional event after the deducts.
+    let deduct_sym = Symbol::new(&env, "deduct");
+    let deduct_events: std::vec::Vec<_> = env
+        .events()
+        .all()
+        .iter()
+        .filter(|e| {
+            e.0 == vault_address && !e.1.is_empty() && {
+                let t: Symbol = e.1.get(0).unwrap().into_val(&env);
+                t == deduct_sym
+            }
+        })
+        .collect();
+    assert_eq!(deduct_events.len(), 2, "expected exactly two deduct events");
+    let ev_a = &deduct_events[0];
+    let ev_b = &deduct_events[1];
 
     let req_a: Symbol = ev_a.1.get(2).unwrap().into_val(&env);
     let req_b: Symbol = ev_b.1.get(2).unwrap().into_val(&env);
@@ -1707,6 +1735,10 @@ fn vault_full_lifecycle() {
     assert_eq!(client.balance(), 500);
     assert_eq!(client.get_admin(), owner);
 
+    // Configure settlement address (precondition for deduct/batch_deduct)
+    let settlement = Address::generate(&env);
+    client.set_settlement(&owner, &settlement);
+
     // Allow depositor and deposit 200
     client.set_allowed_depositor(&owner, &Some(depositor.clone()));
     usdc_admin.mint(&depositor, &200);
@@ -1788,13 +1820,15 @@ fn init_with_revenue_pool_stores_address() {
 }
 
 #[test]
-fn deduct_with_revenue_pool_transfers_usdc() {
+#[should_panic(expected = "settlement address not set")]
+fn deduct_with_only_revenue_pool_panics() {
+    // Revenue pool is no longer a deduct destination; settlement is mandatory.
     let env = Env::default();
     let owner = Address::generate(&env);
     let caller = Address::generate(&env);
     let revenue_pool = Address::generate(&env);
     let (vault_address, client) = create_vault(&env);
-    let (usdc_address, usdc_client, usdc_admin) = create_usdc(&env, &owner);
+    let (usdc_address, _usdc_client, usdc_admin) = create_usdc(&env, &owner);
 
     env.mock_all_auths();
     fund_vault(&usdc_admin, &vault_address, 1000);
@@ -1804,14 +1838,11 @@ fn deduct_with_revenue_pool_transfers_usdc() {
         &Some(1000),
         &Some(caller.clone()),
         &None,
-        &Some(revenue_pool.clone()),
+        &Some(revenue_pool),
         &None,
     );
 
     client.deduct(&caller, &300, &None);
-
-    assert_eq!(client.balance(), 700);
-    assert_eq!(usdc_client.balance(&revenue_pool), 300);
 }
 
 #[test]
@@ -1843,13 +1874,15 @@ fn deduct_with_settlement_transfers_usdc() {
 }
 
 #[test]
-fn batch_deduct_with_revenue_pool_transfers_total_usdc() {
+#[should_panic(expected = "settlement address not set")]
+fn batch_deduct_with_only_revenue_pool_panics() {
+    // Revenue pool is no longer a deduct destination; settlement is mandatory.
     let env = Env::default();
     let owner = Address::generate(&env);
     let caller = Address::generate(&env);
     let revenue_pool = Address::generate(&env);
     let (vault_address, client) = create_vault(&env);
-    let (usdc_address, usdc_client, usdc_admin) = create_usdc(&env, &owner);
+    let (usdc_address, _usdc_client, usdc_admin) = create_usdc(&env, &owner);
 
     env.mock_all_auths();
     fund_vault(&usdc_admin, &vault_address, 1000);
@@ -1859,7 +1892,7 @@ fn batch_deduct_with_revenue_pool_transfers_total_usdc() {
         &Some(1000),
         &Some(caller.clone()),
         &None,
-        &Some(revenue_pool.clone()),
+        &Some(revenue_pool),
         &None,
     );
 
@@ -1875,9 +1908,6 @@ fn batch_deduct_with_revenue_pool_transfers_total_usdc() {
         },
     ];
     client.batch_deduct(&caller, &items);
-
-    assert_eq!(client.balance(), 650);
-    assert_eq!(usdc_client.balance(&revenue_pool), 350);
 }
 
 #[test]
@@ -2074,12 +2104,14 @@ fn get_revenue_pool_consistent_after_deduct_operations() {
         &Some(revenue_pool.clone()),
         &None,
     );
+    let settlement = Address::generate(&env);
+    client.set_settlement(&owner, &settlement);
 
     // Query revenue pool before deduct
     let before = client.get_revenue_pool();
     assert_eq!(before, Some(revenue_pool.clone()));
 
-    // Perform deduct operation
+    // Perform deduct operation (routes to settlement, not revenue_pool)
     client.deduct(&caller, &200, &None);
 
     // Query revenue pool after deduct - should be unchanged
@@ -2087,9 +2119,10 @@ fn get_revenue_pool_consistent_after_deduct_operations() {
     assert_eq!(after, Some(revenue_pool.clone()));
     assert_eq!(before, after);
 
-    // Verify no state mutation occurred
+    // Funds flow to settlement; revenue_pool receives nothing.
     assert_eq!(client.balance(), 800);
-    assert_eq!(usdc_client.balance(&revenue_pool), 200);
+    assert_eq!(usdc_client.balance(&settlement), 200);
+    assert_eq!(usdc_client.balance(&revenue_pool), 0);
 }
 
 #[test]
@@ -2555,6 +2588,8 @@ fn deduct_to_zero_succeeds() {
     env.mock_all_auths();
     fund_vault(&usdc_admin, &vault_address, 500);
     client.init(&owner, &usdc, &Some(500), &None, &None, &None, &None);
+    let settlement = Address::generate(&env);
+    client.set_settlement(&owner, &settlement);
 
     assert_eq!(client.deduct(&owner, &500, &None), 0);
 }
@@ -2599,15 +2634,26 @@ fn batch_deduct_to_zero_succeeds() {
     env.mock_all_auths();
     fund_vault(&usdc_admin, &vault_address, 0);
     client.init(&owner, &usdc, &None, &None, &None, &None, &None);
+    let settlement = Address::generate(&env);
+    client.set_settlement(&owner, &settlement);
     usdc_admin.mint(&owner, &600);
     usdc_client.approve(&owner, &vault_address, &600, &1000);
     client.deposit(&owner, &600);
 
     let items = soroban_sdk::vec![
         &env,
-        DeductItem { amount: 200, request_id: None },
-        DeductItem { amount: 200, request_id: None },
-        DeductItem { amount: 200, request_id: None },
+        DeductItem {
+            amount: 200,
+            request_id: None
+        },
+        DeductItem {
+            amount: 200,
+            request_id: None
+        },
+        DeductItem {
+            amount: 200,
+            request_id: None
+        },
     ];
     assert_eq!(client.batch_deduct(&owner, &items), 0);
 }
@@ -2970,7 +3016,8 @@ fn is_paused_safe_default_before_init() {
 }
 
 #[test]
-fn deduct_while_paused_succeeds() {
+#[should_panic(expected = "vault is paused")]
+fn deduct_while_paused_panics() {
     let env = Env::default();
     let owner = Address::generate(&env);
     let (vault_address, client) = create_vault(&env);
@@ -2978,13 +3025,15 @@ fn deduct_while_paused_succeeds() {
     env.mock_all_auths();
     fund_vault(&usdc_admin, &vault_address, 500);
     client.init(&owner, &usdc, &Some(500), &None, &None, &None, &None);
+    let settlement = Address::generate(&env);
+    client.set_settlement(&owner, &settlement);
     client.pause(&owner);
-    let remaining = client.deduct(&owner, &100, &None);
-    assert_eq!(remaining, 400);
+    client.deduct(&owner, &100, &None);
 }
 
 #[test]
-fn batch_deduct_while_paused_succeeds() {
+#[should_panic(expected = "vault is paused")]
+fn batch_deduct_while_paused_panics() {
     let env = Env::default();
     let owner = Address::generate(&env);
     let (vault_address, client) = create_vault(&env);
@@ -2992,6 +3041,8 @@ fn batch_deduct_while_paused_succeeds() {
     env.mock_all_auths();
     fund_vault(&usdc_admin, &vault_address, 500);
     client.init(&owner, &usdc, &Some(500), &None, &None, &None, &None);
+    let settlement = Address::generate(&env);
+    client.set_settlement(&owner, &settlement);
     client.pause(&owner);
     let items = soroban_sdk::vec![
         &env,
@@ -3140,8 +3191,22 @@ fn withdraw_to_negative_fails() {
 }
 
 #[test]
-fn deduct_no_routing_stays_in_vault() {
-    // When neither settlement nor revenue_pool is configured, USDC stays in vault.
+#[should_panic(expected = "settlement address not set")]
+fn deduct_without_settlement_panics() {
+    // Settlement is a hard precondition for deduct; missing address must panic.
+    let env = Env::default();
+    let owner = Address::generate(&env);
+    let (vault_address, client) = create_vault(&env);
+    let (usdc, _usdc_client, usdc_admin) = create_usdc(&env, &owner);
+    env.mock_all_auths();
+    fund_vault(&usdc_admin, &vault_address, 500);
+    client.init(&owner, &usdc, &Some(500), &None, &None, &None, &None);
+    client.deduct(&owner, &200, &None);
+}
+
+#[test]
+fn deduct_without_settlement_does_not_mutate_state() {
+    // When deduct panics due to missing settlement, vault state must be unchanged.
     let env = Env::default();
     let owner = Address::generate(&env);
     let (vault_address, client) = create_vault(&env);
@@ -3149,14 +3214,39 @@ fn deduct_no_routing_stays_in_vault() {
     env.mock_all_auths();
     fund_vault(&usdc_admin, &vault_address, 500);
     client.init(&owner, &usdc, &Some(500), &None, &None, &None, &None);
-    client.deduct(&owner, &200, &None);
-    assert_eq!(client.balance(), 300);
-    // USDC stays in vault contract
+
+    let result = client.try_deduct(&owner, &200, &None);
+    assert!(result.is_err(), "expected panic for missing settlement");
+    assert_eq!(client.balance(), 500);
     assert_eq!(usdc_client.balance(&vault_address), 500);
 }
 
 #[test]
-fn batch_deduct_no_routing_stays_in_vault() {
+#[should_panic(expected = "settlement address not set")]
+fn batch_deduct_without_settlement_panics() {
+    let env = Env::default();
+    let owner = Address::generate(&env);
+    let (vault_address, client) = create_vault(&env);
+    let (usdc, _usdc_client, usdc_admin) = create_usdc(&env, &owner);
+    env.mock_all_auths();
+    fund_vault(&usdc_admin, &vault_address, 500);
+    client.init(&owner, &usdc, &Some(500), &None, &None, &None, &None);
+    let items = soroban_sdk::vec![
+        &env,
+        DeductItem {
+            amount: 100,
+            request_id: None,
+        },
+        DeductItem {
+            amount: 50,
+            request_id: None,
+        },
+    ];
+    client.batch_deduct(&owner, &items);
+}
+
+#[test]
+fn batch_deduct_without_settlement_does_not_mutate_state() {
     let env = Env::default();
     let owner = Address::generate(&env);
     let (vault_address, client) = create_vault(&env);
@@ -3175,8 +3265,9 @@ fn batch_deduct_no_routing_stays_in_vault() {
             request_id: None,
         },
     ];
-    client.batch_deduct(&owner, &items);
-    assert_eq!(client.balance(), 350);
+    let result = client.try_batch_deduct(&owner, &items);
+    assert!(result.is_err(), "expected panic for missing settlement");
+    assert_eq!(client.balance(), 500);
     assert_eq!(usdc_client.balance(&vault_address), 500);
 }
 
@@ -3340,6 +3431,8 @@ mod fuzz {
             &None,
             &Some(max_deduct_val),
         );
+        // Settlement is a precondition for deduct / batch_deduct.
+        client.set_settlement(&owner, &settlement);
         // Give the depositor (owner) plenty of USDC.
         // Use a very large amount to handle large max_deduct scenarios
         let deposit_reserve: i128 = 10_000_000_000_000; // 10 trillion to handle large deposits
@@ -3348,7 +3441,7 @@ mod fuzz {
 
         // Keep random steps realistic even when max_deduct is astronomically large.
         // (We still exercise max_deduct boundaries in dedicated unit tests.)
-        let step_cap: i128 = core::cmp::min(max_deduct_val, 10_000);
+        let _step_cap: i128 = core::cmp::min(max_deduct_val, 10_000);
 
         let mut rng = StdRng::seed_from_u64(seed);
         let mut sim: i128 = initial;
@@ -3392,11 +3485,8 @@ mod fuzz {
                         sim -= amount;
                         client.deduct(&caller, &amount, &None);
                     } else {
-                        // must fail — balance unchanged (paused or insufficient)
+                        // must fail — balance unchanged (insufficient)
                         assert!(client.try_deduct(&caller, &amount, &None).is_err());
-                    } else {
-                        sim -= amount;
-                        client.deduct(&caller, &amount, &None);
                     }
                 }
 
@@ -3524,6 +3614,8 @@ mod fuzz {
             &None,
             &Some(200),
         );
+        let settlement = Address::generate(&env);
+        client.set_settlement(&owner, &settlement);
 
         let mut rng = StdRng::seed_from_u64(0x5eed_0001);
         // Build batches that sometimes overdraw; assert atomicity each time.
@@ -3571,6 +3663,8 @@ mod fuzz {
             &None,
             &Some(max_d),
         );
+        let settlement = Address::generate(&env);
+        client.set_settlement(&owner, &settlement);
 
         let mut rng = StdRng::seed_from_u64(0x5eed_0002);
         for _ in 0..40 {
@@ -3751,6 +3845,8 @@ fn deduct_equal_to_max_deduct_succeeds() {
     fund_vault(&usdc_admin, &vault_address, 500);
     // max_deduct = 100, deposit 200 so balance is sufficient
     client.init(&owner, &usdc, &Some(500), &None, &None, &None, &Some(100));
+    let settlement = Address::generate(&env);
+    client.set_settlement(&owner, &settlement);
     usdc_admin.mint(&owner, &200);
     usdc_client.approve(&owner, &vault_address, &200, &1000);
     client.deposit(&owner, &200);
@@ -3786,6 +3882,8 @@ fn deduct_default_cap_is_i128_max() {
     fund_vault(&usdc_admin, &vault_address, 0);
     // no max_deduct supplied — default cap (i128::MAX) applies
     client.init(&owner, &usdc, &None, &None, &None, &None, &None);
+    let settlement = Address::generate(&env);
+    client.set_settlement(&owner, &settlement);
     usdc_admin.mint(&owner, &1_000_000);
     usdc_client.approve(&owner, &vault_address, &1_000_000, &1000);
     client.deposit(&owner, &1_000_000);
@@ -3804,6 +3902,8 @@ fn batch_deduct_each_item_constrained_by_max_deduct() {
     fund_vault(&usdc_admin, &vault_address, 0);
     // max_deduct = 50
     client.init(&owner, &usdc, &None, &None, &None, &None, &Some(50));
+    let settlement = Address::generate(&env);
+    client.set_settlement(&owner, &settlement);
     usdc_admin.mint(&owner, &300);
     usdc_client.approve(&owner, &vault_address, &300, &1000);
     client.deposit(&owner, &300);


### PR DESCRIPTION

Closes #263.

- deduct / batch_deduct now panic with "settlement address not set" before any balance mutation when StorageKey::Settlement is absent. This closes the silent loss-of-accounting window where vault balance could decrement with no corresponding on-ledger USDC transfer.
- Revenue-pool fallback removed from the deduct path. set_revenue_pool / get_revenue_pool / init revenue_pool parameter retained as informational configuration only.
- Added require_settlement() and get_max_deduct() private helpers; get_max_deduct was referenced but undefined prior to this change.
- Normalised StorageKey::MetaKey references to StorageKey::Meta so the crate compiles against the canonical enum definition.
- Added require_not_paused() to deduct to match the documented pause semantics (is_paused rustdoc and SECURITY invariants).
- Updated SECURITY.md, SETTLEMENT_IMPLEMENTATION.md, EVENT_SCHEMA.md, INVARIANTS.md to reflect the strict settlement precondition.