### PR TITLE
feat: extend vault instance storage TTL on mutating entrypoints

### DIFF
--- a/contracts/vault/STORAGE.md
+++ b/contracts/vault/STORAGE.md
@@ -2,6 +2,21 @@
 
 This document describes the storage layout of the Callora Vault contract, including storage keys, data types, and access control implications.
 
+## Instance Storage TTL
+
+All critical vault state lives in instance storage. To prevent archival on infrequently-used vaults, every mutating entrypoint calls `env.storage().instance().extend_ttl(threshold, extend_to)`.
+
+| Constant | Value | Rationale |
+|---|---|---|
+| `INSTANCE_BUMP_THRESHOLD` | `17_280 * 30` (~30 days) | Bump is triggered when fewer than 30 days of TTL remain |
+| `INSTANCE_BUMP_AMOUNT` | `17_280 * 60` (~60 days) | Each bump extends the TTL to 60 days from the current ledger |
+
+Ledger rate assumption: **17 280 ledgers/day** (5-second close time on Stellar mainnet).
+
+Entrypoints that bump TTL: `init`, `deposit`, `deduct`, `batch_deduct`, `withdraw`, `withdraw_to`.
+
+Pure view functions (`get_meta`, `balance`, `get_admin`, `get_usdc_token`, `get_settlement`, `get_revenue_pool`, `get_contract_addresses`, `is_paused`, `is_authorized_depositor`, `get_metadata`, `get_max_deduct`, `get_allowed_depositors`) do **not** bump the TTL — they are read-only and incur no write cost.
+
 ## Storage Overview
 
 The Callora Vault contract uses Soroban's instance storage to persist contract state. Data is organized using the `StorageKey` enum, providing type-safe access to contract state.

--- a/contracts/vault/src/lib.rs
+++ b/contracts/vault/src/lib.rs
@@ -42,7 +42,7 @@ pub enum StorageKey {
     UsdcToken,
     Settlement,
     RevenuePool,
-    /// Storage slot for `MAX_DEDUCT_KEY` (maximum allowed amount per deduct call).
+    /// Storage slot for the maximum allowed amount per deduct call.
     MaxDeduct,
     Paused,
     Metadata(String),
@@ -56,6 +56,11 @@ pub const DEFAULT_MIN_DEPOSIT: i128 = 1;
 pub const MAX_BATCH_SIZE: u32 = 50;
 pub const MAX_METADATA_LEN: u32 = 256;
 pub const MAX_OFFERING_ID_LEN: u32 = 64;
+
+// ~17 280 ledgers per day at 5-second close time.
+// Bump when fewer than 30 days remain; extend to 60 days.
+pub const INSTANCE_BUMP_THRESHOLD: u32 = 17_280 * 30; // ~30 days
+pub const INSTANCE_BUMP_AMOUNT: u32 = 17_280 * 60; // ~60 days
 
 #[contract]
 pub struct CalloraVault;
@@ -147,13 +152,14 @@ impl CalloraVault {
             inst.set(&StorageKey::RevenuePool, &p);
         }
         inst.set(&StorageKey::MaxDeduct, &max_d);
+        inst.extend_ttl(INSTANCE_BUMP_THRESHOLD, INSTANCE_BUMP_AMOUNT);
         env.events()
             .publish((Symbol::new(&env, "init"), owner.clone()), balance);
         meta
     }
 
     // -----------------------------------------------------------------------
-    // View functions
+    // View functions — no TTL bump (read-only, zero write cost)
     // -----------------------------------------------------------------------
 
     /// Return full vault state. Panics if vault is not initialized.
@@ -185,8 +191,7 @@ impl CalloraVault {
             .expect("vault not initialized")
     }
 
-    /// Return the configured `MAX_DEDUCT_KEY` value.
-    /// Returns `i128::MAX` (no cap) if not explicitly set.
+    /// Return the configured max deduct value. Returns `i128::MAX` if not explicitly set.
     pub fn get_max_deduct(env: Env) -> i128 {
         env.storage()
             .instance()
@@ -243,21 +248,19 @@ impl CalloraVault {
         list.contains(&caller)
     }
 
-    #[allow(dead_code)]
-    fn migrate(env: &Env) {
-        let inst = env.storage().instance();
-        if !inst.has(&StorageKey::Admin) {
-            if let Some(meta) = inst.get::<_, VaultMeta>(&StorageKey::MetaKey) {
-                inst.set(&StorageKey::Admin, &meta.owner);
-            }
-        }
-    }
-
     /// Return stored offering metadata, or `None` if not set.
     pub fn get_metadata(env: Env, offering_id: String) -> Option<String> {
         env.storage()
             .instance()
             .get(&StorageKey::Metadata(offering_id))
+    }
+
+    /// Return the full allowed-depositor list.
+    pub fn get_allowed_depositors(env: Env) -> Vec<Address> {
+        env.storage()
+            .instance()
+            .get(&StorageKey::DepositorList)
+            .unwrap_or(Vec::new(&env))
     }
 
     // -----------------------------------------------------------------------
@@ -296,6 +299,7 @@ impl CalloraVault {
         assert!(caller == meta.owner, "unauthorized: owner only");
     }
 
+    /// Set or clear the authorized caller for `deduct`/`batch_deduct` (owner only).
     pub fn set_authorized_caller(env: Env, new_caller: Option<Address>) {
         let mut meta = Self::get_meta(env.clone());
         meta.owner.require_auth();
@@ -311,11 +315,10 @@ impl CalloraVault {
         );
     }
 
-    /// Set `MAX_DEDUCT_KEY` (owner only).
+    /// Set `max_deduct` (owner only).
     ///
     /// # Panics
     /// - `"max_deduct must be positive"` when `max_deduct <= 0`.
-    /// - `"vault not initialized"` if called before `init`.
     pub fn set_max_deduct(env: Env, max_deduct: i128) {
         let meta = Self::get_meta(env.clone());
         meta.owner.require_auth();
@@ -333,7 +336,6 @@ impl CalloraVault {
     pub fn set_allowed_depositor(env: Env, caller: Address, depositor: Option<Address>) {
         caller.require_auth();
         Self::require_owner(env.clone(), caller.clone());
-
         match depositor {
             Some(d) => {
                 let mut list: Vec<Address> = env
@@ -364,38 +366,6 @@ impl CalloraVault {
             .set(&StorageKey::DepositorList, &Vec::<Address>::new(&env));
     }
 
-    fn require_authorized_deduct_caller(env: Env, caller: &Address) {
-        let meta = Self::get_meta(env.clone());
-        let owner = meta.owner.clone();
-        let auth = match meta.authorized_caller {
-            Some(ac) => *caller == ac || *caller == owner,
-            None => *caller == owner,
-        };
-        assert!(auth, "unauthorized caller");
-    }
-
-    pub fn get_allowed_depositors(env: Env) -> Vec<Address> {
-        env.storage()
-            .instance()
-            .get(&StorageKey::DepositorList)
-            .unwrap_or(Vec::new(&env))
-    }
-
-    pub fn set_authorized_caller(env: Env, new_caller: Option<Address>) {
-        let mut meta = Self::get_meta(env.clone());
-        meta.owner.require_auth();
-        let old_authorized_caller = meta.authorized_caller.clone();
-        meta.authorized_caller = caller.clone();
-        env.storage().instance().set(&StorageKey::MetaKey, &meta);
-        env.events().publish(
-            (
-                Symbol::new(&env, "set_authorized_caller"),
-                meta.owner.clone(),
-            ),
-            (old_authorized_caller, caller),
-        );
-    }
-
     pub fn pause(env: Env, caller: Address) {
         caller.require_auth();
         Self::require_admin_or_owner(env.clone(), &caller);
@@ -412,15 +382,6 @@ impl CalloraVault {
         env.storage().instance().set(&StorageKey::Paused, &false);
         env.events()
             .publish((Symbol::new(&env, "vault_unpaused"), caller), ());
-    }
-
-    /// Returns `true` if the vault is currently paused, `false` otherwise.
-    /// Safe default: returns `false` when the pause key is absent.
-    pub fn is_paused(env: Env) -> bool {
-        env.storage()
-            .instance()
-            .get(&StorageKey::Paused)
-            .unwrap_or(false)
     }
 
     pub fn deposit(env: Env, caller: Address, amount: i128) -> i128 {
@@ -443,14 +404,16 @@ impl CalloraVault {
             .instance()
             .get(&StorageKey::UsdcToken)
             .expect("vault not initialized");
-        let usdc = token::Client::new(&env, &usdc_addr);
-        usdc.transfer(&caller, &env.current_contract_address(), &amount);
-        let mut meta = Self::get_meta(env.clone());
+        token::Client::new(&env, &usdc_addr)
+            .transfer(&caller, &env.current_contract_address(), &amount);
         meta.balance = meta
             .balance
             .checked_add(amount)
             .unwrap_or_else(|| panic!("balance overflow"));
         env.storage().instance().set(&StorageKey::MetaKey, &meta);
+        env.storage()
+            .instance()
+            .extend_ttl(INSTANCE_BUMP_THRESHOLD, INSTANCE_BUMP_AMOUNT);
         env.events().publish(
             (Symbol::new(&env, "deposit"), caller),
             (amount, meta.balance),
@@ -472,9 +435,6 @@ impl CalloraVault {
         Self::require_authorized_deduct_caller(env.clone(), &caller);
         let max_d = Self::get_max_deduct(env.clone());
         assert!(amount <= max_d, "deduct amount exceeds max_deduct");
-        let meta = Self::get_meta(env.clone());
-        assert!(meta.balance >= amount, "insufficient balance");
-        let settlement = Self::require_settlement(&env);
         let mut meta = Self::get_meta(env.clone());
         assert!(meta.balance >= amount, "insufficient balance");
         let settlement = Self::require_settlement(&env);
@@ -483,12 +443,14 @@ impl CalloraVault {
             .checked_sub(amount)
             .unwrap_or_else(|| panic!("balance underflow"));
         env.storage().instance().set(&StorageKey::MetaKey, &meta);
+        env.storage()
+            .instance()
+            .extend_ttl(INSTANCE_BUMP_THRESHOLD, INSTANCE_BUMP_AMOUNT);
         let ut: Address = env
             .storage()
             .instance()
             .get(&StorageKey::UsdcToken)
-            .unwrap();
-        let settlement = Self::require_settlement(&env);
+            .expect("vault not initialized");
         Self::transfer_funds(&env, &ut, &settlement, amount);
         let rid = request_id.unwrap_or(Symbol::new(&env, ""));
         env.events().publish(
@@ -496,10 +458,6 @@ impl CalloraVault {
             (amount, meta.balance),
         );
         meta.balance
-    }
-
-    pub fn get_max_deduct(env: Env) -> i128 {
-        Self::get_max_deduct_internal(env)
     }
 
     /// Deduct multiple items atomically.
@@ -529,19 +487,17 @@ impl CalloraVault {
                 .unwrap_or_else(|| panic!("total overflow"));
         }
         let settlement = Self::require_settlement(&env);
-
         meta.balance = running;
         env.storage().instance().set(&StorageKey::MetaKey, &meta);
+        env.storage()
+            .instance()
+            .extend_ttl(INSTANCE_BUMP_THRESHOLD, INSTANCE_BUMP_AMOUNT);
         let ut: Address = env
             .storage()
             .instance()
             .get(&StorageKey::UsdcToken)
-            .unwrap();
-        let settlement = Self::require_settlement(&env);
+            .expect("vault not initialized");
         Self::transfer_funds(&env, &ut, &settlement, total);
-
-        meta.balance = running;
-        env.storage().instance().set(&StorageKey::MetaKey, &meta);
         for item in items.iter() {
             let rid = item.request_id.unwrap_or(Symbol::new(&env, ""));
             env.events().publish(
@@ -550,10 +506,6 @@ impl CalloraVault {
             );
         }
         meta.balance
-    }
-
-    pub fn balance(env: Env) -> i128 {
-        Self::get_meta(env).balance
     }
 
     pub fn transfer_ownership(env: Env, new_owner: Address) {
@@ -614,6 +566,9 @@ impl CalloraVault {
             .checked_sub(amount)
             .unwrap_or_else(|| panic!("balance underflow"));
         env.storage().instance().set(&StorageKey::MetaKey, &meta);
+        env.storage()
+            .instance()
+            .extend_ttl(INSTANCE_BUMP_THRESHOLD, INSTANCE_BUMP_AMOUNT);
         env.events().publish(
             (Symbol::new(&env, "withdraw"), meta.owner.clone()),
             (amount, meta.balance),
@@ -637,6 +592,9 @@ impl CalloraVault {
             .checked_sub(amount)
             .unwrap_or_else(|| panic!("balance underflow"));
         env.storage().instance().set(&StorageKey::MetaKey, &meta);
+        env.storage()
+            .instance()
+            .extend_ttl(INSTANCE_BUMP_THRESHOLD, INSTANCE_BUMP_AMOUNT);
         env.events().publish(
             (Symbol::new(&env, "withdraw_to"), meta.owner.clone(), to),
             (amount, meta.balance),
@@ -665,44 +623,6 @@ impl CalloraVault {
         usdc.transfer(&env.current_contract_address(), &to, &amount);
         env.events()
             .publish((Symbol::new(&env, "distribute"), to), amount);
-    }
-
-    pub fn transfer_ownership(env: Env, new_owner: Address) {
-        let meta = Self::get_meta(env.clone());
-        meta.owner.require_auth();
-        assert!(
-            new_owner != meta.owner,
-            "new_owner must be different from current owner"
-        );
-        env.storage()
-            .instance()
-            .set(&StorageKey::PendingOwner, &new_owner);
-        env.events().publish(
-            (
-                Symbol::new(&env, "ownership_nominated"),
-                meta.owner,
-                new_owner,
-            ),
-            (),
-        );
-    }
-
-    pub fn accept_ownership(env: Env) {
-        let pending: Address = env
-            .storage()
-            .instance()
-            .get(&StorageKey::PendingOwner)
-            .expect("no ownership transfer pending");
-        pending.require_auth();
-        let mut meta = Self::get_meta(env.clone());
-        let old = meta.owner.clone();
-        meta.owner = pending;
-        env.storage().instance().set(&StorageKey::MetaKey, &meta);
-        env.storage().instance().remove(&StorageKey::PendingOwner);
-        env.events().publish(
-            (Symbol::new(&env, "ownership_accepted"), old, meta.owner),
-            (),
-        );
     }
 
     pub fn set_revenue_pool(env: Env, caller: Address, revenue_pool: Option<Address>) {
@@ -744,23 +664,6 @@ impl CalloraVault {
             (Symbol::new(&env, "set_settlement"), caller),
             settlement_address,
         );
-    }
-
-    /// Return the settlement address, panicking if not set.
-    pub fn get_settlement(env: Env) -> Address {
-        env.storage()
-            .instance()
-            .get(&StorageKey::Settlement)
-            .unwrap_or_else(|| panic!("settlement address not set"))
-    }
-
-    /// Return `(usdc_token, settlement, revenue_pool)` in one call.
-    pub fn get_contract_addresses(env: Env) -> (Option<Address>, Option<Address>, Option<Address>) {
-        let inst = env.storage().instance();
-        let usdc: Option<Address> = inst.get(&StorageKey::UsdcToken);
-        let settlement: Option<Address> = inst.get(&StorageKey::Settlement);
-        let revenue_pool: Option<Address> = inst.get(&StorageKey::RevenuePool);
-        (usdc, settlement, revenue_pool)
     }
 
     pub fn set_metadata(
@@ -861,24 +764,18 @@ impl CalloraVault {
         );
     }
 
-    pub fn add_address(env: Env, caller: Address, depositor: Address) {
-        Self::set_allowed_depositor(env.clone(), caller.clone(), Some(depositor.clone()));
-        env.events()
-            .publish((Symbol::new(&env, "allowlist_add"), caller, depositor), ());
-    }
-
-    pub fn get_allowlist(env: Env) -> Vec<Address> {
-        Self::get_allowed_depositors(env)
-    }
-
-    pub fn clear_all(env: Env, caller: Address) {
-        Self::clear_allowed_depositors(env.clone(), caller.clone());
-        env.events()
-            .publish((Symbol::new(&env, "allowlist_clear"), caller), ());
+    #[allow(dead_code)]
+    fn migrate(env: &Env) {
+        let inst = env.storage().instance();
+        if !inst.has(&StorageKey::Admin) {
+            if let Some(meta) = inst.get::<_, VaultMeta>(&StorageKey::MetaKey) {
+                inst.set(&StorageKey::Admin, &meta.owner);
+            }
+        }
     }
 }
 
-// Allowlist aliases used by tests
+// Allowlist aliases — convenience wrappers used by tests and external callers.
 #[contractimpl]
 impl CalloraVault {
     pub fn add_address(env: Env, caller: Address, depositor: Address) {

--- a/contracts/vault/src/test.rs
+++ b/contracts/vault/src/test.rs
@@ -454,6 +454,7 @@ fn owner_deposit_increases_balance_and_emits_event() {
         "topics must have exactly 2 entries (deposit, caller)"
     );
     let topic0: Symbol = deposit_event.1.get(0).unwrap().into_val(&env);
+    let topic1: Address = deposit_event.1.get(1).unwrap().into_val(&env);
     assert_eq!(topic0, Symbol::new(&env, "deposit"));
     assert_eq!(topic1, owner);
 
@@ -552,6 +553,7 @@ fn deposit_event_schema_alignment() {
         "deposit event must have exactly 2 topics"
     );
     let topic0: Symbol = deposit_event.1.get(0).unwrap().into_val(&env);
+    let topic1: Address = deposit_event.1.get(1).unwrap().into_val(&env);
     assert_eq!(
         topic0,
         Symbol::new(&env, "deposit"),
@@ -778,7 +780,7 @@ fn deduct_reduces_balance() {
         &owner,
         &usdc,
         &Some(300),
-        &Some(caller.clone()),
+        &None,
         &None,
         &None,
         &None,
@@ -804,7 +806,7 @@ fn deduct_with_request_id() {
         &owner,
         &usdc,
         &Some(1000),
-        &Some(caller.clone()),
+        &None,
         &None,
         &None,
         &None,
@@ -829,7 +831,7 @@ fn deduct_insufficient_balance_fails() {
         &owner,
         &usdc,
         &Some(10),
-        &Some(caller.clone()),
+        &None,
         &None,
         &None,
         &None,
@@ -852,7 +854,7 @@ fn deduct_exact_balance_succeeds() {
         &owner,
         &usdc,
         &Some(75),
-        &Some(caller.clone()),
+        &None,
         &None,
         &None,
         &None,
@@ -878,7 +880,7 @@ fn deduct_event_contains_request_id() {
         &owner,
         &usdc,
         &Some(500),
-        &Some(caller.clone()),
+        &None,
         &None,
         &None,
         &None,
@@ -984,14 +986,14 @@ fn deduct_event_no_request_id_uses_empty_symbol() {
         &owner,
         &usdc,
         &Some(300),
-        &Some(caller.clone()),
+        &None,
         &None,
         &None,
         &None,
     );
     let settlement = Address::generate(&env);
     client.set_settlement(&owner, &settlement);
-    client.deduct(&caller, &100, &None);
+    client.deduct(&owner, &100, &None);
 
     let events = env.events().all();
     let ev = events.last().expect("expected deduct event");
@@ -1014,7 +1016,6 @@ fn deduct_event_no_request_id_uses_empty_symbol() {
 fn deduct_zero_panics() {
     let env = Env::default();
     let owner = Address::generate(&env);
-    let _caller = Address::generate(&env);
     let (vault_address, client) = create_vault(&env);
     let (usdc, _, usdc_admin) = create_usdc(&env, &owner);
 
@@ -1024,12 +1025,12 @@ fn deduct_zero_panics() {
         &owner,
         &usdc,
         &Some(500),
-        &Some(caller.clone()),
+        &None,
         &None,
         &None,
         &None,
     );
-    client.deduct(&caller, &0, &None);
+    client.deduct(&owner, &0, &None);
 }
 
 #[test]
@@ -1037,7 +1038,6 @@ fn deduct_zero_panics() {
 fn deduct_negative_panics() {
     let env = Env::default();
     let owner = Address::generate(&env);
-    let _caller = Address::generate(&env);
     let (vault_address, client) = create_vault(&env);
     let (usdc, _, usdc_admin) = create_usdc(&env, &owner);
 
@@ -1047,12 +1047,12 @@ fn deduct_negative_panics() {
         &owner,
         &usdc,
         &Some(100),
-        &Some(caller.clone()),
+        &None,
         &None,
         &None,
         &None,
     );
-    client.deduct(&caller, &-50, &None);
+    client.deduct(&owner, &-50, &None);
 }
 
 #[test]
@@ -1069,12 +1069,12 @@ fn deduct_exceeds_balance_panics() {
         &owner,
         &usdc,
         &Some(50),
-        &Some(caller.clone()),
+        &None,
         &None,
         &None,
         &None,
     );
-    client.deduct(&caller, &100, &None);
+    client.deduct(&owner, &100, &None);
 }
 
 #[test]
@@ -1090,7 +1090,7 @@ fn balance_unchanged_after_failed_deduct() {
         &owner,
         &usdc,
         &Some(100),
-        &Some(caller.clone()),
+        &None,
         &None,
         &None,
         &None,
@@ -1108,7 +1108,6 @@ fn balance_unchanged_after_failed_deduct() {
 fn batch_deduct_multiple_items() {
     let env = Env::default();
     let owner = Address::generate(&env);
-    let _caller = Address::generate(&env);
     let (vault_address, client) = create_vault(&env);
     let (usdc, _, usdc_admin) = create_usdc(&env, &owner);
 
@@ -1118,7 +1117,7 @@ fn batch_deduct_multiple_items() {
         &owner,
         &usdc,
         &Some(1000),
-        &Some(caller.clone()),
+        &None,
         &None,
         &None,
         &None,
@@ -1151,7 +1150,6 @@ fn batch_deduct_multiple_items() {
 fn batch_deduct_events_contain_request_ids() {
     let env = Env::default();
     let owner = Address::generate(&env);
-    let _caller = Address::generate(&env);
     let (vault_address, client) = create_vault(&env);
     let (usdc, _, usdc_admin) = create_usdc(&env, &owner);
 
@@ -1161,7 +1159,7 @@ fn batch_deduct_events_contain_request_ids() {
         &owner,
         &usdc,
         &Some(1000),
-        &Some(caller.clone()),
+        &None,
         &None,
         &None,
         &None,
@@ -1984,7 +1982,7 @@ fn vault_full_lifecycle() {
         &owner,
         &usdc,
         &Some(500),
-        &Some(caller.clone()),
+        &None,
         &Some(10),
         &None,
         &None,
@@ -4821,4 +4819,115 @@ fn get_contract_addresses_updates_after_clear_revenue_pool() {
 
     let (_, _, got_pool) = client.get_contract_addresses();
     assert_eq!(got_pool, None);
+}
+
+// ---------------------------------------------------------------------------
+// Instance TTL tests
+// ---------------------------------------------------------------------------
+
+/// Verifies that state written during `init` survives a simulated ledger
+/// advance of INSTANCE_BUMP_THRESHOLD - 1 ledgers (still within the TTL
+/// window) and that the vault remains fully operational afterwards.
+#[test]
+fn instance_ttl_extended_on_init_and_state_survives_ledger_advance() {
+    use soroban_sdk::testutils::Ledger as _;
+    use crate::{INSTANCE_BUMP_THRESHOLD, INSTANCE_BUMP_AMOUNT};
+
+    let env = Env::default();
+    let owner = Address::generate(&env);
+    let (usdc, usdc_client, usdc_admin) = create_usdc(&env, &owner);
+    let (vault_address, client) = create_vault(&env);
+
+    env.mock_all_auths();
+    client.init(&owner, &usdc, &None, &None, &None, &None, &None);
+
+    // Advance the ledger to just inside the bump window.
+    let current = env.ledger().sequence();
+    env.ledger().set_sequence_number(current + INSTANCE_BUMP_THRESHOLD - 1);
+
+    // State must still be readable — the TTL was extended to INSTANCE_BUMP_AMOUNT.
+    assert_eq!(client.balance(), 0);
+    assert_eq!(client.get_admin(), owner);
+
+    // A deposit must also succeed (and re-extend the TTL).
+    usdc_admin.mint(&owner, &100);
+    usdc_client.approve(&owner, &vault_address, &100, &(current + INSTANCE_BUMP_AMOUNT + 1000));
+    let new_balance = client.deposit(&owner, &100);
+    assert_eq!(new_balance, 100);
+}
+
+/// Verifies that `deposit`, `withdraw`, and `withdraw_to` each extend the TTL
+/// so state remains accessible after a ledger advance.
+#[test]
+fn instance_ttl_extended_on_mutating_entrypoints() {
+    use soroban_sdk::testutils::Ledger as _;
+    use crate::INSTANCE_BUMP_THRESHOLD;
+
+    let env = Env::default();
+    let owner = Address::generate(&env);
+    let recipient = Address::generate(&env);
+    let (usdc, usdc_client, usdc_admin) = create_usdc(&env, &owner);
+    let (vault_address, client) = create_vault(&env);
+
+    env.mock_all_auths();
+    client.init(&owner, &usdc, &None, &None, &None, &None, &None);
+
+    usdc_admin.mint(&owner, &500);
+    usdc_client.approve(&owner, &vault_address, &500, &200_000);
+
+    // deposit — bumps TTL
+    client.deposit(&owner, &300);
+    let seq = env.ledger().sequence();
+    env.ledger().set_sequence_number(seq + INSTANCE_BUMP_THRESHOLD - 1);
+    assert_eq!(client.balance(), 300, "balance readable after ledger advance post-deposit");
+
+    // withdraw — bumps TTL
+    client.withdraw(&100);
+    let seq = env.ledger().sequence();
+    env.ledger().set_sequence_number(seq + INSTANCE_BUMP_THRESHOLD - 1);
+    assert_eq!(client.balance(), 200, "balance readable after ledger advance post-withdraw");
+
+    // withdraw_to — bumps TTL
+    client.withdraw_to(&recipient, &50);
+    let seq = env.ledger().sequence();
+    env.ledger().set_sequence_number(seq + INSTANCE_BUMP_THRESHOLD - 1);
+    assert_eq!(client.balance(), 150, "balance readable after ledger advance post-withdraw_to");
+}
+
+/// Verifies that `deduct` and `batch_deduct` extend the TTL.
+#[test]
+fn instance_ttl_extended_on_deduct_and_batch_deduct() {
+    use soroban_sdk::testutils::Ledger as _;
+    use crate::INSTANCE_BUMP_THRESHOLD;
+
+    let env = Env::default();
+    let owner = Address::generate(&env);
+    let settlement = Address::generate(&env);
+    let (usdc, usdc_client, usdc_admin) = create_usdc(&env, &owner);
+    let (vault_address, client) = create_vault(&env);
+
+    env.mock_all_auths();
+    client.init(&owner, &usdc, &None, &None, &None, &None, &None);
+    client.set_settlement(&owner, &settlement);
+
+    usdc_admin.mint(&owner, &500);
+    usdc_client.approve(&owner, &vault_address, &500, &200_000);
+    client.deposit(&owner, &500);
+
+    // deduct — bumps TTL
+    client.deduct(&owner, &100, &None);
+    let seq = env.ledger().sequence();
+    env.ledger().set_sequence_number(seq + INSTANCE_BUMP_THRESHOLD - 1);
+    assert_eq!(client.balance(), 400, "balance readable after ledger advance post-deduct");
+
+    // batch_deduct — bumps TTL
+    let items = soroban_sdk::vec![
+        &env,
+        DeductItem { amount: 50, request_id: None },
+        DeductItem { amount: 50, request_id: None },
+    ];
+    client.batch_deduct(&owner, &items);
+    let seq = env.ledger().sequence();
+    env.ledger().set_sequence_number(seq + INSTANCE_BUMP_THRESHOLD - 1);
+    assert_eq!(client.balance(), 300, "balance readable after ledger advance post-batch_deduct");
 }


### PR DESCRIPTION
- Add INSTANCE_BUMP_THRESHOLD (30 days) and INSTANCE_BUMP_AMOUNT (60 days) constants based on ~17 280 ledgers/day at 5-second close time
- Call extend_ttl on every mutating entrypoint: init, deposit, deduct, batch_deduct, withdraw, withdraw_to
- View functions (get_meta, balance, get_admin, is_paused, etc.) do NOT bump TTL — zero write cost on reads
- Fix duplicate function definitions in lib.rs (set_authorized_caller, is_paused, transfer_ownership, accept_ownership, get_settlement, get_contract_addresses, add_address/clear_all/get_allowlist)
- Fix broken get_max_deduct call to non-existent get_max_deduct_internal
- Remove duplicate state writes in deduct and batch_deduct
- Fix undeclared 'caller' variable in deduct unit tests (replace with owner)
- Fix undeclared 'topic1' variable in deposit event tests
- Add 3 TTL tests: init survives ledger advance, mutating entrypoints each bump TTL, deduct/batch_deduct bump TTL
- Document TTL window and archival risk in contracts/vault/STORAGE.md

closes #326 