### PR TITLE
docs(vault): add rustdoc to get_max_deduct private helper

### DIFF
--- a/contracts/revenue_pool/src/lib.rs
+++ b/contracts/revenue_pool/src/lib.rs
@@ -315,7 +315,7 @@ impl RevenuePool {
         let mut total_amount: i128 = 0;
         for payment in payments.iter() {
             let (_, amount) = payment;
-            
+
             // Validate each amount is strictly positive
             if amount <= 0 {
                 panic!("{}", ERR_AMOUNT_NOT_POSITIVE);
@@ -346,7 +346,7 @@ impl RevenuePool {
             let (to, amount) = payment;
             Self::validate_recipient(&to, &contract_address);
             usdc.transfer(&contract_address, &to, &amount);
-            
+
             // Emit event for this leg of the batch
             env.events()
                 .publish((Symbol::new(&env, "batch_distribute"), to), amount);

--- a/contracts/vault/src/lib.rs
+++ b/contracts/vault/src/lib.rs
@@ -288,7 +288,10 @@ impl CalloraVault {
         meta.authorized_caller = Some(caller.clone());
         env.storage().instance().set(&StorageKey::Meta, &meta);
         env.events().publish(
-            (Symbol::new(&env, "set_authorized_caller"), meta.owner.clone()),
+            (
+                Symbol::new(&env, "set_authorized_caller"),
+                meta.owner.clone(),
+            ),
             (old_authorized_caller, caller),
         );
     }
@@ -311,6 +314,11 @@ impl CalloraVault {
             .publish((Symbol::new(&env, "vault_unpaused"), caller), ());
     }
 
+    /// Retrieve the configured maximum deduction amount for a single call.
+    ///
+    /// Returns the value stored in `StorageKey::MaxDeduct`, or `DEFAULT_MAX_DEDUCT`
+    /// if not explicitly configured during initialization. Used internally by `deduct`
+    /// and `batch_deduct` to enforce per-call deduction limits.
     fn get_max_deduct(env: Env) -> i128 {
         env.storage()
             .instance()

--- a/contracts/vault/src/test.rs
+++ b/contracts/vault/src/test.rs
@@ -1118,7 +1118,15 @@ fn deduct_reduces_balance() {
 
     env.mock_all_auths();
     fund_vault(&usdc_admin, &vault_address, 300);
-    client.init(&owner, &usdc, &Some(300), &Some(caller.clone()), &None, &None, &None);
+    client.init(
+        &owner,
+        &usdc,
+        &Some(300),
+        &Some(caller.clone()),
+        &None,
+        &None,
+        &None,
+    );
 
     let returned = client.deduct(&owner, &50, &None);
     assert_eq!(returned, 250);
@@ -1134,7 +1142,15 @@ fn deduct_with_request_id() {
 
     env.mock_all_auths();
     fund_vault(&usdc_admin, &vault_address, 1000);
-    client.init(&owner, &usdc, &Some(1000), &Some(caller.clone()), &None, &None, &None);
+    client.init(
+        &owner,
+        &usdc,
+        &Some(1000),
+        &Some(caller.clone()),
+        &None,
+        &None,
+        &None,
+    );
 
     let remaining = client.deduct(&owner, &100, &Some(Symbol::new(&env, "req123")));
     assert_eq!(remaining, 900);
@@ -1149,7 +1165,15 @@ fn deduct_insufficient_balance_fails() {
 
     env.mock_all_auths();
     fund_vault(&usdc_admin, &vault_address, 10);
-    client.init(&owner, &usdc, &Some(10), &Some(caller.clone()), &None, &None, &None);
+    client.init(
+        &owner,
+        &usdc,
+        &Some(10),
+        &Some(caller.clone()),
+        &None,
+        &None,
+        &None,
+    );
 
     let result = client.try_deduct(&owner, &100, &None);
     assert!(result.is_err(), "expected error for insufficient balance");
@@ -1164,7 +1188,15 @@ fn deduct_exact_balance_succeeds() {
 
     env.mock_all_auths();
     fund_vault(&usdc_admin, &vault_address, 75);
-    client.init(&owner, &usdc, &Some(75), &Some(caller.clone()), &None, &None, &None);
+    client.init(
+        &owner,
+        &usdc,
+        &Some(75),
+        &Some(caller.clone()),
+        &None,
+        &None,
+        &None,
+    );
 
     let remaining = client.deduct(&owner, &75, &None);
     assert_eq!(remaining, 0);
@@ -1180,7 +1212,15 @@ fn deduct_event_contains_request_id() {
 
     env.mock_all_auths();
     fund_vault(&usdc_admin, &vault_address, 500);
-    client.init(&owner, &usdc, &Some(500), &Some(caller.clone()), &None, &None, &None);
+    client.init(
+        &owner,
+        &usdc,
+        &Some(500),
+        &Some(caller.clone()),
+        &None,
+        &None,
+        &None,
+    );
 
     let request_id = Symbol::new(&env, "api_call_42");
     client.deduct(&owner, &150, &Some(request_id.clone()));
@@ -1274,7 +1314,15 @@ fn deduct_event_no_request_id_uses_empty_symbol() {
 
     env.mock_all_auths();
     fund_vault(&usdc_admin, &vault_address, 300);
-    client.init(&owner, &usdc, &Some(300), &Some(caller.clone()), &None, &None, &None);
+    client.init(
+        &owner,
+        &usdc,
+        &Some(300),
+        &Some(caller.clone()),
+        &None,
+        &None,
+        &None,
+    );
     client.deduct(&caller, &100, &None);
 
     let events = env.events().all();
@@ -1304,7 +1352,15 @@ fn deduct_zero_panics() {
 
     env.mock_all_auths();
     fund_vault(&usdc_admin, &vault_address, 500);
-    client.init(&owner, &usdc, &Some(500), &Some(caller.clone()), &None, &None, &None);
+    client.init(
+        &owner,
+        &usdc,
+        &Some(500),
+        &Some(caller.clone()),
+        &None,
+        &None,
+        &None,
+    );
     client.deduct(&caller, &0, &None);
 }
 
@@ -1319,7 +1375,15 @@ fn deduct_negative_panics() {
 
     env.mock_all_auths();
     fund_vault(&usdc_admin, &vault_address, 100);
-    client.init(&owner, &usdc, &Some(100), &Some(caller.clone()), &None, &None, &None);
+    client.init(
+        &owner,
+        &usdc,
+        &Some(100),
+        &Some(caller.clone()),
+        &None,
+        &None,
+        &None,
+    );
     client.deduct(&caller, &-50, &None);
 }
 
@@ -1333,7 +1397,15 @@ fn deduct_exceeds_balance_panics() {
 
     env.mock_all_auths();
     fund_vault(&usdc_admin, &vault_address, 50);
-    client.init(&owner, &usdc, &Some(50), &Some(caller.clone()), &None, &None, &None);
+    client.init(
+        &owner,
+        &usdc,
+        &Some(50),
+        &Some(caller.clone()),
+        &None,
+        &None,
+        &None,
+    );
     client.deduct(&caller, &100, &None);
 }
 
@@ -1346,7 +1418,15 @@ fn balance_unchanged_after_failed_deduct() {
 
     env.mock_all_auths();
     fund_vault(&usdc_admin, &vault_address, 100);
-    client.init(&owner, &usdc, &Some(100), &Some(caller.clone()), &None, &None, &None);
+    client.init(
+        &owner,
+        &usdc,
+        &Some(100),
+        &Some(caller.clone()),
+        &None,
+        &None,
+        &None,
+    );
 
     let _ = client.try_deduct(&owner, &200, &None);
     assert_eq!(client.balance(), 100);
@@ -1366,7 +1446,15 @@ fn batch_deduct_multiple_items() {
 
     env.mock_all_auths();
     fund_vault(&usdc_admin, &vault_address, 1000);
-    client.init(&owner, &usdc, &Some(1000), &Some(caller.clone()), &None, &None, &None);
+    client.init(
+        &owner,
+        &usdc,
+        &Some(1000),
+        &Some(caller.clone()),
+        &None,
+        &None,
+        &None,
+    );
 
     let items = soroban_sdk::vec![
         &env,
@@ -1399,7 +1487,15 @@ fn batch_deduct_events_contain_request_ids() {
 
     env.mock_all_auths();
     fund_vault(&usdc_admin, &vault_address, 1000);
-    client.init(&owner, &usdc, &Some(1000), &Some(caller.clone()), &None, &None, &None);
+    client.init(
+        &owner,
+        &usdc,
+        &Some(1000),
+        &Some(caller.clone()),
+        &None,
+        &None,
+        &None,
+    );
 
     let rid_a = Symbol::new(&env, "batch_a");
     let rid_b = Symbol::new(&env, "batch_b");
@@ -1455,7 +1551,15 @@ fn batch_deduct_insufficient_balance_fails() {
 
     env.mock_all_auths();
     fund_vault(&usdc_admin, &vault_address, 100);
-    client.init(&owner, &usdc, &Some(100), &Some(caller.clone()), &None, &None, &None);
+    client.init(
+        &owner,
+        &usdc,
+        &Some(100),
+        &Some(caller.clone()),
+        &None,
+        &None,
+        &None,
+    );
 
     let items = soroban_sdk::vec![
         &env,
@@ -1485,7 +1589,15 @@ fn batch_deduct_empty_fails() {
 
     env.mock_all_auths();
     fund_vault(&usdc_admin, &vault_address, 100);
-    client.init(&owner, &usdc, &Some(100), &Some(caller.clone()), &None, &None, &None);
+    client.init(
+        &owner,
+        &usdc,
+        &Some(100),
+        &Some(caller.clone()),
+        &None,
+        &None,
+        &None,
+    );
 
     let items: soroban_sdk::Vec<DeductItem> = soroban_sdk::vec![&env];
     let result = client.try_batch_deduct(&caller, &items);
@@ -1502,7 +1614,15 @@ fn batch_deduct_zero_amount_fails() {
 
     env.mock_all_auths();
     fund_vault(&usdc_admin, &vault_address, 100);
-    client.init(&owner, &usdc, &Some(100), &Some(caller.clone()), &None, &None, &None);
+    client.init(
+        &owner,
+        &usdc,
+        &Some(100),
+        &Some(caller.clone()),
+        &None,
+        &None,
+        &None,
+    );
 
     let items = soroban_sdk::vec![
         &env,
@@ -3931,7 +4051,9 @@ mod fuzz {
                     if paused {
                         // deposit must fail while paused
                         assert!(client.try_deposit(&owner, &amount).is_err());
-                    } else if let (Some(new_sim), Some(new_token_sim)) = (sim.checked_add(amount), token_sim.checked_add(amount)) {
+                    } else if let (Some(new_sim), Some(new_token_sim)) =
+                        (sim.checked_add(amount), token_sim.checked_add(amount))
+                    {
                         // mint amount to owner to avoid insufficient balance on large fuzz tests
                         usdc_admin.mint(&owner, &amount);
                         sim = new_sim;


### PR DESCRIPTION
Closes #243

## Summary
Improves code maintainability by adding missing documentation to the `get_max_deduct` private helper that was restored as part of issue #243.

## Changes
- Added rustdoc comment to `get_max_deduct` explaining its purpose, storage key, default behavior, and internal usage
- No logic changes; purely documentation

## Testing
- `cargo fmt --all` ✓
- `cargo clippy --all-targets --all-features -- -D warnings` ✓
- `cargo test -p callora-vault` ✓