### PR TITLE
feat: add get_pending_admin view to settlement

### DIFF
--- a/contracts/settlement/src/lib.rs
+++ b/contracts/settlement/src/lib.rs
@@ -405,6 +405,19 @@ impl CalloraSettlement {
         result
     }
 
+    /// Return the pending admin address, or `None` if no transfer is in progress.
+    ///
+    /// Integrators can poll this to detect an in-flight two-step admin handover
+    /// before `accept_admin` is called.
+    ///
+    /// # Returns
+    /// `Some(Address)` of the nominated admin, or `None` when no transfer is pending.
+    pub fn get_pending_admin(env: Env) -> Option<Address> {
+        env.storage()
+            .instance()
+            .get(&StorageKey::PendingAdmin)
+    }
+
     /// Nominate a new admin (admin only).
     ///
     /// # Arguments

--- a/contracts/settlement/src/test.rs
+++ b/contracts/settlement/src/test.rs
@@ -325,6 +325,38 @@ mod settlement_tests {
     }
 
     #[test]
+    fn test_get_pending_admin_none_before_nomination() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let admin = Address::generate(&env);
+        let vault = Address::generate(&env);
+        let addr = env.register(CalloraSettlement, ());
+        let client = CalloraSettlementClient::new(&env, &addr);
+        client.init(&admin, &vault);
+
+        assert_eq!(client.get_pending_admin(), None);
+    }
+
+    #[test]
+    fn test_get_pending_admin_some_after_nomination() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let admin = Address::generate(&env);
+        let vault = Address::generate(&env);
+        let new_admin = Address::generate(&env);
+        let addr = env.register(CalloraSettlement, ());
+        let client = CalloraSettlementClient::new(&env, &addr);
+        client.init(&admin, &vault);
+
+        client.set_admin(&admin, &new_admin);
+        assert_eq!(client.get_pending_admin(), Some(new_admin.clone()));
+
+        // clears after acceptance
+        client.accept_admin();
+        assert_eq!(client.get_pending_admin(), None);
+    }
+
+    #[test]
     #[should_panic(expected = "no admin transfer pending")]
     fn test_accept_admin_fails_if_not_nominated() {
         let env = Env::default();

--- a/docs/interfaces/settlement.json
+++ b/docs/interfaces/settlement.json
@@ -138,6 +138,16 @@
     },
 
     {
+      "name": "get_pending_admin",
+      "description": "Return the pending admin address, or null if no two-step transfer is in progress. Integrators can poll this to detect an in-flight admin handover before accept_admin is called.",
+      "access": "any",
+      "params": [],
+      "returns": "Address | null",
+      "panics": [],
+      "events": []
+    },
+
+    {
       "name": "get_vault",
       "description": "Return the registered vault contract address.",
       "access": "any",


### PR DESCRIPTION
Closes #340

---

## Problem

`CalloraSettlement` stores `StorageKey::PendingAdmin` during the two-step admin transfer but exposes no way to read it. Integrators have no way to detect an in-flight handover without watching events.

## Changes

### `contracts/settlement/src/lib.rs`
- Add `get_pending_admin(env) -> Option<Address>`: reads `StorageKey::PendingAdmin` from instance storage, returns `Some` when a transfer is pending, `None` otherwise. No auth required — read-only view.

### `contracts/settlement/src/test.rs`
- `test_get_pending_admin_none_before_nomination` — returns `None` when nothing is pending
- `test_get_pending_admin_some_after_nomination` — returns `Some(new_admin)` after `set_admin`, then `None` again after `accept_admin` completes
- Existing `test_accept_admin_fails_if_not_nominated` already covers the accept-without-pending panic path (`"no admin transfer pending"`)

### `docs/interfaces/settlement.json`
- Add `get_pending_admin` entry: returns `Address | null`, no panics, no auth

## No logic changes
Only additive — new view function and tests.