### PR TITLE
fix(vault): remove duplicate DuplicateRequestId variant and Settlemen…

### DIFF
--- a/contracts/vault/src/lib.rs
+++ b/contracts/vault/src/lib.rs
@@ -87,8 +87,6 @@ pub enum VaultError {
     BatchEmpty = 21,
     /// Batch size exceeds maximum allowed (code 22).
     BatchTooLarge = 22,
-    /// Duplicate request ID detected (code 23).
-    DuplicateRequestId = 29,
     /// New owner must be different from current owner (code 23).
     NewOwnerSameAsCurrent = 23,
     /// No ownership transfer is pending (code 24).
@@ -101,7 +99,7 @@ pub enum VaultError {
     MetadataTooLong = 27,
     /// Price parsing error or non‑positive price (code 28).
     PriceParseError = 28,
-    /// Duplicate request ID (code 29).
+    /// Duplicate request ID detected (code 29).
     DuplicateRequestId = 29,
 }
 
@@ -184,17 +182,6 @@ pub const INSTANCE_BUMP_AMOUNT: u32 = 17_280 * 60; // ~60 days
 // After the TTL expires the marker is archived and the request_id can be reused.
 pub const REQUEST_ID_BUMP_THRESHOLD: u32 = 17_280 * 7; // ~7 days
 pub const REQUEST_ID_BUMP_AMOUNT: u32 = 17_280 * 30; // ~30 days
-
-#[soroban_sdk::contractclient(name = "SettlementClient")]
-trait SettlementTrait {
-    fn receive_payment(
-        env: Env,
-        caller: Address,
-        amount: i128,
-        to_pool: bool,
-        developer: Option<Address>,
-    );
-}
 
 #[contract]
 pub struct CalloraVault;

--- a/contracts/vault/src/test_idempotency.rs
+++ b/contracts/vault/src/test_idempotency.rs
@@ -66,6 +66,12 @@ fn setup_vault(env: &Env, balance: i128) -> (Address, CalloraVaultClient<'_>, Ad
 // deduct — single call idempotency
 // ---------------------------------------------------------------------------
 
+/// Pin the numeric error code so a future renumber regression is caught immediately.
+#[test]
+fn duplicate_request_id_error_code_is_29() {
+    assert_eq!(VaultError::DuplicateRequestId as u32, 29);
+}
+
 /// A `Some(request_id)` deduct succeeds on first call and is rejected on retry.
 #[test]
 fn deduct_duplicate_request_id_rejected() {

--- a/docs/interfaces/vault.json
+++ b/docs/interfaces/vault.json
@@ -35,7 +35,8 @@
       { "code": 25, "name": "NoAdminTransferPending", "description": "No admin transfer is pending." },
       { "code": 26, "name": "OfferingIdTooLong", "description": "Offering ID exceeds maximum length." },
       { "code": 27, "name": "MetadataTooLong", "description": "Metadata exceeds maximum length." },
-      { "code": 28, "name": "PriceParseError", "description": "Price parsing error or non‑positive price." }
+      { "code": 28, "name": "PriceParseError", "description": "Price parsing error or non‑positive price." },
+      { "code": 29, "name": "DuplicateRequestId", "description": "Duplicate request ID detected; this request_id has already been processed." }
     ]
   },
 


### PR DESCRIPTION
…tClient

The VaultError enum declared DuplicateRequestId = 29 twice and two traits both generated a SettlementClient, breaking compilation (E0428/E0081/E0592/ E0034/E0004). Collapse to a single definition each; error code stays 29.

- Remove first DuplicateRequestId arm (wrong doc comment 'code 23')
- Fix surviving arm doc to correctly state 'code 29'
- Delete SettlementTrait block; only trait Settlement remains
- Add docs/interfaces/vault.json error code 29 entry
- Add test pinning DuplicateRequestId discriminant to 29