### PR TITLE
fix: validate settlement init addresses are distinct and non-self

### DIFF
--- a/contracts/settlement/src/lib.rs
+++ b/contracts/settlement/src/lib.rs
@@ -71,10 +71,22 @@ impl CalloraSettlement {
     ///
     /// # Panics
     /// Panics if the contract is already initialized.
+    /// Panics if admin and vault_address are the same.
+    /// Panics if admin is the contract's own address.
+    /// Panics if vault_address is the contract's own address.
     pub fn init(env: Env, admin: Address, vault_address: Address) {
         let inst = env.storage().instance();
         if inst.has(&Symbol::new(&env, ADMIN_KEY)) {
             panic!("settlement contract already initialized");
+        }
+        if admin == vault_address {
+            panic!("invalid config: admin and vault_address must be distinct");
+        }
+        if admin == env.current_contract_address() {
+            panic!("invalid config: admin cannot be the contract itself");
+        }
+        if vault_address == env.current_contract_address() {
+            panic!("invalid config: vault_address cannot be the contract itself");
         }
         inst.set(&Symbol::new(&env, ADMIN_KEY), &admin);
         inst.set(&Symbol::new(&env, VAULT_KEY), &vault_address);

--- a/contracts/settlement/src/test.rs
+++ b/contracts/settlement/src/test.rs
@@ -66,6 +66,44 @@ mod settlement_tests {
         assert_eq!(all_balances.len(), 0);
         assert_eq!(client.get_developer_balance(&developer), 0);
     }
+    #[test]
+    #[should_panic(expected = "invalid config: admin and vault_address must be distinct")]
+    fn test_init_admin_equals_vault_panics() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let admin = Address::generate(&env);
+        let addr = env.register(CalloraSettlement, ());
+        let client = CalloraSettlementClient::new(&env, &addr);
+
+        // Passing the same address for admin and vault should be rejected.
+        client.init(&admin, &admin);
+    }
+
+    #[test]
+    #[should_panic(expected = "invalid config: admin cannot be the contract itself")]
+    fn test_init_admin_is_contract_panics() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let vault = Address::generate(&env);
+        let addr = env.register(CalloraSettlement, ());
+        let client = CalloraSettlementClient::new(&env, &addr);
+
+        // Passing the contract's own address as admin should be rejected.
+        client.init(&addr, &vault);
+    }
+
+    #[test]
+    #[should_panic(expected = "invalid config: vault_address cannot be the contract itself")]
+    fn test_init_vault_is_contract_panics() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let admin = Address::generate(&env);
+        let addr = env.register(CalloraSettlement, ());
+        let client = CalloraSettlementClient::new(&env, &addr);
+
+        // Passing the contract's own address as vault_address should be rejected.
+        client.init(&admin, &addr);
+    }
 
     #[test]
     fn test_receive_payment_to_pool() {


### PR DESCRIPTION
Add validation guards to CalloraSettlement::init to reject:
- admin == vault_address
- admin == current_contract_address
- vault_address == current_contract_address

These invalid configurations create confusing authorization semantics. Added tests for each invalid combination following the pattern used in RevenuePool.

Generated with [Devin](https://cli.devin.ai/docs)
closes #357