### PR TITLE
sec(vault): tighten validation on set_metadata and set_price inputs

### DIFF
--- a/contracts/vault/src/lib.rs
+++ b/contracts/vault/src/lib.rs
@@ -101,6 +101,10 @@ pub enum VaultError {
     PriceParseError = 28,
     /// Duplicate request ID detected (code 29).
     DuplicateRequestId = 29,
+    /// Offering ID is empty or contains invalid characters (code 30).
+    OfferingIdInvalid = 30,
+    /// Metadata string is empty or contains invalid characters (code 31).
+    MetadataInvalid = 31,
 }
 
 #[contracttype]
@@ -990,6 +994,27 @@ impl CalloraVault {
         Ok(())
     }
 
+    /// Validate that a vault input string is non-empty, contains no control
+    /// characters (0x00–0x1F, 0x7F), and has no leading/trailing whitespace.
+    fn validate_vault_input(s: &String) -> Result<(), ()> {
+        let len = s.len();
+        if len == 0 {
+            return Err(());
+        }
+        let mut buf = [0u8; 256];
+        s.copy_into_slice(&mut buf[..len as usize]);
+        let bytes = &buf[..len as usize];
+        for &b in bytes {
+            if b <= 0x1F || b == 0x7F {
+                return Err(());
+            }
+        }
+        if bytes[0] == 0x20 || bytes[len as usize - 1] == 0x20 {
+            return Err(());
+        }
+        Ok(())
+    }
+
     pub fn set_metadata(
         env: Env,
         caller: Address,
@@ -998,6 +1023,12 @@ impl CalloraVault {
     ) -> Result<String, VaultError> {
         caller.require_auth();
         Self::require_owner(env.clone(), caller.clone())?;
+        if Self::validate_vault_input(&offering_id).is_err() {
+            return Err(VaultError::OfferingIdInvalid);
+        }
+        if Self::validate_vault_input(&metadata).is_err() {
+            return Err(VaultError::MetadataInvalid);
+        }
         if offering_id.len() > MAX_OFFERING_ID_LEN {
             return Err(VaultError::OfferingIdTooLong);
         }
@@ -1022,12 +1053,16 @@ impl CalloraVault {
     pub fn set_price(env: Env, caller: Address, offering_id: String, price: String) -> Result<(), VaultError> {
         caller.require_auth();
         Self::require_owner(env.clone(), caller.clone())?;
+        if Self::validate_vault_input(&offering_id).is_err() {
+            return Err(VaultError::OfferingIdInvalid);
+        }
         if offering_id.len() > MAX_OFFERING_ID_LEN {
             return Err(VaultError::OfferingIdTooLong);
         }
         let mut price_buf = [0u8; 64];
-        price.copy_into_slice(&mut price_buf);
-        let price_str = core::str::from_utf8(&price_buf[..price.len() as usize])
+        let price_len = price.len() as usize;
+        price.copy_into_slice(&mut price_buf[..price_len]);
+        let price_str = core::str::from_utf8(&price_buf[..price_len])
             .map_err(|_| VaultError::PriceParseError)?;
         let price_i128: i128 = price_str.parse().map_err(|_| VaultError::PriceParseError)?;
         if price_i128 <= 0 {

--- a/contracts/vault/src/test_setter_validation.rs
+++ b/contracts/vault/src/test_setter_validation.rs
@@ -98,3 +98,241 @@ fn set_revenue_pool_vault_address_fails() {
     let result = client.try_set_revenue_pool(&admin, &Some(vault_addr));
     assert!(result.is_err());
 }
+
+// ---------------------------------------------------------------------------
+// set_metadata input validation (length / charset hardening)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn set_metadata_empty_offering_id_fails() {
+    let env = Env::default();
+    let (_, client, _, admin) = setup(&env);
+    let result = client.try_set_metadata(
+        &admin,
+        &String::from_str(&env, ""),
+        &String::from_str(&env, "valid"),
+    );
+    assert_eq!(result, Err(Ok(VaultError::OfferingIdInvalid)));
+}
+
+#[test]
+fn set_metadata_null_byte_in_offering_id_fails() {
+    let env = Env::default();
+    let (_, client, _, admin) = setup(&env);
+    let result = client.try_set_metadata(
+        &admin,
+        &String::from_str(&env, "off\x00ering"),
+        &String::from_str(&env, "valid"),
+    );
+    assert_eq!(result, Err(Ok(VaultError::OfferingIdInvalid)));
+}
+
+#[test]
+fn set_metadata_control_char_in_offering_id_fails() {
+    let env = Env::default();
+    let (_, client, _, admin) = setup(&env);
+    let result = client.try_set_metadata(
+        &admin,
+        &String::from_str(&env, "off\x01ering"),
+        &String::from_str(&env, "valid"),
+    );
+    assert_eq!(result, Err(Ok(VaultError::OfferingIdInvalid)));
+}
+
+#[test]
+fn set_metadata_leading_space_offering_id_fails() {
+    let env = Env::default();
+    let (_, client, _, admin) = setup(&env);
+    let result = client.try_set_metadata(
+        &admin,
+        &String::from_str(&env, " off1"),
+        &String::from_str(&env, "valid"),
+    );
+    assert_eq!(result, Err(Ok(VaultError::OfferingIdInvalid)));
+}
+
+#[test]
+fn set_metadata_trailing_space_offering_id_fails() {
+    let env = Env::default();
+    let (_, client, _, admin) = setup(&env);
+    let result = client.try_set_metadata(
+        &admin,
+        &String::from_str(&env, "off1 "),
+        &String::from_str(&env, "valid"),
+    );
+    assert_eq!(result, Err(Ok(VaultError::OfferingIdInvalid)));
+}
+
+#[test]
+fn set_metadata_whitespace_only_offering_id_fails() {
+    let env = Env::default();
+    let (_, client, _, admin) = setup(&env);
+    let result = client.try_set_metadata(
+        &admin,
+        &String::from_str(&env, "   "),
+        &String::from_str(&env, "valid"),
+    );
+    assert_eq!(result, Err(Ok(VaultError::OfferingIdInvalid)));
+}
+
+#[test]
+fn set_metadata_empty_metadata_fails() {
+    let env = Env::default();
+    let (_, client, _, admin) = setup(&env);
+    let result = client.try_set_metadata(
+        &admin,
+        &String::from_str(&env, "off1"),
+        &String::from_str(&env, ""),
+    );
+    assert_eq!(result, Err(Ok(VaultError::MetadataInvalid)));
+}
+
+#[test]
+fn set_metadata_null_byte_in_metadata_fails() {
+    let env = Env::default();
+    let (_, client, _, admin) = setup(&env);
+    let result = client.try_set_metadata(
+        &admin,
+        &String::from_str(&env, "off1"),
+        &String::from_str(&env, "meta\x00data"),
+    );
+    assert_eq!(result, Err(Ok(VaultError::MetadataInvalid)));
+}
+
+#[test]
+fn set_metadata_control_char_in_metadata_fails() {
+    let env = Env::default();
+    let (_, client, _, admin) = setup(&env);
+    let result = client.try_set_metadata(
+        &admin,
+        &String::from_str(&env, "off1"),
+        &String::from_str(&env, "meta\x1Fdata"),
+    );
+    assert_eq!(result, Err(Ok(VaultError::MetadataInvalid)));
+}
+
+#[test]
+fn set_metadata_leading_space_metadata_fails() {
+    let env = Env::default();
+    let (_, client, _, admin) = setup(&env);
+    let result = client.try_set_metadata(
+        &admin,
+        &String::from_str(&env, "off1"),
+        &String::from_str(&env, " metadata"),
+    );
+    assert_eq!(result, Err(Ok(VaultError::MetadataInvalid)));
+}
+
+#[test]
+fn set_metadata_trailing_space_metadata_fails() {
+    let env = Env::default();
+    let (_, client, _, admin) = setup(&env);
+    let result = client.try_set_metadata(
+        &admin,
+        &String::from_str(&env, "off1"),
+        &String::from_str(&env, "metadata "),
+    );
+    assert_eq!(result, Err(Ok(VaultError::MetadataInvalid)));
+}
+
+#[test]
+fn set_metadata_whitespace_only_metadata_fails() {
+    let env = Env::default();
+    let (_, client, _, admin) = setup(&env);
+    let result = client.try_set_metadata(
+        &admin,
+        &String::from_str(&env, "off1"),
+        &String::from_str(&env, "   "),
+    );
+    assert_eq!(result, Err(Ok(VaultError::MetadataInvalid)));
+}
+
+#[test]
+fn set_metadata_exact_max_length_succeeds() {
+    let env = Env::default();
+    let (_, client, _, admin) = setup(&env);
+    let offering_id = "a".repeat(MAX_OFFERING_ID_LEN as usize);
+    let metadata = "b".repeat(MAX_METADATA_LEN as usize);
+    let result = client.set_metadata(
+        &admin,
+        &String::from_str(&env, &offering_id),
+        &String::from_str(&env, &metadata),
+    );
+    assert_eq!(result, String::from_str(&env, &metadata));
+}
+
+// ---------------------------------------------------------------------------
+// set_price offering_id input validation (length / charset hardening)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn set_price_empty_offering_id_fails() {
+    let env = Env::default();
+    let (_, client, _, admin) = setup(&env);
+    let result = client.try_set_price(
+        &admin,
+        &String::from_str(&env, ""),
+        &String::from_str(&env, "100"),
+    );
+    assert_eq!(result, Err(Ok(VaultError::OfferingIdInvalid)));
+}
+
+#[test]
+fn set_price_null_byte_in_offering_id_fails() {
+    let env = Env::default();
+    let (_, client, _, admin) = setup(&env);
+    let result = client.try_set_price(
+        &admin,
+        &String::from_str(&env, "off\x00ering"),
+        &String::from_str(&env, "100"),
+    );
+    assert_eq!(result, Err(Ok(VaultError::OfferingIdInvalid)));
+}
+
+#[test]
+fn set_price_control_char_in_offering_id_fails() {
+    let env = Env::default();
+    let (_, client, _, admin) = setup(&env);
+    let result = client.try_set_price(
+        &admin,
+        &String::from_str(&env, "off\x01ering"),
+        &String::from_str(&env, "100"),
+    );
+    assert_eq!(result, Err(Ok(VaultError::OfferingIdInvalid)));
+}
+
+#[test]
+fn set_price_leading_space_offering_id_fails() {
+    let env = Env::default();
+    let (_, client, _, admin) = setup(&env);
+    let result = client.try_set_price(
+        &admin,
+        &String::from_str(&env, " off1"),
+        &String::from_str(&env, "100"),
+    );
+    assert_eq!(result, Err(Ok(VaultError::OfferingIdInvalid)));
+}
+
+#[test]
+fn set_price_trailing_space_offering_id_fails() {
+    let env = Env::default();
+    let (_, client, _, admin) = setup(&env);
+    let result = client.try_set_price(
+        &admin,
+        &String::from_str(&env, "off1 "),
+        &String::from_str(&env, "100"),
+    );
+    assert_eq!(result, Err(Ok(VaultError::OfferingIdInvalid)));
+}
+
+#[test]
+fn set_price_whitespace_only_offering_id_fails() {
+    let env = Env::default();
+    let (_, client, _, admin) = setup(&env);
+    let result = client.try_set_price(
+        &admin,
+        &String::from_str(&env, "   "),
+        &String::from_str(&env, "100"),
+    );
+    assert_eq!(result, Err(Ok(VaultError::OfferingIdInvalid)));
+}


### PR DESCRIPTION
Add string content validation that rejects empty strings, null bytes, non-ASCII control characters (0x00-0x1F, 0x7F), and leading/trailing whitespace in offering_id and metadata parameters.

- New VaultError::OfferingIdInvalid (30) and MetadataInvalid (31)
- Introduced validate_vault_input helper for reusable byte-level checks
- Applied validation to set_metadata (offering_id + metadata) and set_price (offering_id) before existing length checks
- Also fixed a pre-existing copy_into_slice buffer-size mismatch in set_price that surfaced with updated Soroban SDK
- 19 new test cases cover: empty, null byte, control char, leading space, trailing space, whitespace-only, and exact-length boundary
- All existing passing tests continue to pass

closes: #438 