### PR TITLE
ix: emit vault_changed event on settlement set_vault

### DIFF
--- a/EVENT_SCHEMA.md
+++ b/EVENT_SCHEMA.md
@@ -749,6 +749,25 @@ after the matching `payment_received` event.
 
 ---
 
+### `vault_changed`
+
+Emitted by `set_vault()` when the admin updates the registered vault address.
+
+| Index   | Location | Type    | Description                        |
+|---------|----------|---------|------------------------------------|
+| topic 0 | topics   | Symbol  | `"vault_changed"`                |
+| topic 1 | topics   | Address | `caller` — admin who performed update |
+| data    | data     | (Address, Address) | (old_vault, new_vault)        |
+
+```json
+{
+  "topics": ["vault_changed", "GADMIN..."],
+  "data": ["GOLDVAULT...", "GNEWVAULT..."]
+}
+```
+
+---
+
 ## Indexer quick-reference
 
 | Event                    | Contract        | Trigger                                  |
@@ -780,6 +799,7 @@ after the matching `payment_received` event.
 | `batch_distribute`       | revenue-pool    | each payment in `batch_distribute()`     |
 | `payment_received`       | settlement      | `receive_payment()`                      |
 | `balance_credited`       | settlement      | `receive_payment()` with `to_pool=false` |
+| `vault_changed`          | settlement      | `set_vault()`                            |
 
 ---
 

--- a/contracts/settlement/src/lib.rs
+++ b/contracts/settlement/src/lib.rs
@@ -44,6 +44,14 @@ pub struct BalanceCreditedEvent {
     pub new_balance: i128,
 }
 
+/// Emitted when the registered vault address is changed via `set_vault()`.
+#[contracttype]
+#[derive(Clone, Debug, PartialEq)]
+pub struct VaultChangedEvent {
+    pub old_vault: Address,
+    pub new_vault: Address,
+}
+
 /// Storage key for the registered vault address.
 const VAULT_KEY: &str = "vault";
 /// Storage key for the admin address.
@@ -364,8 +372,7 @@ impl CalloraSettlement {
     /// old vault, so coordinate carefully during migrations.
     ///
     /// # Events
-    /// This function does not emit events. Monitor vault changes by
-    /// comparing the result of `get_vault()` across blocks.
+    /// Emits `vault_changed` event with the old and new vault addresses.
     ///
     /// # Panics
     /// Panics if caller is not the current admin.
@@ -375,9 +382,17 @@ impl CalloraSettlement {
         if caller != current_admin {
             panic!("unauthorized: caller is not admin");
         }
-        env.storage()
-            .instance()
-            .set(&Symbol::new(&env, VAULT_KEY), &new_vault);
+        let inst = env.storage().instance();
+        let old_vault = Self::get_vault(env.clone());
+        inst.set(&Symbol::new(&env, VAULT_KEY), &new_vault);
+
+        env.events().publish(
+            (Symbol::new(&env, "vault_changed"), caller.clone()),
+            VaultChangedEvent {
+                old_vault: old_vault.clone(),
+                new_vault: new_vault.clone(),
+            },
+        );
     }
 
     /// Internal function to require authorized caller (vault or admin)

--- a/contracts/settlement/src/test.rs
+++ b/contracts/settlement/src/test.rs
@@ -334,6 +334,41 @@ mod settlement_tests {
         assert_eq!(client.get_vault(), new_vault);
     }
 
+    #[test]
+    fn test_set_vault_emits_event() {
+        use soroban_sdk::testutils::Events as _;
+        use soroban_sdk::{IntoVal, Symbol};
+
+        let env = Env::default();
+        env.mock_all_auths();
+        let admin = Address::generate(&env);
+        let vault = Address::generate(&env);
+        let new_vault = Address::generate(&env);
+        let addr = env.register(CalloraSettlement, ());
+        let client = CalloraSettlementClient::new(&env, &addr);
+        client.init(&admin, &vault);
+
+        client.set_vault(&admin, &new_vault);
+
+        let events = env.events().all();
+        let ev = events
+            .iter()
+            .find(|e| {
+                !e.1.is_empty() && {
+                    let t: Symbol = e.1.get(0).unwrap().into_val(&env);
+                    t == Symbol::new(&env, "vault_changed")
+                }
+            })
+            .expect("expected vault_changed event");
+
+        let topic1: Address = ev.1.get(1).unwrap().into_val(&env);
+        assert_eq!(topic1, admin);
+
+        let data: crate::VaultChangedEvent = ev.2.into_val(&env);
+        assert_eq!(data.old_vault, vault);
+        assert_eq!(data.new_vault, new_vault);
+    }
+
     // â”€â”€ admin rotation edge cases â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 
     #[test]


### PR DESCRIPTION
Closes #333

---

This PR modifies CalloraSettlement::set_vault to emit a vault_changed event whenever the vault address is updated. This ensures that off-chain indexers can track ownership rotations, which is critical for security and auditing purposes