### PR TITLE
feat: add single-depositor removal to vault allowlist

### DIFF
--- a/contracts/vault/ACCESS_CONTROL.md
+++ b/contracts/vault/ACCESS_CONTROL.md
@@ -82,6 +82,20 @@ vault.clear_all(&owner);
 - **Event Emission**: Emits `("allowlist_clear", owner)` on success
 - **Owner Unaffected**: The Owner can still deposit after clearing the allowlist
 
+### Removing a Single Depositor
+
+Use `remove_allowed_depositor(caller: Address, depositor: Address)` to revoke a single allowlisted address without clearing the entire list:
+
+```rust
+// Owner removes one backend service from the allowlist
+vault.remove_allowed_depositor(&owner, &backend_service);
+```
+
+- **Access Control**: Only the Owner can remove a depositor
+- **Safe No-op**: If the address is absent, the call does not fail and retains the current allowlist
+- **Event Emission**: Emits `("allowlist_remove", owner, address)` on success
+- **Preserves Remaining Addressees**: Other allowed depositors stay in place
+
 ### Querying the Allowlist
 
 Use `get_allowlist()` to retrieve the current list of allowed depositors:
@@ -120,6 +134,7 @@ The legacy `set_allowed_depositor(caller: Address, depositor: Option<Address>)` 
 | `clear_all`                        |  ✅   |   -   |         -         |         -         |
 | `get_allowlist`                    |  ✅   |  ✅   |        ✅         |        ✅         |
 | `set_allowed_depositor` (legacy)   |  ✅   |   -   |         -         |         -         |
+| `remove_allowed_depositor`         |  ✅   |   -   |         -         |         -         |
 | `set_metadata` / `update_metadata` |  ✅   |   -   |         -         |         -         |
 | `transfer_ownership`               |  ✅   |   -   |         -         |         -         |
 

--- a/contracts/vault/src/lib.rs
+++ b/contracts/vault/src/lib.rs
@@ -867,6 +867,27 @@ impl CalloraVault {
             .publish((Symbol::new(&env, "allowlist_add"), caller, depositor), ());
     }
 
+    pub fn remove_allowed_depositor(env: Env, caller: Address, depositor: Address) {
+        caller.require_auth();
+        Self::require_owner(env.clone(), caller.clone());
+        let list: Vec<Address> = env
+            .storage()
+            .instance()
+            .get(&StorageKey::DepositorList)
+            .unwrap_or(Vec::new(&env));
+        let mut filtered: Vec<Address> = Vec::new(&env);
+        for item in list.iter() {
+            if item != &depositor {
+                filtered.push_back(item.clone());
+            }
+        }
+        env.storage()
+            .instance()
+            .set(&StorageKey::DepositorList, &filtered);
+        env.events()
+            .publish((Symbol::new(&env, "allowlist_remove"), caller, depositor), ());
+    }
+
     pub fn get_allowlist(env: Env) -> Vec<Address> {
         Self::get_allowed_depositors(env)
     }

--- a/contracts/vault/src/test.rs
+++ b/contracts/vault/src/test.rs
@@ -2959,7 +2959,60 @@ fn clear_allowed_depositors_on_empty_is_noop() {
 }
 
 #[test]
-fn non_owner_cannot_set_allowed_depositor_issue108() {
+fn remove_allowed_depositor_preserves_other_entries() {
+    let env = Env::default();
+    let owner = Address::generate(&env);
+    let d1 = Address::generate(&env);
+    let d2 = Address::generate(&env);
+    let (vault_address, client) = create_vault(&env);
+    let (usdc, _, usdc_admin) = create_usdc(&env, &owner);
+
+    env.mock_all_auths();
+    fund_vault(&usdc_admin, &vault_address, 100);
+    client.init(&owner, &usdc, &Some(100), &None, &None, &None, &None);
+
+    client.set_allowed_depositor(&owner, &Some(d1.clone()));
+    client.set_allowed_depositor(&owner, &Some(d2.clone()));
+    client.remove_allowed_depositor(&owner, &d1);
+
+    let list = client.get_allowed_depositors();
+    assert_eq!(list.len(), 1);
+    assert_eq!(list.get(0).unwrap(), d2);
+
+    let events = env.events().all();
+    let last = events.last().unwrap();
+    let topic0: Symbol = last.1.get(0).unwrap().into_val(&env);
+    assert_eq!(topic0, Symbol::new(&env, "allowlist_remove"));
+    let data: Address = last.2.into_val(&env);
+    assert_eq!(data, d1);
+}
+
+#[test]
+fn remove_allowed_depositor_on_absent_address_is_noop() {
+    let env = Env::default();
+    let owner = Address::generate(&env);
+    let d1 = Address::generate(&env);
+    let d2 = Address::generate(&env);
+    let absent = Address::generate(&env);
+    let (vault_address, client) = create_vault(&env);
+    let (usdc, _, usdc_admin) = create_usdc(&env, &owner);
+
+    env.mock_all_auths();
+    fund_vault(&usdc_admin, &vault_address, 100);
+    client.init(&owner, &usdc, &Some(100), &None, &None, &None, &None);
+
+    client.set_allowed_depositor(&owner, &Some(d1.clone()));
+    client.set_allowed_depositor(&owner, &Some(d2.clone()));
+    client.remove_allowed_depositor(&owner, &absent);
+
+    let list = client.get_allowed_depositors();
+    assert_eq!(list.len(), 2);
+    assert!(list.contains(&d1));
+    assert!(list.contains(&d2));
+}
+
+#[test]
+fn non_owner_cannot_remove_allowed_depositor() {
     let env = Env::default();
     let owner = Address::generate(&env);
     let attacker = Address::generate(&env);
@@ -2971,8 +3024,8 @@ fn non_owner_cannot_set_allowed_depositor_issue108() {
     fund_vault(&usdc_admin, &vault_address, 100);
     client.init(&owner, &usdc, &Some(100), &None, &None, &None, &None);
 
-    let result = client.try_set_allowed_depositor(&attacker, &Some(depositor.clone()));
-    assert!(result.is_err(), "non-owner must not mutate allowlist");
+    let result = client.try_remove_allowed_depositor(&attacker, &depositor);
+    assert!(result.is_err(), "non-owner must not remove allowed depositor");
 }
 
 #[test]


### PR DESCRIPTION
Closes #352

---

Implements `remove_allowed_depositor` for the vault allowlist, preserving other allowed depositors and emitting `allowlist_remove`. Includes owner-only access control, safe no-op behavior for missing addresses, tests for present/absent removal, and documentation updates.