### PR TITLE
feat(revenue-pool): add max distribution cap with admin control and r…

### DIFF
--- a/EVENT_SCHEMA.md
+++ b/EVENT_SCHEMA.md
@@ -583,6 +583,25 @@ Emitted when the admin distributes USDC to a single developer.
 
 ---
 
+### `set_max_distribute`
+
+Emitted when the admin updates the per-leg distribution cap.
+
+| Index   | Location | Type    | Description                    |
+|---------|----------|---------|--------------------------------|
+| topic 0 | topics   | Symbol  | `"set_max_distribute"`        |
+| topic 1 | topics   | Address | admin address                  |
+| data    | data     | (i128, i128) | `(old_max, new_max)`       |
+
+```json
+{
+  "topics": ["set_max_distribute", "GADMIN..."],
+  "data": [9223372036854775807, 500]
+}
+```
+
+---
+
 ### `batch_distribute`
 
 Emitted **once per payment** during a `batch_distribute()` call. If a batch has
@@ -774,6 +793,7 @@ after the matching `payment_received` event.
 | `init`                   | revenue-pool    | `init()`                                 |
 | `admin_changed`          | revenue-pool    | `set_admin()`                            |
 | `admin_transfer_started` | revenue-pool    | `set_admin()`                            |
+| `set_max_distribute`     | revenue-pool    | `set_max_distribute()`                   |
 | `admin_transfer_completed`| revenue-pool   | `claim_admin()`                          |
 | `receive_payment`        | revenue-pool    | `receive_payment()`                      |
 | `distribute`             | revenue-pool    | `distribute()`                           |

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -156,6 +156,9 @@ The Revenue Pool contract (`contracts/revenue_pool`) operates under the followin
 - **Resource Exhaustion via Unbounded Batch:** `batch_distribute` accepts a `Vec<(Address, i128)>`. Without a cap, a compromised admin key could submit thousands of entries, exhausting Soroban's per-transaction CPU/memory budget and causing unpredictable mid-execution failures.
   - *Mitigation:* `batch_distribute` enforces `1 <= payments.len() <= MAX_BATCH_SIZE` (currently **50**), matching the vault's `batch_deduct` cap. Empty vectors and oversized vectors are rejected before any iteration or USDC transfer occurs. The cap keeps resource consumption well within Soroban network limits.
 
+- **Excessive Single-Leg Distribution:** A compromised admin could still try to distribute a huge amount in a single `distribute()` or individual `batch_distribute` leg, increasing the blast radius for a compromised admin key.
+  - *Mitigation:* `callora-revenue-pool` now exposes a configurable `max_distribute` cap. Every `distribute` and every individual `batch_distribute` payment leg is validated against this cap. The cap is admin-gated, must be positive, and defaults to `i128::MAX` until configured.
+
 ### Input Validation
 
 - [ ] All amounts validated to be > 0

--- a/contracts/revenue_pool/src/lib.rs
+++ b/contracts/revenue_pool/src/lib.rs
@@ -16,10 +16,14 @@ use soroban_sdk::{contract, contractimpl, token, Address, Env, Symbol, Vec};
 const ADMIN_KEY: &str = "admin";
 const PENDING_ADMIN_KEY: &str = "pending_admin";
 const USDC_KEY: &str = "usdc";
+const MAX_DISTRIBUTE_KEY: &str = "max_distribute";
 const ERR_AMOUNT_NOT_POSITIVE: &str = "amount must be positive";
+const ERR_AMOUNT_EXCEEDS_MAX_DISTRIBUTE: &str = "amount exceeds max_distribute";
 const ERR_UNAUTHORIZED: &str = "unauthorized: caller is not admin";
 const ERR_INSUFFICIENT_BALANCE: &str = "insufficient USDC balance";
 const ERR_NOT_INITIALIZED: &str = "revenue pool not initialized";
+
+pub const DEFAULT_MAX_DISTRIBUTE: i128 = i128::MAX;
 
 /// Maximum number of payments allowed in a single `batch_distribute` call.
 /// Caps CPU/memory usage well within Soroban resource limits and aligns with
@@ -196,6 +200,37 @@ impl RevenuePool {
         );
     }
 
+    /// Get the current per-leg distribution cap.
+    /// Defaults to `i128::MAX` when unset.
+    pub fn get_max_distribute(env: Env) -> i128 {
+        env.storage()
+            .instance()
+            .get(&Symbol::new(&env, MAX_DISTRIBUTE_KEY))
+            .unwrap_or(DEFAULT_MAX_DISTRIBUTE)
+    }
+
+    /// Set the maximum amount that may be distributed in a single `distribute`
+    /// call or as an individual payment leg in `batch_distribute`.
+    ///
+    /// Only the current admin may call this. `max_distribute` must be positive.
+    /// Emits `set_max_distribute` with `(old_max, new_max)`.
+    pub fn set_max_distribute(env: Env, caller: Address, max_distribute: i128) {
+        caller.require_auth();
+        let admin = Self::get_admin(env.clone());
+        if caller != admin {
+            panic!("unauthorized: caller is not admin");
+        }
+        assert!(max_distribute > 0, "max_distribute must be positive");
+        let old_max = Self::get_max_distribute(env.clone());
+        env.storage()
+            .instance()
+            .set(&Symbol::new(&env, MAX_DISTRIBUTE_KEY), &max_distribute);
+        env.events().publish(
+            (Symbol::new(&env, "set_max_distribute"), admin),
+            (old_max, max_distribute),
+        );
+    }
+
     fn validate_recipient(recipient: &Address, contract_self: &Address) {
         // Rule 1 — no self-distributions (the contract sending to itself is almost
         // certainly a logic bug; if you want to "reclaim" funds use a dedicated fn).
@@ -230,6 +265,10 @@ impl RevenuePool {
         }
         if amount <= 0 {
             panic!("{}", ERR_AMOUNT_NOT_POSITIVE);
+        }
+        let max_distribute = Self::get_max_distribute(env.clone());
+        if amount > max_distribute {
+            panic!("{}", ERR_AMOUNT_EXCEEDS_MAX_DISTRIBUTE);
         }
 
         let usdc_address: Address = env
@@ -320,6 +359,7 @@ impl RevenuePool {
             panic!("batch too large");
         }
 
+        let max_distribute = Self::get_max_distribute(env.clone());
         let mut total_amount: i128 = 0;
         for payment in payments.iter() {
             let (_, amount) = payment;
@@ -327,6 +367,9 @@ impl RevenuePool {
             // Validate each amount is strictly positive
             if amount <= 0 {
                 panic!("{}", ERR_AMOUNT_NOT_POSITIVE);
+            }
+            if *amount > max_distribute {
+                panic!("{}", ERR_AMOUNT_EXCEEDS_MAX_DISTRIBUTE);
             }
             total_amount = total_amount
                 .checked_add(amount)

--- a/contracts/revenue_pool/src/test.rs
+++ b/contracts/revenue_pool/src/test.rs
@@ -172,6 +172,106 @@ fn create_usdc<'a>(
     }
 
     #[test]
+    fn get_max_distribute_returns_default_when_not_set() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let admin = Address::generate(&env);
+        let (_, client) = create_pool(&env);
+        let (usdc_address, _, _) = create_usdc(&env, &admin);
+
+        client.init(&admin, &usdc_address);
+
+        assert_eq!(client.get_max_distribute(), i128::MAX);
+    }
+
+    #[test]
+    fn set_max_distribute_updates_cap_and_emits_event() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let admin = Address::generate(&env);
+        let (_, client) = create_pool(&env);
+        let (usdc_address, _, _) = create_usdc(&env, &admin);
+
+        client.init(&admin, &usdc_address);
+        client.set_max_distribute(&admin, &500);
+
+        assert_eq!(client.get_max_distribute(), 500);
+
+        let events = env.events().all();
+        let ev = events.last().unwrap();
+        let t0 = Symbol::try_from_val(&env, &ev.1.get(0).unwrap()).unwrap();
+        assert_eq!(t0, Symbol::new(&env, "set_max_distribute"));
+
+        let data: (i128, i128) = ev.2.into_val(&env);
+        assert_eq!(data, (i128::MAX, 500));
+    }
+
+    #[test]
+    #[should_panic(expected = "unauthorized: caller is not admin")]
+    fn set_max_distribute_unauthorized_panics() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let admin = Address::generate(&env);
+        let attacker = Address::generate(&env);
+        let (_, client) = create_pool(&env);
+        let (usdc_address, _, _) = create_usdc(&env, &admin);
+
+        client.init(&admin, &usdc_address);
+        client.set_max_distribute(&attacker, &500);
+    }
+
+    #[test]
+    #[should_panic(expected = "max_distribute must be positive")]
+    fn set_max_distribute_zero_panics() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let admin = Address::generate(&env);
+        let (_, client) = create_pool(&env);
+        let (usdc_address, _, _) = create_usdc(&env, &admin);
+
+        client.init(&admin, &usdc_address);
+        client.set_max_distribute(&admin, &0);
+    }
+
+    #[test]
+    #[should_panic(expected = "amount exceeds max_distribute")]
+    fn distribute_above_max_distribute_panics() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let admin = Address::generate(&env);
+        let developer = Address::generate(&env);
+        let (pool_addr, client) = create_pool(&env);
+        let (usdc_address, _, usdc_admin) = create_usdc(&env, &admin);
+
+        client.init(&admin, &usdc_address);
+        fund_pool(&usdc_admin, &pool_addr, 500);
+        client.set_max_distribute(&admin, &100);
+        client.distribute(&admin, &developer, &101);
+    }
+
+    #[test]
+    #[should_panic(expected = "amount exceeds max_distribute")]
+    fn batch_distribute_leg_above_max_distribute_panics() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let admin = Address::generate(&env);
+        let dev1 = Address::generate(&env);
+        let dev2 = Address::generate(&env);
+        let (pool_addr, client) = create_pool(&env);
+        let (usdc_address, _, usdc_admin) = create_usdc(&env, &admin);
+
+        client.init(&admin, &usdc_address);
+        fund_pool(&usdc_admin, &pool_addr, 1000);
+        client.set_max_distribute(&admin, &50);
+
+        let mut payments: Vec<(Address, i128)> = Vec::new(&env);
+        payments.push_back((dev1.clone(), 50_i128));
+        payments.push_back((dev2.clone(), 51_i128));
+
+        client.batch_distribute(&admin, &payments);
+    }
+
+    #[test]
     fn set_admin_two_step_transfers_control() {
         let env = Env::default();
         env.mock_all_auths();


### PR DESCRIPTION
closes #360 


Title
feat: add configurable per-leg distribution cap to callora-revenue-pool

Description
This PR introduces a configurable [max_distribute](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) cap to the callora-revenue-pool contract.

What changed

Added [get_max_distribute()](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) view returning [i128::MAX](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) by default.
Added admin-only [set_max_distribute(caller, max_distribute)](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) setter.
Enforced [max_distribute](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) in [distribute()](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) for single transfers.
Enforced [max_distribute](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) per-leg in [batch_distribute()](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html).
Added [set_max_distribute](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) event with [(old_max, new_max)](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html).
Security / behavior

Default behavior remains unbounded until the admin configures a cap.
Prevents a compromised admin from executing excessively large single transfers.
Complements existing [batch_distribute](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) size limits and hardens blast radius.
Tests added

default [get_max_distribute()](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) value
setter updates stored cap
setter emits [set_max_distribute](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) event
unauthorized setter call fails
zero cap setter fails
[distribute()](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) over-cap fails
[batch_distribute()](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) per-leg over-cap fails
Docs updated

[SECURITY.md](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) with new cap mitigation details
[EVENT_SCHEMA.md](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) with [set_max_distribute](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) event definition and quick-reference entry
Validation

Editor diagnostics show no errors in modified files
Note: cargo was unavailable in this environment, so runtime test execution could not be performed here.