### PR TITLE
feat(revenue_pool): typed errors for batch_distribute size violations + chunk_iter (#418)

### DIFF
--- a/contracts/revenue_pool/BATCH_TRANSFER_IMPLEMENTATION.md
+++ b/contracts/revenue_pool/BATCH_TRANSFER_IMPLEMENTATION.md
@@ -2,6 +2,7 @@
 
 **Date:** 2026-04-24  
 **Updated:** 2026-05-27 — duplicate recipient detection added  
+**Updated:** 2026-06-25 — typed size-violation errors (`RevenuePoolError`) and `chunk_iter` helper added (#418)  
 **Feature:** Atomic batch transfer with all-or-nothing execution and duplicate-recipient rejection
 
 ---
@@ -52,7 +53,8 @@ payments.push_back((developer, 2_500)); // aggregated
 - Verifies caller is the current admin via `require_auth()` + explicit address check.
 
 ### Phase 1: Precomputation, Validation & Duplicate Detection
-- Rejects empty batches and batches exceeding `MAX_BATCH_SIZE`.
+- Rejects empty batches and batches exceeding `MAX_BATCH_SIZE` with **typed errors**
+  ([`RevenuePoolError::BatchEmpty`] / [`RevenuePoolError::BatchTooLarge`]), not string panics.
 - Iterates all payments once, building a `Map<Address, bool>` seen-set.
 - Panics on the first duplicate address encountered.
 - Validates each amount is strictly positive and within `max_distribute`.
@@ -101,7 +103,18 @@ loop — well within budget for `MAX_BATCH_SIZE = 50`.
 
 ---
 
-## Error Constants
+## Errors
+
+Batch **size** violations are typed (`#[contracterror] RevenuePoolError`) so integrators
+branch on a numeric code, never a panic string:
+
+| Error | Code | Trigger |
+|---|---|---|
+| `RevenuePoolError::BatchEmpty` | `1` | `payments` is empty |
+| `RevenuePoolError::BatchTooLarge` | `2` | `payments.len() > MAX_BATCH_SIZE` |
+
+Remaining per-leg validations still panic with string constants (typed-error migration for
+these is tracked separately):
 
 | Constant | Value |
 |---|---|
@@ -131,8 +144,73 @@ successful batch.
 ## Batch Size Policy
 
 - **Hard cap:** `MAX_BATCH_SIZE = 50` entries per call.
-- **Minimum:** 1 entry (empty batch panics).
-- For larger distributions, split into multiple transactions off-chain.
+- **Minimum:** 1 entry.
+- Size violations return **typed errors** instead of string panics, so integrators
+  branch on a stable numeric code rather than matching panic text:
+
+| Condition | Error | Code |
+|---|---|---|
+| `payments.len() == 0` | `RevenuePoolError::BatchEmpty` | `1` |
+| `payments.len() > MAX_BATCH_SIZE` | `RevenuePoolError::BatchTooLarge` | `2` |
+
+`batch_distribute` returns `Result<(), RevenuePoolError>`. From the generated client,
+call `try_batch_distribute(...)` to receive `Err(Ok(RevenuePoolError::BatchTooLarge))`
+(or `BatchEmpty`) without triggering a host panic.
+
+---
+
+## Chunking Large Distributions
+
+To pay more than `MAX_BATCH_SIZE` developers, **pre-chunk** the payout list and submit one
+`batch_distribute` call per chunk. Every chunk is guaranteed to satisfy the cap, so no call
+ever returns `BatchTooLarge` and there is no panic string to parse.
+
+### On-chain helper: `chunk_iter`
+
+`chunk_iter(env, payments, chunk_size)` splits an ordered `Vec<(Address, i128)>` into
+consecutive chunks of at most `chunk_size` legs, preserving order. The last chunk may be
+shorter (a single remaining leg becomes a one-element chunk). An empty input — or a
+`chunk_size` of `0` — yields no chunks. It is a pure, read-only helper: no storage access,
+no auth, no token movement.
+
+```rust
+use callora_revenue_pool::{chunk_iter, MAX_BATCH_SIZE};
+
+// Distribute to an arbitrarily large list, MAX_BATCH_SIZE legs at a time.
+for chunk in chunk_iter(&env, payments, MAX_BATCH_SIZE).iter() {
+    pool.batch_distribute(&admin, &chunk); // each chunk is within the cap
+}
+```
+
+### Off-chain (TypeScript) integrators
+
+Backends typically build the payout list off-chain and chunk it before invoking the
+contract. Mirror `MAX_BATCH_SIZE = 50` and submit one transaction per chunk:
+
+```ts
+const MAX_BATCH_SIZE = 50; // must match the contract constant
+
+/** Split an ordered payout list into chunks of at most `size` legs. */
+function chunkPayments<T>(payments: T[], size: number = MAX_BATCH_SIZE): T[][] {
+  if (size <= 0) return [];
+  const chunks: T[][] = [];
+  for (let i = 0; i < payments.length; i += size) {
+    chunks.push(payments.slice(i, i + size));
+  }
+  return chunks;
+}
+
+// payments: Array<{ to: string; amount: bigint }>
+for (const chunk of chunkPayments(payments)) {
+  // Each chunk.length <= MAX_BATCH_SIZE, so batch_distribute never returns BatchTooLarge.
+  await pool.batch_distribute({ caller: admin, payments: chunk });
+}
+```
+
+> **Atomicity note:** each chunk is its own transaction. A failure in one chunk reverts only
+> that chunk, not previously-submitted chunks. Design retries to be idempotent (the
+> duplicate-recipient guard makes accidental re-submission of an already-paid leg safe to
+> reject).
 
 ---
 
@@ -149,7 +227,23 @@ Six new tests cover the duplicate-recipient feature (added to `test.rs`):
 | `batch_distribute_unique_recipients_succeeds` | Valid batch still works after the change |
 | `batch_distribute_duplicate_detected_before_balance_check` | Dedup fires in Phase 1, before Phase 2 balance check |
 
-Total test suite: **54 passing** (1 pre-existing failure in `upgrade_sets_version_and_emits_event`
+### Size-cap & chunking tests (#418)
+
+| Test | Boundary / behavior |
+|---|---|
+| `batch_distribute_empty_returns_typed_error` | length `0` → `RevenuePoolError::BatchEmpty` |
+| `batch_distribute_too_large_returns_typed_error` | length `MAX_BATCH_SIZE + 1` → `BatchTooLarge`, funds untouched |
+| `batch_distribute_at_max_size_succeeds` | length `MAX_BATCH_SIZE` → succeeds |
+| `chunk_iter_empty_input_yields_no_chunks` | empty input → `[]` |
+| `chunk_iter_zero_chunk_size_yields_no_chunks` | `chunk_size == 0` → `[]` |
+| `chunk_iter_single_leg_yields_one_chunk` | single-leg chunk |
+| `chunk_iter_exact_multiple` | even split (`[5, 5]`) |
+| `chunk_iter_with_remainder_has_single_leg_tail` | remainder tail (`[5, 5, 1]`) |
+| `chunk_iter_chunk_size_larger_than_input` | one chunk when `chunk_size > len` |
+| `chunk_iter_preserves_order_and_amounts` | order preserved across chunks |
+| `chunk_iter_chunks_each_distribute_within_cap` | `MAX_BATCH_SIZE + 1` legs pre-chunked → all distribute, pool drained |
+
+Total test suite: **62 passing** (1 pre-existing failure in `upgrade_sets_version_and_emits_event`
 due to a Soroban unit-test environment limitation — WASM upload is not supported in `Env::default()`).
 
 ---
@@ -188,3 +282,6 @@ due to a Soroban unit-test environment limitation — WASM upload is not support
 - [x] `/// doc` comments updated on `batch_distribute`
 - [x] Policy documented in this file
 - [x] No `unwrap()` in production paths
+- [x] Typed `RevenuePoolError::{BatchEmpty, BatchTooLarge}` replace size-violation string panics (#418)
+- [x] `chunk_iter` helper for backend pre-chunking, with Rust + TypeScript usage documented
+- [x] Boundary tests for length `0`, `MAX_BATCH_SIZE`, and `MAX_BATCH_SIZE + 1`

--- a/contracts/revenue_pool/src/lib.rs
+++ b/contracts/revenue_pool/src/lib.rs
@@ -1,6 +1,8 @@
 #![no_std]
 
-use soroban_sdk::{contract, contractimpl, token, Address, BytesN, Env, Map, Symbol, Vec};
+use soroban_sdk::{
+    contract, contracterror, contractimpl, token, Address, BytesN, Env, Map, Symbol, Vec,
+};
 
 /// Revenue settlement contract: receives USDC from vault deducts and distributes to developers.
 ///
@@ -23,7 +25,25 @@ const ERR_UNAUTHORIZED: &str = "unauthorized: caller is not admin";
 const ERR_INSUFFICIENT_BALANCE: &str = "insufficient USDC balance";
 const ERR_NOT_INITIALIZED: &str = "revenue pool not initialized";
 const ERR_DUPLICATE_RECIPIENT: &str = "duplicate recipient in batch";
+const PAUSED_KEY: &str = "paused";
+const ERR_PAUSED: &str = "revenue pool is paused";
 const VERSION_KEY: &str = "version";
+
+/// Typed contract errors for the revenue pool.
+///
+/// Returned (instead of string panics) for batch-size violations so backend
+/// integrators can branch on a stable numeric code rather than parsing panic
+/// strings. See [`chunk_iter`] for pre-chunking large payout lists to avoid
+/// [`RevenuePoolError::BatchTooLarge`] entirely.
+#[contracterror]
+#[repr(u32)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+pub enum RevenuePoolError {
+    /// `batch_distribute` was called with an empty `payments` vector (code 1).
+    BatchEmpty = 1,
+    /// `batch_distribute` received more than [`MAX_BATCH_SIZE`] payment legs (code 2).
+    BatchTooLarge = 2,
+}
 
 pub const DEFAULT_MAX_DISTRIBUTE: i128 = i128::MAX;
 
@@ -415,9 +435,14 @@ impl RevenuePool {
     ///   Must contain between 1 and [`MAX_BATCH_SIZE`] entries (inclusive).
     ///   Each `Address` must be unique within the vector.
     ///
+    /// # Errors
+    /// Returns a typed [`RevenuePoolError`] for batch-size violations so callers can
+    /// branch on a stable numeric code without parsing panic strings:
+    /// * [`RevenuePoolError::BatchEmpty`] if `payments` is empty.
+    /// * [`RevenuePoolError::BatchTooLarge`] if `payments` exceeds [`MAX_BATCH_SIZE`] entries.
+    ///   Use [`chunk_iter`] to pre-split large payout lists and avoid this error.
+    ///
     /// # Panics
-    /// * If `payments` is empty (`"batch_distribute requires at least one payment"`).
-    /// * If `payments` exceeds [`MAX_BATCH_SIZE`] entries (`"batch too large"`).
     /// * If the caller is not the current admin (`"unauthorized: caller is not admin"`).
     /// * If any individual amount is zero or negative (`"amount must be positive"`).
     /// * If any individual amount exceeds `max_distribute` (`"amount exceeds max_distribute"`).
@@ -452,7 +477,11 @@ impl RevenuePool {
     /// ];
     /// pool.batch_distribute(&admin, &bad_payments); // panics
     /// ```
-    pub fn batch_distribute(env: Env, caller: Address, payments: Vec<(Address, i128)>) {
+    pub fn batch_distribute(
+        env: Env,
+        caller: Address,
+        payments: Vec<(Address, i128)>,
+    ) -> Result<(), RevenuePoolError> {
         // Phase 0: Authorization
         caller.require_auth();
         Self::require_not_paused(&env);
@@ -461,12 +490,14 @@ impl RevenuePool {
             panic!("{}", ERR_UNAUTHORIZED);
         }
 
+        // Size guards return typed errors so backend integrators can branch on a
+        // stable code instead of parsing panic strings. See `chunk_iter`.
         let n = payments.len();
         if n == 0 {
-            panic!("batch_distribute requires at least one payment");
+            return Err(RevenuePoolError::BatchEmpty);
         }
         if n > MAX_BATCH_SIZE {
-            panic!("batch too large");
+            return Err(RevenuePoolError::BatchTooLarge);
         }
 
         // Phase 1: Precomputation, validation, and duplicate detection.
@@ -531,6 +562,8 @@ impl RevenuePool {
             env.events()
                 .publish((Symbol::new(&env, "batch_distribute"), to), amount);
         }
+
+        Ok(())
     }
 
     /// Return this contract's USDC balance (for testing and dashboards).
@@ -589,6 +622,57 @@ impl RevenuePool {
             .get(&Symbol::new(&env, VERSION_KEY))
             .expect("version not set")
     }
+}
+
+/// Split `payments` into consecutive chunks of at most `chunk_size` legs each,
+/// preserving order.
+///
+/// Intended for backend integrators who need to distribute to more than
+/// [`MAX_BATCH_SIZE`] developers: pre-chunk the full payout list and submit one
+/// [`RevenuePool::batch_distribute`] call per chunk. Every chunk is guaranteed to
+/// satisfy the size cap, so no call ever returns [`RevenuePoolError::BatchTooLarge`],
+/// and there is no panic string to parse.
+///
+/// The last chunk may contain fewer than `chunk_size` entries. An empty `payments`
+/// vector — or a `chunk_size` of `0` — yields an empty result (no chunks). A single
+/// remaining leg produces a one-element chunk.
+///
+/// This is a pure, read-only helper: it performs no storage access, no
+/// authorization, and moves no tokens.
+///
+/// # Examples
+/// ```ignore
+/// // Distribute to an arbitrarily large list, MAX_BATCH_SIZE legs at a time.
+/// for chunk in chunk_iter(&env, payments, MAX_BATCH_SIZE).iter() {
+///     pool.batch_distribute(&admin, &chunk);
+/// }
+/// ```
+pub fn chunk_iter(
+    env: &Env,
+    payments: Vec<(Address, i128)>,
+    chunk_size: u32,
+) -> Vec<Vec<(Address, i128)>> {
+    let mut chunks: Vec<Vec<(Address, i128)>> = Vec::new(env);
+    // A zero chunk size has no well-defined chunking; return no chunks rather
+    // than looping forever.
+    if chunk_size == 0 {
+        return chunks;
+    }
+
+    let mut current: Vec<(Address, i128)> = Vec::new(env);
+    for payment in payments.iter() {
+        current.push_back(payment);
+        if current.len() == chunk_size {
+            chunks.push_back(current);
+            current = Vec::new(env);
+        }
+    }
+    // Flush the trailing partial chunk, if any.
+    if !current.is_empty() {
+        chunks.push_back(current);
+    }
+
+    chunks
 }
 
 #[cfg(test)]

--- a/contracts/revenue_pool/src/test.rs
+++ b/contracts/revenue_pool/src/test.rs
@@ -1792,8 +1792,8 @@ fn get_usdc_token_before_init_panics() {
 // ---------------------------------------------------------------------------
 
 #[test]
-#[should_panic(expected = "batch_distribute requires at least one payment")]
-fn batch_distribute_empty_panics() {
+fn batch_distribute_empty_returns_typed_error() {
+    // Boundary: length == 0 must surface RevenuePoolError::BatchEmpty (no string panic).
     let env = Env::default();
     env.mock_all_auths();
     let admin = Address::generate(&env);
@@ -1803,17 +1803,18 @@ fn batch_distribute_empty_panics() {
     client.init(&admin, &usdc_address);
 
     let payments: Vec<(Address, i128)> = Vec::new(&env);
-    client.batch_distribute(&admin, &payments);
+    let res = client.try_batch_distribute(&admin, &payments);
+    assert_eq!(res, Err(Ok(RevenuePoolError::BatchEmpty)));
 }
 
 #[test]
-#[should_panic(expected = "batch too large")]
-fn batch_distribute_too_large_panics() {
+fn batch_distribute_too_large_returns_typed_error() {
+    // Boundary: length == MAX_BATCH_SIZE + 1 must surface RevenuePoolError::BatchTooLarge.
     let env = Env::default();
     env.mock_all_auths();
     let admin = Address::generate(&env);
     let (pool_addr, client) = create_pool(&env);
-    let (usdc_address, _, usdc_admin) = create_usdc(&env, &admin);
+    let (usdc_address, usdc_client, usdc_admin) = create_usdc(&env, &admin);
 
     client.init(&admin, &usdc_address);
     fund_pool(&usdc_admin, &pool_addr, 100_000);
@@ -1823,7 +1824,11 @@ fn batch_distribute_too_large_panics() {
     for _ in 0..=crate::MAX_BATCH_SIZE {
         payments.push_back((Address::generate(&env), 1_i128));
     }
-    client.batch_distribute(&admin, &payments);
+    let res = client.try_batch_distribute(&admin, &payments);
+    assert_eq!(res, Err(Ok(RevenuePoolError::BatchTooLarge)));
+
+    // Atomicity: a rejected oversized batch must not move any funds.
+    assert_eq!(usdc_client.balance(&pool_addr), 100_000);
 }
 
 #[test]
@@ -1847,6 +1852,134 @@ fn batch_distribute_at_max_size_succeeds() {
     client.batch_distribute(&admin, &payments);
 
     // Pool should be drained
+    assert_eq!(usdc_client.balance(&pool_addr), 0);
+}
+
+// ---------------------------------------------------------------------------
+// chunk_iter helper tests — backend pre-chunking of large payout lists (#418)
+// ---------------------------------------------------------------------------
+
+fn make_payments(env: &Env, count: u32) -> Vec<(Address, i128)> {
+    let mut payments: Vec<(Address, i128)> = Vec::new(env);
+    for i in 0..count {
+        // Amounts are 1..=count so order can be asserted after chunking.
+        payments.push_back((Address::generate(env), (i as i128) + 1));
+    }
+    payments
+}
+
+fn total_legs(chunks: &Vec<Vec<(Address, i128)>>) -> u32 {
+    let mut total = 0u32;
+    for chunk in chunks.iter() {
+        total += chunk.len();
+    }
+    total
+}
+
+#[test]
+fn chunk_iter_empty_input_yields_no_chunks() {
+    let env = Env::default();
+    let payments: Vec<(Address, i128)> = Vec::new(&env);
+    let chunks = crate::chunk_iter(&env, payments, crate::MAX_BATCH_SIZE);
+    assert_eq!(chunks.len(), 0);
+}
+
+#[test]
+fn chunk_iter_zero_chunk_size_yields_no_chunks() {
+    let env = Env::default();
+    let payments = make_payments(&env, 5);
+    let chunks = crate::chunk_iter(&env, payments, 0);
+    assert_eq!(chunks.len(), 0);
+}
+
+#[test]
+fn chunk_iter_single_leg_yields_one_chunk() {
+    let env = Env::default();
+    let payments = make_payments(&env, 1);
+    let chunks = crate::chunk_iter(&env, payments, crate::MAX_BATCH_SIZE);
+    assert_eq!(chunks.len(), 1);
+    assert_eq!(chunks.get(0).unwrap().len(), 1);
+}
+
+#[test]
+fn chunk_iter_exact_multiple() {
+    let env = Env::default();
+    let payments = make_payments(&env, 10);
+    let chunks = crate::chunk_iter(&env, payments, 5);
+    assert_eq!(chunks.len(), 2);
+    assert_eq!(chunks.get(0).unwrap().len(), 5);
+    assert_eq!(chunks.get(1).unwrap().len(), 5);
+    assert_eq!(total_legs(&chunks), 10);
+}
+
+#[test]
+fn chunk_iter_with_remainder_has_single_leg_tail() {
+    let env = Env::default();
+    // 11 legs in chunks of 5 → [5, 5, 1]; the tail is a single-leg chunk.
+    let payments = make_payments(&env, 11);
+    let chunks = crate::chunk_iter(&env, payments, 5);
+    assert_eq!(chunks.len(), 3);
+    assert_eq!(chunks.get(0).unwrap().len(), 5);
+    assert_eq!(chunks.get(1).unwrap().len(), 5);
+    assert_eq!(chunks.get(2).unwrap().len(), 1);
+    assert_eq!(total_legs(&chunks), 11);
+}
+
+#[test]
+fn chunk_iter_chunk_size_larger_than_input() {
+    let env = Env::default();
+    let payments = make_payments(&env, 3);
+    let chunks = crate::chunk_iter(&env, payments, crate::MAX_BATCH_SIZE);
+    assert_eq!(chunks.len(), 1);
+    assert_eq!(chunks.get(0).unwrap().len(), 3);
+}
+
+#[test]
+fn chunk_iter_preserves_order_and_amounts() {
+    let env = Env::default();
+    let payments = make_payments(&env, 7); // amounts 1..=7
+    let chunks = crate::chunk_iter(&env, payments, 3); // [3, 3, 1]
+    // Flatten and assert amounts return in order 1,2,3,4,5,6,7.
+    let mut expected: i128 = 1;
+    for chunk in chunks.iter() {
+        for (_, amount) in chunk.iter() {
+            assert_eq!(amount, expected);
+            expected += 1;
+        }
+    }
+    assert_eq!(expected, 8);
+}
+
+#[test]
+fn chunk_iter_chunks_each_distribute_within_cap() {
+    // Integration: a payout list larger than MAX_BATCH_SIZE, pre-chunked, must
+    // distribute leg-by-leg with no BatchTooLarge error.
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let (pool_addr, client) = create_pool(&env);
+    let (usdc_address, usdc_client, usdc_admin) = create_usdc(&env, &admin);
+    client.init(&admin, &usdc_address);
+
+    let leg_count = crate::MAX_BATCH_SIZE + 1; // forces 2 chunks
+    let amount_per = 10_i128;
+    let total = amount_per * (leg_count as i128);
+    fund_pool(&usdc_admin, &pool_addr, total);
+
+    let mut payments: Vec<(Address, i128)> = Vec::new(&env);
+    for _ in 0..leg_count {
+        payments.push_back((Address::generate(&env), amount_per));
+    }
+
+    let chunks = crate::chunk_iter(&env, payments, crate::MAX_BATCH_SIZE);
+    assert_eq!(chunks.len(), 2);
+    for chunk in chunks.iter() {
+        assert!(chunk.len() <= crate::MAX_BATCH_SIZE);
+        let res = client.try_batch_distribute(&admin, &chunk);
+        assert_eq!(res, Ok(Ok(())));
+    }
+
+    // Whole payout delivered; pool drained.
     assert_eq!(usdc_client.balance(&pool_addr), 0);
 }
 


### PR DESCRIPTION
Closes #418

## What

`batch_distribute` previously panicked with raw strings on size violations
(`"batch_distribute requires at least one payment"`, `"batch too large"`). This
replaces those with a typed `RevenuePoolError` enum and adds a `chunk_iter`
helper so backend integrators can pre-chunk large payout lists without ever
hitting the cap.

## Changes

- **Typed errors** — new `#[contracterror] RevenuePoolError`:
  | Code | Variant | Trigger |
  |---|---|---|
  | 1 | `BatchEmpty` | `payments.len() == 0` |
  | 2 | `BatchTooLarge` | `payments.len() > MAX_BATCH_SIZE` |

  `batch_distribute` now returns `Result<(), RevenuePoolError>`. Callers use
  `try_batch_distribute(...)` and match `Err(Ok(RevenuePoolError::BatchTooLarge))`
  — no panic-string parsing.

- **`chunk_iter(env, payments, chunk_size)`** — pure, read-only helper that splits
  an ordered `Vec<(Address, i128)>` into `chunk_size`-bounded chunks (order
  preserved, single-leg tail, empty/zero-size → no chunks). Every chunk satisfies
  `MAX_BATCH_SIZE`, so chunked distributions never return `BatchTooLarge`.

- **Docs** — `BATCH_TRANSFER_IMPLEMENTATION.md` updated with the error table, a
  Chunking section, and both Rust and **TypeScript** pre-chunking snippets for
  backend integrators.

## Tests (`cargo test -p callora-revenue-pool`)

Boundary cases required by the issue — length `0`, `MAX_BATCH_SIZE`,
`MAX_BATCH_SIZE + 1` — plus `chunk_iter` coverage (empty, zero chunk size,
single-leg, exact multiple, remainder tail, oversized chunk size, order
preservation, and an end-to-end pre-chunked distribution that drains the pool).

**Result: 62 passed, 1 failed.** The single failure is the **pre-existing**
`upgrade_sets_version_and_emits_event`, which fails on `main` as well — Soroban's
`Env::default()` does not support WASM upload for `update_current_contract_wasm`.
It is unrelated to this change (already noted in the doc).

## Note on build prerequisite

`main` currently does **not compile**: `revenue_pool/src/lib.rs` references
`PAUSED_KEY` / `ERR_PAUSED` which are never defined (tracked by #433). Building
or testing anything in this crate is impossible without them, so this PR adds the
two minimal `const` definitions purely as a build-unblock. It does **not** attempt
the broader pause typed-error migration — that remains for its own issue.

## Acceptance criteria

- [x] No remaining string panics for size violations
- [x] Backend docs explain chunking with a concrete TS snippet
- [x] Tests cover the three boundary cases
