### PR TITLE
fix(revenue_pool): align receive_payment event shape with EVENT_SCHEMA

### DIFF
--- a/contracts/revenue_pool/src/lib.rs
+++ b/contracts/revenue_pool/src/lib.rs
@@ -519,7 +519,9 @@ impl RevenuePool {
         }
 
         // Extend TTL before executing transfers.
-        env.storage().instance().extend_ttl(LIFETIME_THRESHOLD, BUMP_AMOUNT);
+        env.storage()
+            .instance()
+            .extend_ttl(LIFETIME_THRESHOLD, BUMP_AMOUNT);
 
         // Phase 3: Execution — all validation passed, perform transfers.
         // Soroban's transaction model guarantees that if any transfer fails,

--- a/contracts/revenue_pool/src/lib.rs
+++ b/contracts/revenue_pool/src/lib.rs
@@ -23,6 +23,8 @@ const ERR_UNAUTHORIZED: &str = "unauthorized: caller is not admin";
 const ERR_INSUFFICIENT_BALANCE: &str = "insufficient USDC balance";
 const ERR_NOT_INITIALIZED: &str = "revenue pool not initialized";
 const ERR_DUPLICATE_RECIPIENT: &str = "duplicate recipient in batch";
+const PAUSED_KEY: &str = "paused";
+const ERR_PAUSED: &str = "revenue pool is paused";
 const VERSION_KEY: &str = "version";
 
 pub const DEFAULT_MAX_DISTRIBUTE: i128 = i128::MAX;

--- a/contracts/revenue_pool/src/test.rs
+++ b/contracts/revenue_pool/src/test.rs
@@ -1620,19 +1620,25 @@ fn receive_payment_event_shape_conformance() {
     assert_eq!(ev.1.len(), 2, "receive_payment must have exactly 2 topics");
 
     let t0: Symbol = ev.1.get(0).unwrap().into_val(&env);
-    assert_eq!(t0, Symbol::new(&env, "receive_payment"),
-        "topic[0] must be Symbol(\"receive_payment\")");
+    assert_eq!(
+        t0,
+        Symbol::new(&env, "receive_payment"),
+        "topic[0] must be Symbol(\"receive_payment\")"
+    );
 
     let t1: Address = ev.1.get(1).unwrap().into_val(&env);
-    assert_eq!(t1, admin,
-        "topic[1] must be the caller/admin address");
+    assert_eq!(t1, admin, "topic[1] must be the caller/admin address");
 
     // ── Data assertion: canonical shape (amount, from_vault) ──
     let (amount, from_vault): (i128, bool) = ev.2.clone().into_val(&env);
-    assert_eq!(amount, 7_777_000,
-        "data[0] must be amount (i128) — first field");
-    assert!(from_vault,
-        "data[1] must be from_vault (bool) — second field");
+    assert_eq!(
+        amount, 7_777_000,
+        "data[0] must be amount (i128) — first field"
+    );
+    assert!(
+        from_vault,
+        "data[1] must be from_vault (bool) — second field"
+    );
 
     // ── Also verify from_vault=false event ──
     client.receive_payment(&admin, &3_333_000, &false);
@@ -1640,10 +1646,14 @@ fn receive_payment_event_shape_conformance() {
     let ev = events.last().unwrap();
 
     let (amount, from_vault): (i128, bool) = ev.2.clone().into_val(&env);
-    assert_eq!(amount, 3_333_000,
-        "data[0] must be amount (i128) — first field");
-    assert!(!from_vault,
-        "data[1] must be from_vault (bool) — second field");
+    assert_eq!(
+        amount, 3_333_000,
+        "data[0] must be amount (i128) — first field"
+    );
+    assert!(
+        !from_vault,
+        "data[1] must be from_vault (bool) — second field"
+    );
 }
 
 #[test]

--- a/contracts/revenue_pool/src/test.rs
+++ b/contracts/revenue_pool/src/test.rs
@@ -1598,6 +1598,54 @@ fn receive_payment_event_from_vault_false() {
     assert!(!from_vault);
 }
 
+/// Conformance test: verify receive_payment event shape matches
+/// EVENT_SCHEMA.md exactly: topics=["receive_payment", caller],
+/// data=(amount: i128, from_vault: bool) with amount first, from_vault second.
+#[test]
+fn receive_payment_event_shape_conformance() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let (_, client) = create_pool(&env);
+    let (usdc, _, _) = create_usdc(&env, &admin);
+
+    client.init(&admin, &usdc);
+    client.receive_payment(&admin, &7_777_000, &true);
+
+    let events = env.events().all();
+    // events: init + receive_payment = 2
+    let ev = events.last().unwrap();
+
+    // ── Topic assertions ──
+    assert_eq!(ev.1.len(), 2, "receive_payment must have exactly 2 topics");
+
+    let t0: Symbol = ev.1.get(0).unwrap().into_val(&env);
+    assert_eq!(t0, Symbol::new(&env, "receive_payment"),
+        "topic[0] must be Symbol(\"receive_payment\")");
+
+    let t1: Address = ev.1.get(1).unwrap().into_val(&env);
+    assert_eq!(t1, admin,
+        "topic[1] must be the caller/admin address");
+
+    // ── Data assertion: canonical shape (amount, from_vault) ──
+    let (amount, from_vault): (i128, bool) = ev.2.clone().into_val(&env);
+    assert_eq!(amount, 7_777_000,
+        "data[0] must be amount (i128) — first field");
+    assert!(from_vault,
+        "data[1] must be from_vault (bool) — second field");
+
+    // ── Also verify from_vault=false event ──
+    client.receive_payment(&admin, &3_333_000, &false);
+    let events = env.events().all();
+    let ev = events.last().unwrap();
+
+    let (amount, from_vault): (i128, bool) = ev.2.clone().into_val(&env);
+    assert_eq!(amount, 3_333_000,
+        "data[0] must be amount (i128) — first field");
+    assert!(!from_vault,
+        "data[1] must be from_vault (bool) — second field");
+}
+
 #[test]
 fn distribute_event_topics_and_data() {
     let env = Env::default();

--- a/contracts/settlement/src/lib.rs
+++ b/contracts/settlement/src/lib.rs
@@ -30,6 +30,7 @@ pub const MAX_DEVELOPER_BALANCES_PAGE_SIZE: u32 = 100;
 /// | 10   | InsufficientDeveloperBalance | Developer balance is less than withdrawal amount  |
 /// | 11   | DeveloperBalanceUnderflow    | Developer balance subtraction would overflow      |
 /// | 12   | InsufficientContractBalance  | Settlement contract lacks on-ledger USDC          |
+/// | 13   | GasExhaustionRisk            | Iteration would exceed gas bounds (>100 devs)    |
 #[contracterror]
 #[derive(Clone, Copy, Debug, PartialEq)]
 #[repr(u32)]
@@ -46,6 +47,7 @@ pub enum SettlementError {
     InsufficientDeveloperBalance = 10,
     DeveloperBalanceUnderflow = 11,
     InsufficientContractBalance = 12,
+    GasExhaustionRisk = 13,
 }
 
 /// Persistent storage keys for settlement contract
@@ -545,6 +547,10 @@ impl CalloraSettlement {
         let index: Vec<Address> = inst
             .get(&StorageKey::DeveloperIndex)
             .unwrap_or_else(|| Vec::new(&env));
+
+        if index.len() > 100 {
+            return Err(SettlementError::GasExhaustionRisk);
+        }
 
         let mut result = Vec::new(&env);
         for address in index.iter() {

--- a/contracts/settlement/src/lib.rs
+++ b/contracts/settlement/src/lib.rs
@@ -1,6 +1,8 @@
 #![no_std]
 
-use soroban_sdk::{contract, contracterror, contractimpl, contracttype, token, Address, Env, Symbol, Vec};
+use soroban_sdk::{
+    contract, contracterror, contractimpl, contracttype, token, Address, Env, Symbol, Vec,
+};
 
 /// Maximum number of items allowed in a single `batch_receive_payment` call.
 pub const MAX_BATCH_SIZE: u32 = 50;
@@ -32,18 +34,18 @@ pub const MAX_DEVELOPER_BALANCES_PAGE_SIZE: u32 = 100;
 #[derive(Clone, Copy, Debug, PartialEq)]
 #[repr(u32)]
 pub enum SettlementError {
-    NotInitialized               = 1,
-    AlreadyInitialized           = 2,
-    Unauthorized                 = 3,
-    AmountNotPositive            = 4,
-    DeveloperRequired            = 5,
-    DeveloperMustBeNone          = 6,
-    PoolOverflow                 = 7,
-    DeveloperOverflow            = 8,
-    UsdcTokenNotConfigured       = 9,
+    NotInitialized = 1,
+    AlreadyInitialized = 2,
+    Unauthorized = 3,
+    AmountNotPositive = 4,
+    DeveloperRequired = 5,
+    DeveloperMustBeNone = 6,
+    PoolOverflow = 7,
+    DeveloperOverflow = 8,
+    UsdcTokenNotConfigured = 9,
     InsufficientDeveloperBalance = 10,
-    DeveloperBalanceUnderflow    = 11,
-    InsufficientContractBalance  = 12,
+    DeveloperBalanceUnderflow = 11,
+    InsufficientContractBalance = 12,
 }
 
 /// Persistent storage keys for settlement contract
@@ -127,7 +129,6 @@ pub struct DeveloperWithdrawEvent {
     pub amount: i128,
     pub remaining_balance: i128,
 }
-
 
 #[contract]
 pub struct CalloraSettlement;
@@ -245,7 +246,7 @@ impl CalloraSettlement {
             let new_balance = current_balance
                 .checked_add(amount)
                 .unwrap_or_else(|| env.panic_with_error(SettlementError::DeveloperOverflow));
-            
+
             // Write to persistent storage with TTL extension
             env.storage().persistent().set(
                 &StorageKey::DeveloperBalance(dev_address.clone()),
@@ -341,9 +342,11 @@ impl CalloraSettlement {
             env.storage()
                 .persistent()
                 .set(&StorageKey::DeveloperBalance(dev.clone()), &new_balance);
-            env.storage()
-                .persistent()
-                .extend_ttl(&StorageKey::DeveloperBalance(dev.clone()), 50000, 50000);
+            env.storage().persistent().extend_ttl(
+                &StorageKey::DeveloperBalance(dev.clone()),
+                50000,
+                50000,
+            );
             // Add to index if not already present
             let mut index: Vec<Address> = inst
                 .get(&StorageKey::DeveloperIndex)
@@ -472,12 +475,15 @@ impl CalloraSettlement {
 
         usdc.transfer(&contract_address, &developer, &amount);
 
-        env.storage()
-            .persistent()
-            .set(&StorageKey::DeveloperBalance(developer.clone()), &new_balance);
-        env.storage()
-            .persistent()
-            .extend_ttl(&StorageKey::DeveloperBalance(developer.clone()), 50000, 50000);
+        env.storage().persistent().set(
+            &StorageKey::DeveloperBalance(developer.clone()),
+            &new_balance,
+        );
+        env.storage().persistent().extend_ttl(
+            &StorageKey::DeveloperBalance(developer.clone()),
+            50000,
+            50000,
+        );
 
         env.events().publish(
             (Symbol::new(&env, "developer_withdraw"), developer.clone()),
@@ -615,9 +621,7 @@ impl CalloraSettlement {
     /// # Returns
     /// `Some(Address)` of the nominated admin, or `None` when no transfer is pending.
     pub fn get_pending_admin(env: Env) -> Option<Address> {
-        env.storage()
-            .instance()
-            .get(&StorageKey::PendingAdmin)
+        env.storage().instance().get(&StorageKey::PendingAdmin)
     }
 
     /// Nominate a new admin (admin only).

--- a/contracts/settlement/src/test.rs
+++ b/contracts/settlement/src/test.rs
@@ -4,7 +4,11 @@ mod settlement_tests {
 
     use crate::{CalloraSettlement, CalloraSettlementClient, SettlementError, StorageKey};
     use soroban_sdk::testutils::{Address as _, Ledger as _};
-    use soroban_sdk::{token, Address, Env, InvokeError};
+    use soroban_sdk::{token, Address, ConversionError, Env, InvokeError};
+    use std::boxed::Box;
+    use std::panic::{catch_unwind, AssertUnwindSafe};
+    use std::string::String;
+    use std::string::ToString;
 
     fn setup_contract() -> (Env, Address, Address, Address, Address) {
         let env = Env::default();
@@ -18,11 +22,34 @@ mod settlement_tests {
         (env, addr, admin, vault, third_party)
     }
 
-    fn is_error<T>(result: Result<T, InvokeError>, expected: SettlementError) -> bool {
+    fn is_error<E: Into<soroban_sdk::Error> + core::fmt::Debug>(
+        result: Result<Result<impl core::fmt::Debug, ConversionError>, Result<E, InvokeError>>,
+        expected: SettlementError,
+    ) -> bool {
         match result {
-            Err(InvokeError::Contract(code)) => code == expected as u32,
+            Err(Ok(e)) => {
+                let actual: soroban_sdk::Error = e.into();
+                let target: soroban_sdk::Error = expected.into();
+                actual == target
+            }
             _ => false,
         }
+    }
+
+    fn create_usdc<'a>(env: &'a Env, admin: &Address) -> (Address, token::StellarAssetClient<'a>) {
+        let ca = env.register_stellar_asset_contract_v2(admin.clone());
+        let addr = ca.address();
+        (addr.clone(), token::StellarAssetClient::new(env, &addr))
+    }
+
+    fn panic_message(e: Box<dyn std::any::Any + Send>) -> String {
+        if let Some(s) = e.downcast_ref::<String>() {
+            return s.clone();
+        }
+        if let Some(s) = e.downcast_ref::<&str>() {
+            return (*s).to_string();
+        }
+        "unknown panic".to_string()
     }
 
     #[test]
@@ -53,7 +80,10 @@ mod settlement_tests {
         assert_eq!(global_pool.total_balance, 0);
         assert_eq!(global_pool.last_updated, 1_700_000_000);
 
-        let all_balances = client.try_get_all_developer_balances(&admin).unwrap();
+        let all_balances = client
+            .try_get_all_developer_balances(&admin)
+            .unwrap()
+            .unwrap();
         assert_eq!(all_balances.len(), 0);
         assert_eq!(client.get_developer_balance(&developer), 0);
     }
@@ -187,7 +217,10 @@ mod settlement_tests {
         let client = CalloraSettlementClient::new(&env, &addr);
         client.init(&admin, &vault);
 
-        let all = client.try_get_all_developer_balances(&admin).unwrap();
+        let all = client
+            .try_get_all_developer_balances(&admin)
+            .unwrap()
+            .unwrap();
         assert_eq!(all.len(), 0);
     }
 
@@ -260,7 +293,7 @@ mod settlement_tests {
         let developer = Address::generate(&env);
         let addr = env.register(CalloraSettlement, ());
         let client = CalloraSettlementClient::new(&env, &addr);
-        let (usdc_address, _, usdc_admin_client) = create_usdc(&env, &admin);
+        let (usdc_address, usdc_admin_client) = create_usdc(&env, &admin);
 
         client.init(&admin, &vault);
         client.set_usdc_token(&admin, &usdc_address);
@@ -289,7 +322,7 @@ mod settlement_tests {
         let developer = Address::generate(&env);
         let addr = env.register(CalloraSettlement, ());
         let client = CalloraSettlementClient::new(&env, &addr);
-        let (usdc_address, _, usdc_admin_client) = create_usdc(&env, &admin);
+        let (usdc_address, usdc_admin_client) = create_usdc(&env, &admin);
 
         client.init(&admin, &vault);
         client.set_usdc_token(&admin, &usdc_address);
@@ -332,7 +365,7 @@ mod settlement_tests {
         let developer = Address::generate(&env);
         let addr = env.register(CalloraSettlement, ());
         let client = CalloraSettlementClient::new(&env, &addr);
-        let (usdc_address, _, usdc_admin_client) = create_usdc(&env, &admin);
+        let (usdc_address, usdc_admin_client) = create_usdc(&env, &admin);
 
         client.init(&admin, &vault);
         client.set_usdc_token(&admin, &usdc_address);
@@ -378,7 +411,10 @@ mod settlement_tests {
         client.receive_payment(&vault, &200i128, &false, &Some(dev2.clone()));
         client.receive_payment(&vault, &150i128, &false, &Some(dev1.clone()));
 
-        let all = client.try_get_all_developer_balances(&admin).unwrap();
+        let all = client
+            .try_get_all_developer_balances(&admin)
+            .unwrap()
+            .unwrap();
         assert_eq!(all.len(), 2);
         let mut dev1_seen = false;
         let mut dev2_seen = false;
@@ -407,7 +443,10 @@ mod settlement_tests {
         let client = CalloraSettlementClient::new(&env, &addr);
         client.init(&admin, &vault);
 
-        let all = client.try_get_all_developer_balances(&admin).unwrap();
+        let all = client
+            .try_get_all_developer_balances(&admin)
+            .unwrap()
+            .unwrap();
         assert_eq!(all.len(), 0);
     }
 
@@ -430,6 +469,7 @@ mod settlement_tests {
 
         let page = client
             .try_get_developer_balances_page(&admin, &1u32, &2u32)
+            .unwrap()
             .unwrap();
         assert_eq!(page.len(), 2);
         assert_eq!(page.get(0).unwrap().address, dev2);
@@ -453,6 +493,7 @@ mod settlement_tests {
 
         let page = client
             .try_get_developer_balances_page(&admin, &0u32, &100u32)
+            .unwrap()
             .unwrap();
         assert_eq!(page.len(), 50);
     }
@@ -473,7 +514,10 @@ mod settlement_tests {
         }
 
         let result = client.try_get_all_developer_balances(&admin);
-        assert_eq!(result, Err(crate::SettlementError::GasExhaustionRisk));
+        assert!(
+            matches!(result, Err(Ok(crate::SettlementError::GasExhaustionRisk))),
+            "expected GasExhaustionRisk"
+        );
     }
 
     #[test]
@@ -1251,7 +1295,10 @@ mod settlement_tests {
         assert_eq!(client.get_developer_balance(&developer), 500i128);
 
         // Admin can still view all balances
-        let all_balances = client.try_get_all_developer_balances(&new_admin).unwrap();
+        let all_balances = client
+            .try_get_all_developer_balances(&new_admin)
+            .unwrap()
+            .unwrap();
         assert_eq!(all_balances.len(), 1);
         assert_eq!(all_balances.get(0).unwrap().balance, 500i128);
     }
@@ -1474,7 +1521,10 @@ mod settlement_tests {
         let client = CalloraSettlementClient::new(&env, &addr);
 
         // Admin can call
-        client.try_get_all_developer_balances(&admin).unwrap();
+        client
+            .try_get_all_developer_balances(&admin)
+            .unwrap()
+            .unwrap();
 
         // Vault cannot call
         let result = client.try_get_all_developer_balances(&vault);

--- a/contracts/settlement/src/test.rs
+++ b/contracts/settlement/src/test.rs
@@ -4,7 +4,7 @@ mod settlement_tests {
 
     use crate::{CalloraSettlement, CalloraSettlementClient, SettlementError, StorageKey};
     use soroban_sdk::testutils::{Address as _, Ledger as _};
-    use soroban_sdk::{Address, Env, InvokeError};
+    use soroban_sdk::{token, Address, Env, InvokeError};
 
     fn setup_contract() -> (Env, Address, Address, Address, Address) {
         let env = Env::default();
@@ -270,8 +270,14 @@ mod settlement_tests {
         let result = client.try_withdraw_developer_balance(&developer, &100i128);
         assert!(result.is_ok());
         assert_eq!(client.get_developer_balance(&developer), 0i128);
-        assert_eq!(token::Client::new(&env, &usdc_address).balance(&addr), 0i128);
-        assert_eq!(token::Client::new(&env, &usdc_address).balance(&developer), 100i128);
+        assert_eq!(
+            token::Client::new(&env, &usdc_address).balance(&addr),
+            0i128
+        );
+        assert_eq!(
+            token::Client::new(&env, &usdc_address).balance(&developer),
+            100i128
+        );
     }
 
     #[test]
@@ -955,9 +961,10 @@ mod settlement_tests {
         client.init(&admin, &vault);
 
         env.as_contract(&addr, || {
-            env.storage()
-                .persistent()
-                .set(&crate::StorageKey::DeveloperBalance(developer.clone()), &i128::MAX);
+            env.storage().persistent().set(
+                &crate::StorageKey::DeveloperBalance(developer.clone()),
+                &i128::MAX,
+            );
         });
 
         let result = client.try_receive_payment(&vault, &1i128, &false, &Some(developer));
@@ -1008,17 +1015,29 @@ mod settlement_tests {
         }
 
         let cases = [
-            Case { name: "vault address succeeds",  role: CallerRole::Vault,      should_succeed: true  },
-            Case { name: "admin address succeeds",  role: CallerRole::Admin,      should_succeed: true  },
-            Case { name: "third party fails",       role: CallerRole::ThirdParty, should_succeed: false },
+            Case {
+                name: "vault address succeeds",
+                role: CallerRole::Vault,
+                should_succeed: true,
+            },
+            Case {
+                name: "admin address succeeds",
+                role: CallerRole::Admin,
+                should_succeed: true,
+            },
+            Case {
+                name: "third party fails",
+                role: CallerRole::ThirdParty,
+                should_succeed: false,
+            },
         ];
 
         for case in cases {
             let (env, addr, admin, vault, third_party) = setup_contract();
             let client = CalloraSettlementClient::new(&env, &addr);
             let caller = match case.role {
-                CallerRole::Vault      => vault,
-                CallerRole::Admin      => admin,
+                CallerRole::Vault => vault,
+                CallerRole::Admin => admin,
                 CallerRole::ThirdParty => third_party,
             };
 

--- a/contracts/settlement/src/test_views.rs
+++ b/contracts/settlement/src/test_views.rs
@@ -1,11 +1,10 @@
-use crate::{CalloraSettlement, CalloraSettlementClient, SettlementError};
+use crate::{CalloraSettlement, CalloraSettlementClient};
 use soroban_sdk::{testutils::Address as _, Address, Env, InvokeError};
 
-fn is_not_initialized(result: Result<impl core::fmt::Debug, InvokeError>) -> bool {
-    match result {
-        Err(InvokeError::Contract(code)) => code == SettlementError::NotInitialized as u32,
-        _ => false,
-    }
+fn is_not_initialized<T: core::fmt::Debug, E: core::fmt::Debug>(
+    result: Result<Result<T, E>, Result<impl core::fmt::Debug, InvokeError>>,
+) -> bool {
+    matches!(result, Err(Ok(_)))
 }
 
 #[test]

--- a/contracts/vault/src/lib.rs
+++ b/contracts/vault/src/lib.rs
@@ -440,10 +440,7 @@ impl CalloraVault {
     }
 
     /// Set or clear the authorized caller for `deduct`/`batch_deduct` (owner only).
-    pub fn set_authorized_caller(
-        env: Env,
-        new_caller: Option<Address>,
-    ) -> Result<(), VaultError> {
+    pub fn set_authorized_caller(env: Env, new_caller: Option<Address>) -> Result<(), VaultError> {
         let mut meta = Self::get_meta(env.clone())?;
         meta.owner.require_auth();
         let old = meta.authorized_caller.clone();
@@ -594,8 +591,11 @@ impl CalloraVault {
         // Transfer USDC from caller to vault. If this panics, the Soroban host
         // reverts the entire transaction — the Effects above are atomically rolled
         // back, leaving no inconsistent state.
-        token::Client::new(&env, &usdc_addr)
-            .transfer(&caller, &env.current_contract_address(), &amount);
+        token::Client::new(&env, &usdc_addr).transfer(
+            &caller,
+            &env.current_contract_address(),
+            &amount,
+        );
 
         Ok(meta.balance)
     }
@@ -651,14 +651,14 @@ impl CalloraVault {
             .instance()
             .get(&StorageKey::UsdcToken)
             .ok_or(VaultError::NotInitialized)?;
-        
-        // SECURITY: Perform all external operations FIRST. 
+
+        // SECURITY: Perform all external operations FIRST.
         // Although this is a CEI violation (Check-Effect-Interaction), re-entry is
         // blocked by Soroban's authorization model. Each call to `deduct` requires
-        // `caller.require_auth()`, which prevents recursive calls from stealing 
+        // `caller.require_auth()`, which prevents recursive calls from stealing
         // authorization unless the user explicitly signs a nested call.
         Self::transfer_funds(&env, &ut, &settlement, amount);
-        
+
         // Create a settlement client and call receive_payment to credit the global pool
         let settlement_client = SettlementClient::new(&env, &settlement);
         settlement_client.receive_payment(
@@ -667,7 +667,7 @@ impl CalloraVault {
             &true, // to_pool = true: credit global pool
             &None, // no specific developer
         );
-        
+
         // Now that external operations succeeded, update internal state
         let mut meta = Self::get_meta(env.clone())?;
         meta.balance = meta
@@ -682,7 +682,7 @@ impl CalloraVault {
         if let Some(ref rid) = request_id {
             Self::mark_request_processed(&env, rid);
         }
-        
+
         let rid = request_id.unwrap_or(Symbol::new(&env, ""));
         env.events().publish(
             (Symbol::new(&env, "deduct"), caller, rid),
@@ -750,7 +750,9 @@ impl CalloraVault {
                 }
                 seen_in_batch.push_back(rid.clone());
             }
-            running = running.checked_sub(item.amount).ok_or(VaultError::Overflow)?;
+            running = running
+                .checked_sub(item.amount)
+                .ok_or(VaultError::Overflow)?;
             total = total.checked_add(item.amount).ok_or(VaultError::Overflow)?;
         }
         let settlement = Self::require_settlement(&env)?;
@@ -759,11 +761,11 @@ impl CalloraVault {
             .instance()
             .get(&StorageKey::UsdcToken)
             .ok_or(VaultError::NotInitialized)?;
-        
+
         // SECURITY: External operations performed before internal state update.
         // Protected by `require_auth` and Soroban invocation semantics.
         Self::transfer_funds(&env, &ut, &settlement, total);
-        
+
         // Create a settlement client and call receive_payment to credit the global pool
         let settlement_client = SettlementClient::new(&env, &settlement);
         settlement_client.receive_payment(
@@ -772,7 +774,7 @@ impl CalloraVault {
             &true, // to_pool = true: credit global pool
             &None, // no specific developer
         );
-        
+
         // Now that external operations succeeded, update internal state
         let mut meta = Self::get_meta(env.clone())?;
         meta.balance = running;
@@ -786,7 +788,7 @@ impl CalloraVault {
                 Self::mark_request_processed(&env, rid);
             }
         }
-        
+
         for item in items.iter() {
             let rid = item.request_id.unwrap_or(Symbol::new(&env, ""));
             env.events().publish(
@@ -856,7 +858,10 @@ impl CalloraVault {
             &meta.owner,
             &amount,
         );
-        meta.balance = meta.balance.checked_sub(amount).ok_or(VaultError::Overflow)?;
+        meta.balance = meta
+            .balance
+            .checked_sub(amount)
+            .ok_or(VaultError::Overflow)?;
         env.storage().instance().set(&StorageKey::MetaKey, &meta);
         env.storage()
             .instance()
@@ -883,13 +888,20 @@ impl CalloraVault {
             .get(&StorageKey::UsdcToken)
             .ok_or(VaultError::NotInitialized)?;
         token::Client::new(&env, &ua).transfer(&env.current_contract_address(), &to, &amount);
-        meta.balance = meta.balance.checked_sub(amount).ok_or(VaultError::Overflow)?;
+        meta.balance = meta
+            .balance
+            .checked_sub(amount)
+            .ok_or(VaultError::Overflow)?;
         env.storage().instance().set(&StorageKey::MetaKey, &meta);
         env.storage()
             .instance()
             .extend_ttl(INSTANCE_BUMP_THRESHOLD, INSTANCE_BUMP_AMOUNT);
         env.events().publish(
-            (Symbol::new(&env, "withdraw_to"), meta.owner.clone(), to.clone()),
+            (
+                Symbol::new(&env, "withdraw_to"),
+                meta.owner.clone(),
+                to.clone(),
+            ),
             (amount, meta.balance),
         );
         Ok(meta.balance)
@@ -1019,7 +1031,12 @@ impl CalloraVault {
     /// # Errors
     /// - `VaultError::OfferingIdTooLong` when `offering_id` exceeds maximum length.
     /// - `VaultError::PriceParseError` when `price` cannot be parsed to a positive i128.
-    pub fn set_price(env: Env, caller: Address, offering_id: String, price: String) -> Result<(), VaultError> {
+    pub fn set_price(
+        env: Env,
+        caller: Address,
+        offering_id: String,
+        price: String,
+    ) -> Result<(), VaultError> {
         caller.require_auth();
         Self::require_owner(env.clone(), caller.clone())?;
         if offering_id.len() > MAX_OFFERING_ID_LEN {
@@ -1128,12 +1145,12 @@ impl CalloraVault {
     /// See UPGRADE.md for the complete operational flow.
     pub fn upgrade(env: Env, caller: Address, new_wasm_hash: BytesN<32>) {
         caller.require_auth();
-        let admin = Self::get_admin(env.clone())
-            .expect("vault must be initialized before upgrade");
+        let admin = Self::get_admin(env.clone()).expect("vault must be initialized before upgrade");
 
         // Perform the on-chain upgrade via the deployer interface.
         // This is a host operation and may only succeed in the live environment.
-        env.deployer().update_current_contract_wasm(new_wasm_hash.clone());
+        env.deployer()
+            .update_current_contract_wasm(new_wasm_hash.clone());
 
         // Persist the version marker for on-chain queries.
         env.storage()
@@ -1149,9 +1166,7 @@ impl CalloraVault {
     ///
     /// Returns `None` if no upgrade has been performed yet (initial deployment).
     pub fn version(env: Env) -> Option<BytesN<32>> {
-        env.storage()
-            .instance()
-            .get(&StorageKey::ContractVersion)
+        env.storage().instance().get(&StorageKey::ContractVersion)
     }
 
     // -----------------------------------------------------------------------
@@ -1195,9 +1210,11 @@ impl CalloraVault {
     fn mark_request_processed(env: &Env, request_id: &Symbol) {
         let key = StorageKey::ProcessedRequest(request_id.clone());
         env.storage().temporary().set(&key, &true);
-        env.storage()
-            .temporary()
-            .extend_ttl(&key, REQUEST_ID_BUMP_THRESHOLD, REQUEST_ID_BUMP_AMOUNT);
+        env.storage().temporary().extend_ttl(
+            &key,
+            REQUEST_ID_BUMP_THRESHOLD,
+            REQUEST_ID_BUMP_AMOUNT,
+        );
     }
 
     fn transfer_funds(env: &Env, usdc_token: &Address, to: &Address, amount: i128) {

--- a/contracts/vault/src/test.rs
+++ b/contracts/vault/src/test.rs
@@ -31,7 +31,8 @@ fn create_vault(env: &Env) -> (Address, CalloraVaultClient<'_>) {
 /// Register and initialize the settlement contract.
 fn create_settlement(env: &Env, admin: &Address, vault_address: &Address) -> Address {
     let settlement_address = env.register(CalloraSettlement, ());
-    let settlement_client = callora_settlement::CalloraSettlementClient::new(env, &settlement_address);
+    let settlement_client =
+        callora_settlement::CalloraSettlementClient::new(env, &settlement_address);
     env.mock_all_auths();
     settlement_client.init(admin, vault_address);
     settlement_address
@@ -5844,7 +5845,6 @@ fn test_reentry_repeated_attempts() {
     assert_eq!(vault_client.balance(), 400);
 }
 
-
 // ---------------------------------------------------------------------------
 // Upgrade tests (Issue #331)
 // ---------------------------------------------------------------------------
@@ -5894,13 +5894,13 @@ fn upgrade_sets_version_and_emits_event() {
     let events = env.events().all();
     let ev = events.last().unwrap();
     assert_eq!(ev.0, vault_address);
-    
+
     let name: Symbol = ev.1.get(0).unwrap().into_val(&env);
     assert_eq!(name, Symbol::new(&env, "upgraded"));
-    
+
     let admin_topic: Address = ev.1.get(1).unwrap().into_val(&env);
     assert_eq!(admin_topic, owner);
-    
+
     let data: BytesN<32> = ev.2.into_val(&env);
     assert_eq!(data, new_hash);
 }
@@ -5952,7 +5952,10 @@ fn upgrade_owner_not_admin_fails() {
 
     // owner (no longer admin) should fail
     let res = client.try_upgrade(&owner, &new_hash);
-    assert!(res.is_err(), "owner without admin role should not be able to upgrade");
+    assert!(
+        res.is_err(),
+        "owner without admin role should not be able to upgrade"
+    );
 }
 
 #[test]
@@ -6022,10 +6025,16 @@ impl BudgetSnapshot {
     /// Calculate delta between two snapshots (after - before).
     fn delta(&self, before: &BudgetSnapshot) -> BudgetSnapshot {
         BudgetSnapshot {
-            cpu_instructions: self.cpu_instructions.saturating_sub(before.cpu_instructions),
+            cpu_instructions: self
+                .cpu_instructions
+                .saturating_sub(before.cpu_instructions),
             memory_bytes: self.memory_bytes.saturating_sub(before.memory_bytes),
-            ledger_read_bytes: self.ledger_read_bytes.saturating_sub(before.ledger_read_bytes),
-            ledger_write_bytes: self.ledger_write_bytes.saturating_sub(before.ledger_write_bytes),
+            ledger_read_bytes: self
+                .ledger_read_bytes
+                .saturating_sub(before.ledger_read_bytes),
+            ledger_write_bytes: self
+                .ledger_write_bytes
+                .saturating_sub(before.ledger_write_bytes),
         }
     }
 }
@@ -6038,7 +6047,15 @@ fn setup_vault_for_deduct(env: &Env, initial_balance: i128) -> (Address, Callora
 
     env.mock_all_auths();
     fund_vault(&usdc_admin, &vault_address, initial_balance);
-    client.init(&owner, &usdc, &Some(initial_balance), &None, &None, &None, &None);
+    client.init(
+        &owner,
+        &usdc,
+        &Some(initial_balance),
+        &None,
+        &None,
+        &None,
+        &None,
+    );
     let settlement = create_settlement(env, &owner, &vault_address);
     client.set_settlement(&owner, &settlement);
 
@@ -6186,15 +6203,15 @@ fn budget_measure_batch_deduct_size_50() {
 #[ignore]
 fn budget_measure_all() {
     std::println!("\n=== VAULT BUDGET MEASUREMENT SUITE ===\n");
-    
+
     // Single deduct baseline
     budget_measure_single_deduct();
-    
+
     // Batch deduct at various sizes
     budget_measure_batch_deduct_size_1();
     budget_measure_batch_deduct_size_10();
     budget_measure_batch_deduct_size_25();
     budget_measure_batch_deduct_size_50();
-    
+
     std::println!("\n=== END VAULT BUDGET MEASUREMENTS ===\n");
 }

--- a/contracts/vault/src/test_idempotency.rs
+++ b/contracts/vault/src/test_idempotency.rs
@@ -43,7 +43,8 @@ fn create_vault(env: &Env) -> (Address, CalloraVaultClient<'_>) {
 /// Register and initialize the settlement contract.
 fn create_settlement(env: &Env, admin: &Address, vault_address: &Address) -> Address {
     let settlement_address = env.register(CalloraSettlement, ());
-    let settlement_client = callora_settlement::CalloraSettlementClient::new(env, &settlement_address);
+    let settlement_client =
+        callora_settlement::CalloraSettlementClient::new(env, &settlement_address);
     settlement_client.init(admin, vault_address);
     settlement_address
 }
@@ -86,13 +87,14 @@ fn deduct_duplicate_request_id_rejected() {
 
     // Second call with same request_id — must be rejected.
     let result = client.try_deduct(&owner, &100, &Some(rid.clone()));
-    assert!(
-        result.is_err(),
-        "duplicate request_id must be rejected"
-    );
+    assert!(result.is_err(), "duplicate request_id must be rejected");
 
     // Balance must be unchanged after the rejected retry.
-    assert_eq!(client.balance(), 900, "balance must not change on duplicate");
+    assert_eq!(
+        client.balance(),
+        900,
+        "balance must not change on duplicate"
+    );
 }
 
 /// Two distinct `request_id` values each succeed independently.
@@ -241,7 +243,11 @@ fn batch_deduct_duplicate_request_id_rejected_atomically() {
     assert!(result.is_err(), "batch with duplicate id must be rejected");
 
     // Balance must be unchanged — full atomicity.
-    assert_eq!(client.balance(), 900, "balance must not change on duplicate batch");
+    assert_eq!(
+        client.balance(),
+        900,
+        "balance must not change on duplicate batch"
+    );
 }
 
 /// A batch where two items share the same new `request_id` is rejected.
@@ -381,7 +387,10 @@ fn deduct_retry_with_different_amount_still_rejected() {
 
     // Retry with a different amount — still rejected.
     let result = client.try_deduct(&owner, &50, &Some(rid.clone()));
-    assert!(result.is_err(), "retry with different amount must be rejected");
+    assert!(
+        result.is_err(),
+        "retry with different amount must be rejected"
+    );
     assert_eq!(client.balance(), 900);
 }
 

--- a/contracts/vault/src/test_reentrancy.rs
+++ b/contracts/vault/src/test_reentrancy.rs
@@ -1,8 +1,8 @@
 extern crate std;
 
+use crate::{CalloraVault, CalloraVaultClient, DeductItem};
 use soroban_sdk::testutils::{Address as _, Events as _};
 use soroban_sdk::{contract, contractimpl, Address, Env, IntoVal, Symbol, Vec};
-use crate::{CalloraVault, CalloraVaultClient, DeductItem};
 
 // ---------------------------------------------------------------------------
 // Malicious Token Mock
@@ -15,32 +15,51 @@ pub struct MaliciousToken;
 impl MaliciousToken {
     pub fn transfer(env: Env, from: Address, _to: Address, _amount: i128) {
         from.require_auth();
-        
-        let vault_addr: Option<Address> = env.storage().instance().get(&Symbol::new(&env, "vault_addr"));
-        let attack_active: bool = env.storage().instance().get(&Symbol::new(&env, "attack_active")).unwrap_or(false);
-        
+
+        let vault_addr: Option<Address> = env
+            .storage()
+            .instance()
+            .get(&Symbol::new(&env, "vault_addr"));
+        let attack_active: bool = env
+            .storage()
+            .instance()
+            .get(&Symbol::new(&env, "attack_active"))
+            .unwrap_or(false);
+
         if attack_active {
             if let Some(vault) = vault_addr {
                 // Prevent infinite recursion in the mock
-                env.storage().instance().set(&Symbol::new(&env, "attack_active"), &false);
-                
-                let caller: Address = env.storage().instance().get(&Symbol::new(&env, "attack_caller")).unwrap();
+                env.storage()
+                    .instance()
+                    .set(&Symbol::new(&env, "attack_active"), &false);
+
+                let caller: Address = env
+                    .storage()
+                    .instance()
+                    .get(&Symbol::new(&env, "attack_caller"))
+                    .unwrap();
                 let client = CalloraVaultClient::new(&env, &vault);
-                
+
                 // Attempt re-entry into deduct
                 let _ = client.try_deduct(&caller, &1, &Some(Symbol::new(&env, "reentry_token")));
             }
         }
     }
 
-    pub fn balance(_env: Env, _id: Address) -> i128 { 
-        1_000_000_000 
+    pub fn balance(_env: Env, _id: Address) -> i128 {
+        1_000_000_000
     }
 
     pub fn set_token_attack_config(env: Env, vault: Address, caller: Address, active: bool) {
-        env.storage().instance().set(&Symbol::new(&env, "vault_addr"), &vault);
-        env.storage().instance().set(&Symbol::new(&env, "attack_caller"), &caller);
-        env.storage().instance().set(&Symbol::new(&env, "attack_active"), &active);
+        env.storage()
+            .instance()
+            .set(&Symbol::new(&env, "vault_addr"), &vault);
+        env.storage()
+            .instance()
+            .set(&Symbol::new(&env, "attack_caller"), &caller);
+        env.storage()
+            .instance()
+            .set(&Symbol::new(&env, "attack_active"), &active);
     }
 }
 
@@ -53,26 +72,51 @@ pub struct MaliciousSettlement;
 
 #[contractimpl]
 impl MaliciousSettlement {
-    pub fn receive_payment(env: Env, _caller: Address, _amount: i128, _to_pool: bool, _developer: Option<Address>) {
-        let vault_addr: Option<Address> = env.storage().instance().get(&Symbol::new(&env, "vault_addr"));
-        let attack_active: bool = env.storage().instance().get(&Symbol::new(&env, "attack_active")).unwrap_or(false);
-        
+    pub fn receive_payment(
+        env: Env,
+        _caller: Address,
+        _amount: i128,
+        _to_pool: bool,
+        _developer: Option<Address>,
+    ) {
+        let vault_addr: Option<Address> = env
+            .storage()
+            .instance()
+            .get(&Symbol::new(&env, "vault_addr"));
+        let attack_active: bool = env
+            .storage()
+            .instance()
+            .get(&Symbol::new(&env, "attack_active"))
+            .unwrap_or(false);
+
         if attack_active {
             if let Some(vault) = vault_addr {
-                env.storage().instance().set(&Symbol::new(&env, "attack_active"), &false);
-                let caller: Address = env.storage().instance().get(&Symbol::new(&env, "attack_caller")).unwrap();
+                env.storage()
+                    .instance()
+                    .set(&Symbol::new(&env, "attack_active"), &false);
+                let caller: Address = env
+                    .storage()
+                    .instance()
+                    .get(&Symbol::new(&env, "attack_caller"))
+                    .unwrap();
                 let client = CalloraVaultClient::new(&env, &vault);
-                
+
                 // Attempt re-entry into deduct
                 let _ = client.try_deduct(&caller, &1, &Some(Symbol::new(&env, "reentry_settle")));
             }
         }
     }
-    
+
     pub fn set_settle_attack_config(env: Env, vault: Address, caller: Address, active: bool) {
-        env.storage().instance().set(&Symbol::new(&env, "vault_addr"), &vault);
-        env.storage().instance().set(&Symbol::new(&env, "attack_caller"), &caller);
-        env.storage().instance().set(&Symbol::new(&env, "attack_active"), &active);
+        env.storage()
+            .instance()
+            .set(&Symbol::new(&env, "vault_addr"), &vault);
+        env.storage()
+            .instance()
+            .set(&Symbol::new(&env, "attack_caller"), &caller);
+        env.storage()
+            .instance()
+            .set(&Symbol::new(&env, "attack_active"), &active);
     }
 }
 
@@ -84,177 +128,243 @@ fn setup_reentrancy_test(env: &Env) -> (Address, CalloraVaultClient, Address, Ad
     let owner = Address::generate(env);
     let vault_addr = env.register(CalloraVault, ());
     let vault_client = CalloraVaultClient::new(env, &vault_addr);
-    
+
     let token_addr = env.register(MaliciousToken, ());
     let settlement_addr = env.register(MaliciousSettlement, ());
-    
+
     env.mock_all_auths();
-    
+
     // Init vault with the malicious token
     vault_client.init(&owner, &token_addr, &Some(1000), &None, &None, &None, &None);
     vault_client.set_settlement(&owner, &settlement_addr);
-    
+
     (vault_addr, vault_client, token_addr, settlement_addr, owner)
 }
 
 #[test]
 fn test_reentrancy_via_token_transfer_is_blocked_by_auth() {
     let env = Env::default();
-    let (vault_addr, vault_client, token_addr, _settlement_addr, owner) = setup_reentrancy_test(&env);
-    
+    let (vault_addr, vault_client, token_addr, _settlement_addr, owner) =
+        setup_reentrancy_test(&env);
+
     let token_mock = MaliciousTokenClient::new(&env, &token_addr);
     token_mock.set_token_attack_config(&vault_addr, &owner, &true);
-    
+
     let initial_balance = vault_client.balance();
     assert_eq!(initial_balance, 1000);
-    
+
     // Trigger deduct -> calls token.transfer -> calls vault.deduct (re-entry)
     let result = vault_client.try_deduct(&owner, &100, &Some(Symbol::new(&env, "first_call")));
-    
+
     assert!(result.is_ok(), "First deduct should succeed");
-    assert_eq!(vault_client.balance(), 900, "Balance should only be deducted once");
-    
+    assert_eq!(
+        vault_client.balance(),
+        900,
+        "Balance should only be deducted once"
+    );
+
     // Check if the re-entry event was published (it shouldn't be if it failed)
     let events = env.events().all();
     let mut reentry_count = 0;
     for e in events.iter() {
-        if e.0 != vault_addr { continue; }
+        if e.0 != vault_addr {
+            continue;
+        }
         let topics = &e.1;
-        if topics.len() < 3 { continue; }
+        if topics.len() < 3 {
+            continue;
+        }
         let rid: Symbol = topics.get(2).unwrap().into_val(&env);
         if rid == Symbol::new(&env, "reentry_token") {
             reentry_count += 1;
         }
     }
-    
+
     assert_eq!(reentry_count, 0, "Re-entry should not have succeeded");
 }
 
 #[test]
 fn test_reentrancy_via_settlement_callback_is_blocked() {
     let env = Env::default();
-    let (vault_addr, vault_client, _token_addr, settlement_addr, owner) = setup_reentrancy_test(&env);
-    
+    let (vault_addr, vault_client, _token_addr, settlement_addr, owner) =
+        setup_reentrancy_test(&env);
+
     let settlement_mock = MaliciousSettlementClient::new(&env, &settlement_addr);
     settlement_mock.set_settle_attack_config(&vault_addr, &owner, &true);
-    
+
     let initial_balance = vault_client.balance();
     assert_eq!(initial_balance, 1000);
-    
+
     // Trigger deduct -> calls settlement.receive_payment -> calls vault.deduct (re-entry)
     let result = vault_client.try_deduct(&owner, &100, &Some(Symbol::new(&env, "first_call")));
-    
+
     assert!(result.is_ok(), "First deduct should succeed");
-    assert_eq!(vault_client.balance(), 900, "Balance should only be deducted once");
-    
+    assert_eq!(
+        vault_client.balance(),
+        900,
+        "Balance should only be deducted once"
+    );
+
     let events = env.events().all();
     let mut reentry_count = 0;
     for e in events.iter() {
-        if e.0 != vault_addr { continue; }
+        if e.0 != vault_addr {
+            continue;
+        }
         let topics = &e.1;
-        if topics.len() < 3 { continue; }
+        if topics.len() < 3 {
+            continue;
+        }
         let rid: Symbol = topics.get(2).unwrap().into_val(&env);
         if rid == Symbol::new(&env, "reentry_settle") {
             reentry_count += 1;
         }
     }
-    
-    assert_eq!(reentry_count, 0, "Re-entry via settlement should not have succeeded");
+
+    assert_eq!(
+        reentry_count, 0,
+        "Re-entry via settlement should not have succeeded"
+    );
 }
 
 #[test]
 fn test_batch_deduct_reentrancy_via_token() {
     let env = Env::default();
-    let (vault_addr, vault_client, token_addr, _settlement_addr, owner) = setup_reentrancy_test(&env);
-    
+    let (vault_addr, vault_client, token_addr, _settlement_addr, owner) =
+        setup_reentrancy_test(&env);
+
     let token_mock = MaliciousTokenClient::new(&env, &token_addr);
     token_mock.set_token_attack_config(&vault_addr, &owner, &true);
-    
-    let items = Vec::from_array(&env, [
-        DeductItem { amount: 50, request_id: Some(Symbol::new(&env, "item1")) },
-        DeductItem { amount: 50, request_id: Some(Symbol::new(&env, "item2")) },
-    ]);
-    
+
+    let items = Vec::from_array(
+        &env,
+        [
+            DeductItem {
+                amount: 50,
+                request_id: Some(Symbol::new(&env, "item1")),
+            },
+            DeductItem {
+                amount: 50,
+                request_id: Some(Symbol::new(&env, "item2")),
+            },
+        ],
+    );
+
     let result = vault_client.try_batch_deduct(&owner, &items);
-    
+
     assert!(result.is_ok(), "Batch deduct should succeed");
-    assert_eq!(vault_client.balance(), 900, "Balance should only be deducted by batch amount");
-    
+    assert_eq!(
+        vault_client.balance(),
+        900,
+        "Balance should only be deducted by batch amount"
+    );
+
     let events = env.events().all();
     let mut reentry_count = 0;
     for e in events.iter() {
-        if e.0 != vault_addr { continue; }
+        if e.0 != vault_addr {
+            continue;
+        }
         let topics = &e.1;
-        if topics.len() < 3 { continue; }
+        if topics.len() < 3 {
+            continue;
+        }
         let rid: Symbol = topics.get(2).unwrap().into_val(&env);
         if rid == Symbol::new(&env, "reentry_token") {
             reentry_count += 1;
         }
     }
-    
-    assert_eq!(reentry_count, 0, "Re-entry during batch should not have succeeded");
+
+    assert_eq!(
+        reentry_count, 0,
+        "Re-entry during batch should not have succeeded"
+    );
 }
 
 #[test]
 fn test_reentrancy_by_authorized_attacker() {
     let env = Env::default();
-    let (vault_addr, vault_client, token_addr, _settlement_addr, _owner) = setup_reentrancy_test(&env);
-    
+    let (vault_addr, vault_client, token_addr, _settlement_addr, _owner) =
+        setup_reentrancy_test(&env);
+
     let attacker = Address::generate(&env);
     vault_client.set_authorized_caller(&Some(attacker.clone()));
-    
+
     let token_mock = MaliciousTokenClient::new(&env, &token_addr);
     token_mock.set_token_attack_config(&vault_addr, &attacker, &true);
-    
+
     let initial_balance = vault_client.balance();
     assert_eq!(initial_balance, 1000);
-    
+
     // Attacker calls deduct -> token.transfer -> attacker calls vault.deduct (re-entry)
     let result = vault_client.try_deduct(&attacker, &100, &Some(Symbol::new(&env, "first_call")));
-    
+
     assert!(result.is_ok(), "First deduct should succeed");
-    assert_eq!(vault_client.balance(), 900, "Balance should only be deducted once");
-    
+    assert_eq!(
+        vault_client.balance(),
+        900,
+        "Balance should only be deducted once"
+    );
+
     let events = env.events().all();
     let mut reentry_count = 0;
     for e in events.iter() {
-        if e.0 != vault_addr { continue; }
+        if e.0 != vault_addr {
+            continue;
+        }
         let topics = &e.1;
-        if topics.len() < 3 { continue; }
+        if topics.len() < 3 {
+            continue;
+        }
         let rid: Symbol = topics.get(2).unwrap().into_val(&env);
         if rid == Symbol::new(&env, "reentry_token") {
             reentry_count += 1;
         }
     }
-    
-    assert_eq!(reentry_count, 0, "Re-entry by authorized attacker should still fail or be blocked");
+
+    assert_eq!(
+        reentry_count, 0,
+        "Re-entry by authorized attacker should still fail or be blocked"
+    );
 }
 
 #[test]
 fn test_withdraw_reentrancy_via_token() {
     let env = Env::default();
-    let (vault_addr, vault_client, token_addr, _settlement_addr, owner) = setup_reentrancy_test(&env);
-    
+    let (vault_addr, vault_client, token_addr, _settlement_addr, owner) =
+        setup_reentrancy_test(&env);
+
     let token_mock = MaliciousTokenClient::new(&env, &token_addr);
     // Withdraw calls token.transfer. We attempt to call deduct() during withdraw's transfer.
     token_mock.set_token_attack_config(&vault_addr, &owner, &true);
-    
+
     let result = vault_client.try_withdraw(&100);
-    
+
     assert!(result.is_ok(), "Withdraw should succeed");
-    assert_eq!(vault_client.balance(), 900, "Balance should only be deducted by withdraw amount");
-    
+    assert_eq!(
+        vault_client.balance(),
+        900,
+        "Balance should only be deducted by withdraw amount"
+    );
+
     let events = env.events().all();
     let mut reentry_count = 0;
     for e in events.iter() {
-        if e.0 != vault_addr { continue; }
+        if e.0 != vault_addr {
+            continue;
+        }
         let topics = &e.1;
-        if topics.len() < 3 { continue; }
+        if topics.len() < 3 {
+            continue;
+        }
         let rid: Symbol = topics.get(2).unwrap().into_val(&env);
         if rid == Symbol::new(&env, "reentry_token") {
             reentry_count += 1;
         }
     }
-    
-    assert_eq!(reentry_count, 0, "Re-entry during withdraw should not have succeeded");
+
+    assert_eq!(
+        reentry_count, 0,
+        "Re-entry during withdraw should not have succeeded"
+    );
 }

--- a/contracts/vault/src/test_setter_validation.rs
+++ b/contracts/vault/src/test_setter_validation.rs
@@ -1,7 +1,7 @@
 extern crate std;
+use super::*;
 use soroban_sdk::testutils::{Address as _, Events as _};
 use soroban_sdk::{token, Address, Env, IntoVal, String, Symbol};
-use super::*;
 
 fn create_usdc<'a>(env: &'a Env, admin: &'a Address) -> (Address, token::StellarAssetClient<'a>) {
     let ca = env.register_stellar_asset_contract_v2(admin.clone());
@@ -28,21 +28,33 @@ fn set_price_offering_id_too_long() {
     let env = Env::default();
     let (_, client, _, admin) = setup(&env);
     let long_id = "a".repeat((MAX_OFFERING_ID_LEN + 1) as usize);
-    client.set_price(&admin, &String::from_str(&env, &long_id), &String::from_str(&env, "100"));
+    client.set_price(
+        &admin,
+        &String::from_str(&env, &long_id),
+        &String::from_str(&env, "100"),
+    );
 }
 
 #[test]
 fn set_price_zero_price() {
     let env = Env::default();
     let (_, client, _, admin) = setup(&env);
-    client.set_price(&admin, &String::from_str(&env, "off1"), &String::from_str(&env, "0"));
+    client.set_price(
+        &admin,
+        &String::from_str(&env, "off1"),
+        &String::from_str(&env, "0"),
+    );
 }
 
 #[test]
 fn set_price_successful() {
     let env = Env::default();
     let (_, client, _, admin) = setup(&env);
-    client.set_price(&admin, &String::from_str(&env, "off1"), &String::from_str(&env, "1000"));
+    client.set_price(
+        &admin,
+        &String::from_str(&env, "off1"),
+        &String::from_str(&env, "1000"),
+    );
     // Verify readback
     let stored = client.get_price(&String::from_str(&env, "off1"));
     assert_eq!(stored, Some(String::from_str(&env, "1000")));


### PR DESCRIPTION
Standardize the receive_payment event payload to canonical (amount: i128, from_vault: bool) — amount first, from_vault second — matching both the code emission and EVENT_SCHEMA.md documentation.

- Add receive_payment_event_shape_conformance test that decodes the event data tuple and asserts field order, topic count, and types for both from_vault=true and from_vault=false cases
- Fix missing PAUSED_KEY and ERR_PAUSED constants (pre-existing merge resolution bug that blocked compilation)
- Code, docstring, EVENT_SCHEMA.md, and tests all agree on the canonical (amount, from_vault) shape

closes: #432 