### PR TITLE
feat(revenue-pool): replace string panics with RevenuePoolError contract error

### DIFF
--- a/contracts/revenue_pool/src/lib.rs
+++ b/contracts/revenue_pool/src/lib.rs
@@ -1,6 +1,35 @@
 #![no_std]
 
-use soroban_sdk::{contract, contractimpl, token, Address, BytesN, Env, Map, Symbol, Vec};
+use soroban_sdk::{
+    contract, contracterror, contractimpl, token, Address, BytesN, Env, Map, Symbol, Vec,
+};
+
+#[contracterror]
+#[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u32)]
+pub enum RevenuePoolError {
+    NotInitialized = 1,
+    AlreadyInitialized = 2,
+    Unauthorized = 3,
+    UnauthorizedNotPendingAdmin = 4,
+    AlreadyPaused = 5,
+    NotPaused = 6,
+    Paused = 7,
+    AmountNotPositive = 8,
+    AmountExceedsMaxDistribute = 9,
+    InsufficientBalance = 10,
+    MaxDistributeNotPositive = 11,
+    DuplicateRecipient = 12,
+    InvalidRecipientContractSelf = 13,
+    InvalidRecipientNoTrustline = 14,
+    BatchEmpty = 15,
+    BatchTooLarge = 16,
+    TotalOverflow = 17,
+    InvalidConfigUsdcTokenIsContract = 18,
+    InvalidConfigUsdcTokenIsAdmin = 19,
+    NoPendingAdmin = 20,
+    VersionNotSet = 21,
+}
 
 /// Revenue settlement contract: receives USDC from vault deducts and distributes to developers.
 ///
@@ -17,13 +46,8 @@ const ADMIN_KEY: &str = "admin";
 const PENDING_ADMIN_KEY: &str = "pending_admin";
 const USDC_KEY: &str = "usdc";
 const MAX_DISTRIBUTE_KEY: &str = "max_distribute";
-const ERR_AMOUNT_NOT_POSITIVE: &str = "amount must be positive";
-const ERR_AMOUNT_EXCEEDS_MAX_DISTRIBUTE: &str = "amount exceeds max_distribute";
-const ERR_UNAUTHORIZED: &str = "unauthorized: caller is not admin";
-const ERR_INSUFFICIENT_BALANCE: &str = "insufficient USDC balance";
-const ERR_NOT_INITIALIZED: &str = "revenue pool not initialized";
-const ERR_DUPLICATE_RECIPIENT: &str = "duplicate recipient in batch";
 const VERSION_KEY: &str = "version";
+const PAUSED_KEY: &str = "paused";
 
 pub const DEFAULT_MAX_DISTRIBUTE: i128 = i128::MAX;
 
@@ -62,14 +86,14 @@ impl RevenuePool {
     pub fn init(env: Env, admin: Address, usdc_token: Address) {
         admin.require_auth();
         if usdc_token == env.current_contract_address() {
-            panic!("invalid config: usdc_token cannot be the contract itself");
+            env.panic_with_error(RevenuePoolError::InvalidConfigUsdcTokenIsContract);
         }
         if usdc_token == admin {
-            panic!("invalid config: usdc_token cannot be the admin address");
+            env.panic_with_error(RevenuePoolError::InvalidConfigUsdcTokenIsAdmin);
         }
         let inst = env.storage().instance();
         if inst.has(&Symbol::new(&env, ADMIN_KEY)) {
-            panic!("revenue pool already initialized");
+            env.panic_with_error(RevenuePoolError::AlreadyInitialized);
         }
         inst.set(&Symbol::new(&env, ADMIN_KEY), &admin);
         inst.set(&Symbol::new(&env, USDC_KEY), &usdc_token);
@@ -95,7 +119,7 @@ impl RevenuePool {
         env.storage()
             .instance()
             .get(&Symbol::new(&env, ADMIN_KEY))
-            .expect("revenue pool not initialized")
+            .unwrap_or_else(|| env.panic_with_error(RevenuePoolError::NotInitialized))
     }
 
     /// Initiate replacement of the current admin. Only the existing admin may call this.
@@ -115,7 +139,7 @@ impl RevenuePool {
         caller.require_auth();
         let current = Self::get_admin(env.clone());
         if caller != current {
-            panic!("unauthorized: caller is not admin");
+            env.panic_with_error(RevenuePoolError::Unauthorized);
         }
         let inst = env.storage().instance();
         inst.set(&Symbol::new(&env, PENDING_ADMIN_KEY), &new_admin);
@@ -144,7 +168,7 @@ impl RevenuePool {
         env.storage()
             .instance()
             .get(&Symbol::new(&env, USDC_KEY))
-            .expect("revenue pool not initialized")
+            .unwrap_or_else(|| env.panic_with_error(RevenuePoolError::NotInitialized))
     }
 
     /// Complete the admin transfer. Only the pending admin may call this.
@@ -164,10 +188,10 @@ impl RevenuePool {
         let inst = env.storage().instance();
         let pending: Address = inst
             .get(&Symbol::new(&env, PENDING_ADMIN_KEY))
-            .expect("no pending admin");
+            .unwrap_or_else(|| env.panic_with_error(RevenuePoolError::NoPendingAdmin));
 
         if caller != pending {
-            panic!("unauthorized: caller is not pending admin");
+            env.panic_with_error(RevenuePoolError::UnauthorizedNotPendingAdmin);
         }
 
         inst.set(&Symbol::new(&env, ADMIN_KEY), &pending);
@@ -185,7 +209,7 @@ impl RevenuePool {
             .get::<_, bool>(&Symbol::new(env, PAUSED_KEY))
             .unwrap_or(false)
         {
-            panic!("{}", ERR_PAUSED);
+            env.panic_with_error(RevenuePoolError::Paused);
         }
     }
 
@@ -203,9 +227,11 @@ impl RevenuePool {
         caller.require_auth();
         let admin = Self::get_admin(env.clone());
         if caller != admin {
-            panic!("{}", ERR_UNAUTHORIZED);
+            env.panic_with_error(RevenuePoolError::Unauthorized);
         }
-        assert!(!Self::is_paused(env.clone()), "revenue pool already paused");
+        if Self::is_paused(env.clone()) {
+            env.panic_with_error(RevenuePoolError::AlreadyPaused);
+        }
         env.storage()
             .instance()
             .set(&Symbol::new(&env, PAUSED_KEY), &true);
@@ -227,9 +253,11 @@ impl RevenuePool {
         caller.require_auth();
         let admin = Self::get_admin(env.clone());
         if caller != admin {
-            panic!("{}", ERR_UNAUTHORIZED);
+            env.panic_with_error(RevenuePoolError::Unauthorized);
         }
-        assert!(Self::is_paused(env.clone()), "revenue pool not paused");
+        if !Self::is_paused(env.clone()) {
+            env.panic_with_error(RevenuePoolError::NotPaused);
+        }
         env.storage()
             .instance()
             .set(&Symbol::new(&env, PAUSED_KEY), &false);
@@ -273,7 +301,7 @@ impl RevenuePool {
         caller.require_auth();
         let admin = Self::get_admin(env.clone());
         if caller != admin {
-            panic!("unauthorized: caller is not admin");
+            env.panic_with_error(RevenuePoolError::Unauthorized);
         }
         env.events().publish(
             (Symbol::new(&env, "receive_payment"), caller),
@@ -299,9 +327,11 @@ impl RevenuePool {
         caller.require_auth();
         let admin = Self::get_admin(env.clone());
         if caller != admin {
-            panic!("unauthorized: caller is not admin");
+            env.panic_with_error(RevenuePoolError::Unauthorized);
         }
-        assert!(max_distribute > 0, "max_distribute must be positive");
+        if max_distribute <= 0 {
+            env.panic_with_error(RevenuePoolError::MaxDistributeNotPositive);
+        }
         let old_max = Self::get_max_distribute(env.clone());
         env.storage()
             .instance()
@@ -312,11 +342,9 @@ impl RevenuePool {
         );
     }
 
-    fn validate_recipient(recipient: &Address, contract_self: &Address) {
-        // Rule 1 — no self-distributions (the contract sending to itself is almost
-        // certainly a logic bug; if you want to "reclaim" funds use a dedicated fn).
+    fn validate_recipient(env: &Env, recipient: &Address, contract_self: &Address) {
         if recipient == contract_self {
-            panic!("invalid recipient: cannot distribute to the contract itself");
+            env.panic_with_error(RevenuePoolError::InvalidRecipientContractSelf);
         }
     }
 
@@ -343,35 +371,32 @@ impl RevenuePool {
         Self::require_not_paused(&env);
         let admin = Self::get_admin(env.clone());
         if caller != admin {
-            panic!("{}", ERR_UNAUTHORIZED);
+            env.panic_with_error(RevenuePoolError::Unauthorized);
         }
         if amount <= 0 {
-            panic!("{}", ERR_AMOUNT_NOT_POSITIVE);
+            env.panic_with_error(RevenuePoolError::AmountNotPositive);
         }
         let max_distribute = Self::get_max_distribute(env.clone());
         if amount > max_distribute {
-            panic!("{}", ERR_AMOUNT_EXCEEDS_MAX_DISTRIBUTE);
+            env.panic_with_error(RevenuePoolError::AmountExceedsMaxDistribute);
         }
 
         let usdc_address: Address = env
             .storage()
             .instance()
             .get(&Symbol::new(&env, USDC_KEY))
-            .expect(ERR_NOT_INITIALIZED);
+            .unwrap_or_else(|| env.panic_with_error(RevenuePoolError::NotInitialized));
         let usdc = token::Client::new(&env, &usdc_address);
 
         let contract_address = env.current_contract_address();
-        Self::validate_recipient(&to, &contract_address);
+        Self::validate_recipient(&env, &to, &contract_address);
 
         let _ = usdc.try_balance(&to).unwrap_or_else(|_| {
-            panic!(
-                "invalid recipient: account does not exist \
-                                      or has no USDC trustline"
-            )
+            env.panic_with_error(RevenuePoolError::InvalidRecipientNoTrustline)
         });
 
         if usdc.balance(&contract_address) < amount {
-            panic!("{}", ERR_INSUFFICIENT_BALANCE);
+            env.panic_with_error(RevenuePoolError::InsufficientBalance);
         }
 
         env.storage()
@@ -458,15 +483,15 @@ impl RevenuePool {
         Self::require_not_paused(&env);
         let admin = Self::get_admin(env.clone());
         if caller != admin {
-            panic!("{}", ERR_UNAUTHORIZED);
+            env.panic_with_error(RevenuePoolError::Unauthorized);
         }
 
         let n = payments.len();
         if n == 0 {
-            panic!("batch_distribute requires at least one payment");
+            env.panic_with_error(RevenuePoolError::BatchEmpty);
         }
         if n > MAX_BATCH_SIZE {
-            panic!("batch too large");
+            env.panic_with_error(RevenuePoolError::BatchTooLarge);
         }
 
         // Phase 1: Precomputation, validation, and duplicate detection.
@@ -486,21 +511,21 @@ impl RevenuePool {
 
             // Reject duplicate recipients before any transfer is attempted.
             if seen.contains_key(to.clone()) {
-                panic!("{}", ERR_DUPLICATE_RECIPIENT);
+                env.panic_with_error(RevenuePoolError::DuplicateRecipient);
             }
             seen.set(to.clone(), true);
 
             // Validate each amount is strictly positive.
             if amount <= 0 {
-                panic!("{}", ERR_AMOUNT_NOT_POSITIVE);
+                env.panic_with_error(RevenuePoolError::AmountNotPositive);
             }
             if amount > max_distribute {
-                panic!("{}", ERR_AMOUNT_EXCEEDS_MAX_DISTRIBUTE);
+                env.panic_with_error(RevenuePoolError::AmountExceedsMaxDistribute);
             }
 
             total_amount = total_amount
                 .checked_add(amount)
-                .unwrap_or_else(|| panic!("total overflow"));
+                .unwrap_or_else(|| env.panic_with_error(RevenuePoolError::TotalOverflow));
         }
 
         // Phase 2: Balance Check — single external read before any writes.
@@ -508,23 +533,25 @@ impl RevenuePool {
             .storage()
             .instance()
             .get(&Symbol::new(&env, USDC_KEY))
-            .expect(ERR_NOT_INITIALIZED);
+            .unwrap_or_else(|| env.panic_with_error(RevenuePoolError::NotInitialized));
         let usdc = token::Client::new(&env, &usdc_address);
         let contract_address = env.current_contract_address();
 
         if usdc.balance(&contract_address) < total_amount {
-            panic!("{}", ERR_INSUFFICIENT_BALANCE);
+            env.panic_with_error(RevenuePoolError::InsufficientBalance);
         }
 
         // Extend TTL before executing transfers.
-        env.storage().instance().extend_ttl(LIFETIME_THRESHOLD, BUMP_AMOUNT);
+        env.storage()
+            .instance()
+            .extend_ttl(LIFETIME_THRESHOLD, BUMP_AMOUNT);
 
         // Phase 3: Execution — all validation passed, perform transfers.
         // Soroban's transaction model guarantees that if any transfer fails,
         // the entire transaction reverts (no partial state).
         for payment in payments.iter() {
             let (to, amount) = payment;
-            Self::validate_recipient(&to, &contract_address);
+            Self::validate_recipient(&env, &to, &contract_address);
             usdc.transfer(&contract_address, &to, &amount);
 
             // Emit one event per leg reflecting the final transferred amount.
@@ -548,7 +575,7 @@ impl RevenuePool {
             .storage()
             .instance()
             .get(&Symbol::new(&env, USDC_KEY))
-            .expect("revenue pool not initialized");
+            .unwrap_or_else(|| env.panic_with_error(RevenuePoolError::NotInitialized));
         let usdc = token::Client::new(&env, &usdc_address);
         usdc.balance(&env.current_contract_address())
     }
@@ -562,7 +589,7 @@ impl RevenuePool {
         caller.require_auth();
         let admin = Self::get_admin(env.clone());
         if caller != admin {
-            panic!("{}", ERR_UNAUTHORIZED);
+            env.panic_with_error(RevenuePoolError::Unauthorized);
         }
 
         // Perform the on-chain upgrade via the deployer interface.
@@ -587,7 +614,7 @@ impl RevenuePool {
         env.storage()
             .instance()
             .get(&Symbol::new(&env, VERSION_KEY))
-            .expect("version not set")
+            .unwrap_or_else(|| env.panic_with_error(RevenuePoolError::VersionNotSet))
     }
 }
 

--- a/contracts/revenue_pool/src/test.rs
+++ b/contracts/revenue_pool/src/test.rs
@@ -12,1026 +12,6 @@ fn create_usdc<'a>(
     admin: &Address,
 ) -> (Address, token::Client<'a>, token::StellarAssetClient<'a>) {
     let contract_address = env.register_stellar_asset_contract_v2(admin.clone());
-    extern crate std;
-
-    use super::*;
-    use soroban_sdk::testutils::{Address as _, Events as _};
-    use soroban_sdk::token;
-    use soroban_sdk::TryFromVal;
-    use soroban_sdk::{Address, Env, IntoVal, Symbol, Vec};
-
-    fn create_usdc<'a>(
-        env: &'a Env,
-        admin: &Address,
-    ) -> (Address, token::Client<'a>, token::StellarAssetClient<'a>) {
-        let contract_address = env.register_stellar_asset_contract_v2(admin.clone());
-        let address = contract_address.address();
-        let client = token::Client::new(env, &address);
-        let admin_client = token::StellarAssetClient::new(env, &address);
-        (address, client, admin_client)
-    }
-
-    fn create_pool(env: &Env) -> (Address, RevenuePoolClient<'_>) {
-        let address = env.register(RevenuePool, ());
-        let client = RevenuePoolClient::new(env, &address);
-        (address, client)
-    }
-
-    fn fund_pool(
-        usdc_admin_client: &token::StellarAssetClient,
-        pool_address: &Address,
-        amount: i128,
-    ) {
-        usdc_admin_client.mint(pool_address, &amount);
-    }
-
-    #[test]
-    fn init_success() {
-        let env = Env::default();
-        env.mock_all_auths();
-        let admin = Address::generate(&env);
-        let (_pool_addr, client) = create_pool(&env);
-        let (usdc, _, _) = create_usdc(&env, &admin);
-
-        client.init(&admin, &usdc);
-        assert_eq!(client.get_admin(), admin);
-        assert_eq!(client.balance(), 0);
-    }
-
-    #[test]
-    fn init_emits_event() {
-        let env = Env::default();
-        env.mock_all_auths();
-        let admin = Address::generate(&env);
-        let (_, client) = create_pool(&env);
-        let (usdc, _, _) = create_usdc(&env, &admin);
-
-        client.init(&admin, &usdc);
-
-        let events = env.events().all();
-        let init_event = events.last().unwrap();
-        let event_name = Symbol::try_from_val(&env, &init_event.1.get(0).unwrap()).unwrap();
-        assert_eq!(event_name, Symbol::new(&env, "init"));
-    }
-
-    #[test]
-    #[should_panic(expected = "revenue pool already initialized")]
-    fn init_double_panics() {
-        let env = Env::default();
-        env.mock_all_auths();
-        let admin = Address::generate(&env);
-        let (_, client) = create_pool(&env);
-        let (usdc, _, _) = create_usdc(&env, &admin);
-
-        client.init(&admin, &usdc);
-        client.init(&admin, &usdc);
-    }
-
-    #[test]
-    #[should_panic(expected = "revenue pool already initialized")]
-    fn init_double_different_admin_panics() {
-        let env = Env::default();
-        env.mock_all_auths();
-        let admin = Address::generate(&env);
-        let other_admin = Address::generate(&env);
-        let (_, client) = create_pool(&env);
-        let (usdc, _, _) = create_usdc(&env, &admin);
-        let (usdc2, _, _) = create_usdc(&env, &other_admin);
-
-        client.init(&admin, &usdc);
-        client.init(&other_admin, &usdc2);
-    }
-
-    #[test]
-    #[should_panic(expected = "invalid config: usdc_token cannot be the contract itself")]
-    fn init_usdc_token_is_contract_panics() {
-        let env = Env::default();
-        env.mock_all_auths();
-        let admin = Address::generate(&env);
-        let (pool_addr, client) = create_pool(&env);
-
-        // Passing the contract's own address as usdc_token should be rejected.
-        client.init(&admin, &pool_addr);
-    }
-
-    #[test]
-    #[should_panic(expected = "invalid config: usdc_token cannot be the admin address")]
-    fn init_usdc_token_is_admin_panics() {
-        let env = Env::default();
-        env.mock_all_auths();
-        let admin = Address::generate(&env);
-        let (_, client) = create_pool(&env);
-
-        // Passing the admin address as usdc_token should be rejected.
-        client.init(&admin, &admin);
-    }
-
-    #[test]
-    fn distribute_success() {
-        let env = Env::default();
-        env.mock_all_auths();
-        let admin = Address::generate(&env);
-        let developer = Address::generate(&env);
-        let (pool_addr, client) = create_pool(&env);
-        let (usdc_address, usdc_client, usdc_admin) = create_usdc(&env, &admin);
-
-        client.init(&admin, &usdc_address);
-        fund_pool(&usdc_admin, &pool_addr, 1_000);
-        client.distribute(&admin, &developer, &400);
-
-        assert_eq!(usdc_client.balance(&pool_addr), 600);
-        assert_eq!(usdc_client.balance(&developer), 400);
-    }
-
-    #[test]
-    #[should_panic(expected = "amount must be positive")]
-    fn distribute_zero_panics() {
-        let env = Env::default();
-        env.mock_all_auths();
-        let admin = Address::generate(&env);
-        let developer = Address::generate(&env);
-        let (_, client) = create_pool(&env);
-        let (usdc, _, _) = create_usdc(&env, &admin);
-
-        client.init(&admin, &usdc);
-        client.distribute(&admin, &developer, &0);
-    }
-
-    #[test]
-    #[should_panic(expected = "insufficient USDC balance")]
-    fn distribute_excess_panics() {
-        let env = Env::default();
-        env.mock_all_auths();
-        let admin = Address::generate(&env);
-        let developer = Address::generate(&env);
-        let (pool_addr, client) = create_pool(&env);
-        let (usdc_address, _, usdc_admin) = create_usdc(&env, &admin);
-
-        client.init(&admin, &usdc_address);
-        fund_pool(&usdc_admin, &pool_addr, 100);
-        client.distribute(&admin, &developer, &101);
-    }
-
-    #[test]
-    fn get_max_distribute_returns_default_when_not_set() {
-        let env = Env::default();
-        env.mock_all_auths();
-        let admin = Address::generate(&env);
-        let (_, client) = create_pool(&env);
-        let (usdc_address, _, _) = create_usdc(&env, &admin);
-
-        client.init(&admin, &usdc_address);
-
-        assert_eq!(client.get_max_distribute(), i128::MAX);
-    }
-
-    #[test]
-    fn set_max_distribute_updates_cap_and_emits_event() {
-        let env = Env::default();
-        env.mock_all_auths();
-        let admin = Address::generate(&env);
-        let (_, client) = create_pool(&env);
-        let (usdc_address, _, _) = create_usdc(&env, &admin);
-
-        client.init(&admin, &usdc_address);
-        client.set_max_distribute(&admin, &500);
-
-        assert_eq!(client.get_max_distribute(), 500);
-
-        let events = env.events().all();
-        let ev = events.last().unwrap();
-        let t0 = Symbol::try_from_val(&env, &ev.1.get(0).unwrap()).unwrap();
-        assert_eq!(t0, Symbol::new(&env, "set_max_distribute"));
-
-        let data: (i128, i128) = ev.2.into_val(&env);
-        assert_eq!(data, (i128::MAX, 500));
-    }
-
-    #[test]
-    #[should_panic(expected = "unauthorized: caller is not admin")]
-    fn set_max_distribute_unauthorized_panics() {
-        let env = Env::default();
-        env.mock_all_auths();
-        let admin = Address::generate(&env);
-        let attacker = Address::generate(&env);
-        let (_, client) = create_pool(&env);
-        let (usdc_address, _, _) = create_usdc(&env, &admin);
-
-        client.init(&admin, &usdc_address);
-        client.set_max_distribute(&attacker, &500);
-    }
-
-    #[test]
-    #[should_panic(expected = "max_distribute must be positive")]
-    fn set_max_distribute_zero_panics() {
-        let env = Env::default();
-        env.mock_all_auths();
-        let admin = Address::generate(&env);
-        let (_, client) = create_pool(&env);
-        let (usdc_address, _, _) = create_usdc(&env, &admin);
-
-        client.init(&admin, &usdc_address);
-        client.set_max_distribute(&admin, &0);
-    }
-
-    #[test]
-    #[should_panic(expected = "amount exceeds max_distribute")]
-    fn distribute_above_max_distribute_panics() {
-        let env = Env::default();
-        env.mock_all_auths();
-        let admin = Address::generate(&env);
-        let developer = Address::generate(&env);
-        let (pool_addr, client) = create_pool(&env);
-        let (usdc_address, _, usdc_admin) = create_usdc(&env, &admin);
-
-        client.init(&admin, &usdc_address);
-        fund_pool(&usdc_admin, &pool_addr, 500);
-        client.set_max_distribute(&admin, &100);
-        client.distribute(&admin, &developer, &101);
-    }
-
-    #[test]
-    #[should_panic(expected = "amount exceeds max_distribute")]
-    fn batch_distribute_leg_above_max_distribute_panics() {
-        let env = Env::default();
-        env.mock_all_auths();
-        let admin = Address::generate(&env);
-        let dev1 = Address::generate(&env);
-        let dev2 = Address::generate(&env);
-        let (pool_addr, client) = create_pool(&env);
-        let (usdc_address, _, usdc_admin) = create_usdc(&env, &admin);
-
-        client.init(&admin, &usdc_address);
-        fund_pool(&usdc_admin, &pool_addr, 1000);
-        client.set_max_distribute(&admin, &50);
-
-        let mut payments: Vec<(Address, i128)> = Vec::new(&env);
-        payments.push_back((dev1.clone(), 50_i128));
-        payments.push_back((dev2.clone(), 51_i128));
-
-        client.batch_distribute(&admin, &payments);
-    }
-
-    #[test]
-    fn set_admin_two_step_transfers_control() {
-        let env = Env::default();
-        env.mock_all_auths();
-        let admin = Address::generate(&env);
-        let new_admin = Address::generate(&env);
-        let developer = Address::generate(&env);
-        let (pool_addr, client) = create_pool(&env);
-        let (usdc_address, usdc_client, usdc_admin) = create_usdc(&env, &admin);
-
-        client.init(&admin, &usdc_address);
-        fund_pool(&usdc_admin, &pool_addr, 300);
-
-        client.set_admin(&admin, &new_admin);
-        assert_eq!(client.get_admin(), admin);
-
-        client.claim_admin(&new_admin);
-        assert_eq!(client.get_admin(), new_admin);
-
-        client.distribute(&new_admin, &developer, &100);
-        assert_eq!(usdc_client.balance(&developer), 100);
-    }
-
-    #[test]
-    #[should_panic(expected = "unauthorized: caller is not admin")]
-    fn set_admin_unauthorized_panics() {
-        let env = Env::default();
-        env.mock_all_auths();
-        let admin = Address::generate(&env);
-        let attacker = Address::generate(&env);
-        let new_admin = Address::generate(&env);
-        let (_, client) = create_pool(&env);
-        let (usdc, _, _) = create_usdc(&env, &admin);
-
-        client.init(&admin, &usdc);
-        client.set_admin(&attacker, &new_admin);
-    }
-
-    #[test]
-    #[should_panic(expected = "unauthorized: caller is not pending admin")]
-    fn claim_admin_wrong_address_panics() {
-        let env = Env::default();
-        env.mock_all_auths();
-        let admin = Address::generate(&env);
-        let new_admin = Address::generate(&env);
-        let attacker = Address::generate(&env);
-        let (_, client) = create_pool(&env);
-        let (usdc, _, _) = create_usdc(&env, &admin);
-
-        client.init(&admin, &usdc);
-        client.set_admin(&admin, &new_admin);
-        client.claim_admin(&attacker);
-    }
-
-    #[test]
-    fn admin_transfer_emits_events() {
-        let env = Env::default();
-        env.mock_all_auths();
-        let admin = Address::generate(&env);
-        let new_admin = Address::generate(&env);
-        let (_, client) = create_pool(&env);
-        let (usdc, _, _) = create_usdc(&env, &admin);
-
-        client.init(&admin, &usdc);
-
-        // Step 1 event
-        client.set_admin(&admin, &new_admin);
-        let events = env.events().all();
-        let transfer_started = events.last().unwrap();
-
-        // FIX: Convert Val to Symbol for comparison
-        let event_name = Symbol::try_from_val(&env, &transfer_started.1.get(0).unwrap()).unwrap();
-        assert_eq!(event_name, Symbol::new(&env, "admin_transfer_started"));
-
-        // Step 2 event
-        client.claim_admin(&new_admin);
-        let events = env.events().all();
-        let transfer_completed = events.last().unwrap();
-
-        // FIX: Convert Val to Symbol for comparison
-        let event_name_comp =
-            Symbol::try_from_val(&env, &transfer_completed.1.get(0).unwrap()).unwrap();
-        assert_eq!(
-            event_name_comp,
-            Symbol::new(&env, "admin_transfer_completed")
-        );
-    }
-
-    #[test]
-    fn receive_payment_emits_event() {
-        let env = Env::default();
-        env.mock_all_auths();
-        let admin = Address::generate(&env);
-        let (_, client) = create_pool(&env);
-        let (usdc, _, _) = create_usdc(&env, &admin);
-
-        client.init(&admin, &usdc);
-        client.receive_payment(&admin, &250, &true);
-
-        let events = env.events().all();
-        let receive_payment_event = events.last().unwrap();
-        let event_name =
-            Symbol::try_from_val(&env, &receive_payment_event.1.get(0).unwrap()).unwrap();
-        assert_eq!(event_name, Symbol::new(&env, "receive_payment"));
-
-        let amount_and_source: (i128, bool) =
-            <(i128, bool)>::try_from_val(&env, &receive_payment_event.2).unwrap();
-        assert_eq!(amount_and_source, (250, true));
-    }
-
-    #[test]
-    #[should_panic(expected = "unauthorized: caller is not admin")]
-    fn receive_payment_non_admin_panics() {
-        let env = Env::default();
-        env.mock_all_auths();
-        let admin = Address::generate(&env);
-        let attacker = Address::generate(&env);
-        let (_, client) = create_pool(&env);
-        let (usdc, _, _) = create_usdc(&env, &admin);
-
-        client.init(&admin, &usdc);
-        client.receive_payment(&attacker, &250, &true);
-    }
-
-    #[test]
-    fn receive_payment_is_event_only_and_does_not_move_tokens() {
-        let env = Env::default();
-        env.mock_all_auths();
-        let admin = Address::generate(&env);
-        let developer = Address::generate(&env);
-        let (pool_addr, client) = create_pool(&env);
-        let (usdc_address, usdc_client, usdc_admin) = create_usdc(&env, &admin);
-
-        client.init(&admin, &usdc_address);
-        fund_pool(&usdc_admin, &pool_addr, 500);
-
-        let before_pool = usdc_client.balance(&pool_addr);
-        let before_developer = usdc_client.balance(&developer);
-
-        client.receive_payment(&admin, &250, &true);
-
-        assert_eq!(usdc_client.balance(&pool_addr), before_pool);
-        assert_eq!(usdc_client.balance(&developer), before_developer);
-    }
-
-    // ---------------------------------------------------------------------------
-    // Batch distribute tests - Comprehensive coverage
-    // ---------------------------------------------------------------------------
-
-    #[test]
-    fn batch_distribute_success() {
-        let env = Env::default();
-        env.mock_all_auths();
-        let admin = Address::generate(&env);
-        let dev1 = Address::generate(&env);
-        let dev2 = Address::generate(&env);
-        let (pool_addr, client) = create_pool(&env);
-        let (usdc_address, usdc_client, usdc_admin) = create_usdc(&env, &admin);
-
-        client.init(&admin, &usdc_address);
-        fund_pool(&usdc_admin, &pool_addr, 1000);
-
-        let mut payments: Vec<(Address, i128)> = Vec::new(&env);
-        payments.push_back((dev1.clone(), 300_i128));
-        payments.push_back((dev2.clone(), 200_i128));
-        client.batch_distribute(&admin, &payments);
-
-        assert_eq!(usdc_client.balance(&dev1), 300);
-        assert_eq!(usdc_client.balance(&dev2), 200);
-        assert_eq!(client.balance(), 500);
-    }
-
-    #[test]
-    fn batch_distribute_success_events() {
-        let env = Env::default();
-        env.mock_all_auths();
-        let admin = Address::generate(&env);
-        let dev1 = Address::generate(&env);
-        let dev2 = Address::generate(&env);
-        let (pool_addr, client) = create_pool(&env);
-        let (usdc_address, _, usdc_admin) = create_usdc(&env, &admin);
-
-        client.init(&admin, &usdc_address);
-        fund_pool(&usdc_admin, &pool_addr, 1000);
-
-        let mut payments: Vec<(Address, i128)> = Vec::new(&env);
-        payments.push_back((dev1.clone(), 300_i128));
-        payments.push_back((dev2.clone(), 200_i128));
-        client.batch_distribute(&admin, &payments);
-
-        let events = env.events().all();
-        assert!(events.len() >= 4);
-
-        for i in 0..events.len() {
-            let (_, topics, data) = events.get(i).unwrap();
-            let topic_0 = topics.get(0).unwrap();
-            if let Ok(event_name) = Symbol::try_from_val(&env, &topic_0) {
-                if event_name == Symbol::new(&env, "batch_distribute") {
-                    let value: i128 = i128::try_from_val(&env, &data).unwrap();
-                    assert!(value == 300 || value == 200);
-                }
-            }
-        }
-    }
-
-    #[test]
-    fn receive_payment_emits_event_for_admin() {
-        let env = Env::default();
-        env.mock_all_auths();
-        let admin = Address::generate(&env);
-        let (_, client) = create_pool(&env);
-        let (usdc, _, _) = create_usdc(&env, &admin);
-
-        client.init(&admin, &usdc);
-        client.receive_payment(&admin, &250, &true);
-
-        let events = env.events().all();
-        let receive_event = events.last().unwrap();
-        let event_name = Symbol::try_from_val(&env, &receive_event.1.get(0).unwrap()).unwrap();
-        assert_eq!(event_name, Symbol::new(&env, "receive_payment"));
-
-        let caller: Address =
-            Address::try_from_val(&env, &receive_event.1.get(1).unwrap()).unwrap();
-        assert_eq!(caller, admin);
-
-        let (amount, from_vault): (i128, bool) = receive_event.2.into_val(&env);
-        assert_eq!(amount, 250);
-        assert!(from_vault);
-    }
-
-    #[test]
-    #[should_panic(expected = "no pending admin")]
-    fn claim_admin_without_pending_panics() {
-        let env = Env::default();
-        env.mock_all_auths();
-        let admin = Address::generate(&env);
-        let candidate = Address::generate(&env);
-        let (_, client) = create_pool(&env);
-        let (usdc, _, _) = create_usdc(&env, &admin);
-
-        client.init(&admin, &usdc);
-        client.claim_admin(&candidate);
-    }
-
-    #[test]
-    #[should_panic(expected = "unauthorized: caller is not pending admin")]
-    fn claim_admin_wrong_caller_panics() {
-        let env = Env::default();
-        env.mock_all_auths();
-        let admin = Address::generate(&env);
-        let pending_admin = Address::generate(&env);
-        let attacker = Address::generate(&env);
-        let (_, client) = create_pool(&env);
-        let (usdc, _, _) = create_usdc(&env, &admin);
-
-        client.init(&admin, &usdc);
-        client.set_admin(&admin, &pending_admin);
-        client.claim_admin(&attacker);
-    }
-
-    #[test]
-    #[should_panic(expected = "invalid recipient: cannot distribute to the contract itself")]
-    fn distribute_to_self_panics() {
-        let env = Env::default();
-        env.mock_all_auths();
-        let admin = Address::generate(&env);
-        let (pool_addr, client) = create_pool(&env);
-        let (usdc_address, _, usdc_admin) = create_usdc(&env, &admin);
-
-        client.init(&admin, &usdc_address);
-        fund_pool(&usdc_admin, &pool_addr, 100);
-        client.distribute(&admin, &pool_addr, &50);
-    }
-
-    #[test]
-    #[should_panic(expected = "amount must be positive")]
-    fn batch_distribute_zero_amount_panics() {
-        let env = Env::default();
-        env.mock_all_auths();
-        let admin = Address::generate(&env);
-        let dev = Address::generate(&env);
-        let (_, client) = create_pool(&env);
-        let (usdc_address, _, _) = create_usdc(&env, &admin);
-
-        client.init(&admin, &usdc_address);
-
-        let mut payments: Vec<(Address, i128)> = Vec::new(&env);
-        payments.push_back((dev, 0));
-        client.batch_distribute(&admin, &payments);
-    }
-
-    // ---------------------------------------------------------------------------
-    // Event schema tests (Issue #256)
-    // Each test below pins the exact topic/data layout documented in EVENT_SCHEMA.md
-    // ---------------------------------------------------------------------------
-
-    #[test]
-    fn init_event_topics_and_data() {
-        let env = Env::default();
-        env.mock_all_auths();
-        let admin = Address::generate(&env);
-        let (_, client) = create_pool(&env);
-        let (usdc, _, _) = create_usdc(&env, &admin);
-
-        client.init(&admin, &usdc);
-
-        let events = env.events().all();
-        let ev = events.last().unwrap();
-
-        // topic 0 = "init"
-        let t0 = Symbol::try_from_val(&env, &ev.1.get(0).unwrap()).unwrap();
-        assert_eq!(t0, Symbol::new(&env, "init"));
-
-        // topic 1 = admin address
-        let t1 = Address::try_from_val(&env, &ev.1.get(1).unwrap()).unwrap();
-        assert_eq!(t1, admin);
-
-        // data = usdc_token address
-        let data = Address::try_from_val(&env, &ev.2).unwrap();
-        assert_eq!(data, usdc);
-    }
-
-    #[test]
-    fn admin_transfer_started_event_topics_and_data() {
-        let env = Env::default();
-        env.mock_all_auths();
-        let admin = Address::generate(&env);
-        let new_admin = Address::generate(&env);
-        let (_, client) = create_pool(&env);
-        let (usdc, _, _) = create_usdc(&env, &admin);
-
-        client.init(&admin, &usdc);
-        client.set_admin(&admin, &new_admin);
-
-        let events = env.events().all();
-        let ev = events.last().unwrap();
-
-        // topic 0 = "admin_transfer_started"
-        let t0 = Symbol::try_from_val(&env, &ev.1.get(0).unwrap()).unwrap();
-        assert_eq!(t0, Symbol::new(&env, "admin_transfer_started"));
-
-        // topic 1 = current admin
-        let t1 = Address::try_from_val(&env, &ev.1.get(1).unwrap()).unwrap();
-        assert_eq!(t1, admin);
-
-        // data = pending admin
-        let data = Address::try_from_val(&env, &ev.2).unwrap();
-        assert_eq!(data, new_admin);
-    }
-
-    #[test]
-    fn admin_changed_event_topics_and_data() {
-        let env = Env::default();
-        env.mock_all_auths();
-        let admin = Address::generate(&env);
-        let new_admin = Address::generate(&env);
-        let (_, client) = create_pool(&env);
-        let (usdc, _, _) = create_usdc(&env, &admin);
-
-        client.init(&admin, &usdc);
-        client.set_admin(&admin, &new_admin);
-
-        let events = env.events().all();
-        // After set_admin, last event is admin_transfer_started and the one before it is admin_changed.
-        let ev = events.get(events.len() - 2).unwrap();
-
-        // topic 0 = "admin_changed"
-        let t0 = Symbol::try_from_val(&env, &ev.1.get(0).unwrap()).unwrap();
-        assert_eq!(t0, Symbol::new(&env, "admin_changed"));
-
-        // topic 1 = current admin
-        let t1 = Address::try_from_val(&env, &ev.1.get(1).unwrap()).unwrap();
-        assert_eq!(t1, admin);
-
-        // data = (old_admin, new_admin)
-        let data: (Address, Address) = ev.2.into_val(&env);
-        assert_eq!(data.0, admin);
-        assert_eq!(data.1, new_admin);
-    }
-
-    #[test]
-    fn admin_transfer_completed_event_topics_and_data() {
-        let env = Env::default();
-        env.mock_all_auths();
-        let admin = Address::generate(&env);
-        let new_admin = Address::generate(&env);
-        let (_, client) = create_pool(&env);
-        let (usdc, _, _) = create_usdc(&env, &admin);
-
-        client.init(&admin, &usdc);
-        client.set_admin(&admin, &new_admin);
-        client.claim_admin(&new_admin);
-
-        let events = env.events().all();
-        let ev = events.last().unwrap();
-
-        // topic 0 = "admin_transfer_completed"
-        let t0 = Symbol::try_from_val(&env, &ev.1.get(0).unwrap()).unwrap();
-        assert_eq!(t0, Symbol::new(&env, "admin_transfer_completed"));
-
-        // topic 1 = new admin
-        let t1 = Address::try_from_val(&env, &ev.1.get(1).unwrap()).unwrap();
-        assert_eq!(t1, new_admin);
-
-        // data = () empty
-        let _: () = ev.2.into_val(&env);
-    }
-
-    #[test]
-    fn receive_payment_event_from_vault_true() {
-        let env = Env::default();
-        env.mock_all_auths();
-        let admin = Address::generate(&env);
-        let (_, client) = create_pool(&env);
-        let (usdc, _, _) = create_usdc(&env, &admin);
-
-        client.init(&admin, &usdc);
-        client.receive_payment(&admin, &5_000_000, &true);
-
-        let events = env.events().all();
-        let ev = events.last().unwrap();
-
-        // topic 0 = "receive_payment"
-        let t0 = Symbol::try_from_val(&env, &ev.1.get(0).unwrap()).unwrap();
-        assert_eq!(t0, Symbol::new(&env, "receive_payment"));
-
-        // topic 1 = caller (admin)
-        let t1 = Address::try_from_val(&env, &ev.1.get(1).unwrap()).unwrap();
-        assert_eq!(t1, admin);
-
-        // data = (amount, from_vault)
-        let (amount, from_vault): (i128, bool) = ev.2.into_val(&env);
-        assert_eq!(amount, 5_000_000);
-        assert!(from_vault);
-    }
-
-    #[test]
-    fn receive_payment_event_from_vault_false() {
-        let env = Env::default();
-        env.mock_all_auths();
-        let admin = Address::generate(&env);
-        let (_, client) = create_pool(&env);
-        let (usdc, _, _) = create_usdc(&env, &admin);
-
-        client.init(&admin, &usdc);
-        client.receive_payment(&admin, &1_000_000, &false);
-
-        let events = env.events().all();
-        let ev = events.last().unwrap();
-
-        let (amount, from_vault): (i128, bool) = ev.2.into_val(&env);
-        assert_eq!(amount, 1_000_000);
-        assert!(!from_vault);
-    }
-
-    #[test]
-    fn distribute_event_topics_and_data() {
-        let env = Env::default();
-        env.mock_all_auths();
-        let admin = Address::generate(&env);
-        let developer = Address::generate(&env);
-        let (pool_addr, client) = create_pool(&env);
-        let (usdc_address, _, usdc_admin) = create_usdc(&env, &admin);
-
-        client.init(&admin, &usdc_address);
-        fund_pool(&usdc_admin, &pool_addr, 1_000_000);
-        client.distribute(&admin, &developer, &1_000_000);
-
-        let events = env.events().all();
-        let ev = events.last().unwrap();
-
-        // topic 0 = "distribute"
-        let t0 = Symbol::try_from_val(&env, &ev.1.get(0).unwrap()).unwrap();
-        assert_eq!(t0, Symbol::new(&env, "distribute"));
-
-        // topic 1 = recipient
-        let t1 = Address::try_from_val(&env, &ev.1.get(1).unwrap()).unwrap();
-        assert_eq!(t1, developer);
-
-        // data = amount
-        let amount: i128 = ev.2.into_val(&env);
-        assert_eq!(amount, 1_000_000);
-    }
-
-    #[test]
-    fn batch_distribute_event_topics_and_data() {
-        let env = Env::default();
-        env.mock_all_auths();
-        let admin = Address::generate(&env);
-        let dev1 = Address::generate(&env);
-        let dev2 = Address::generate(&env);
-        let dev3 = Address::generate(&env);
-        let (pool_addr, client) = create_pool(&env);
-        let (usdc_address, _, usdc_admin) = create_usdc(&env, &admin);
-
-        client.init(&admin, &usdc_address);
-        fund_pool(&usdc_admin, &pool_addr, 3_500_000);
-
-        let mut payments: Vec<(Address, i128)> = Vec::new(&env);
-        payments.push_back((dev1.clone(), 1_000_000_i128));
-        payments.push_back((dev2.clone(), 2_000_000_i128));
-        payments.push_back((dev3.clone(), 500_000_i128));
-        client.batch_distribute(&admin, &payments);
-
-        let all_events = env.events().all();
-        let batch_events: std::vec::Vec<_> = all_events
-            .iter()
-            .filter(|e| {
-                e.1.get(0)
-                    .and_then(|v| Symbol::try_from_val(&env, &v).ok())
-                    .map(|s| s == Symbol::new(&env, "batch_distribute"))
-                    .unwrap_or(false)
-            })
-            .collect();
-
-        // 3 payments → 3 batch_distribute events
-        assert_eq!(batch_events.len(), 3);
-
-        // verify each event has correct topic 0 and a positive amount
-        for ev in batch_events.iter() {
-            let t0 = Symbol::try_from_val(&env, &ev.1.get(0).unwrap()).unwrap();
-            assert_eq!(t0, Symbol::new(&env, "batch_distribute"));
-            let amount: i128 = ev.2.into_val(&env);
-            assert!(amount > 0);
-        }
-    }
-
-    #[test]
-    fn batch_distribute_is_atomic_all_or_nothing() {
-        // If any payment fails the entire batch reverts — no events emitted.
-        let env = Env::default();
-        env.mock_all_auths();
-        let admin = Address::generate(&env);
-        let dev1 = Address::generate(&env);
-        let dev2 = Address::generate(&env);
-        let (pool_addr, client) = create_pool(&env);
-        let (usdc_address, _, usdc_admin) = create_usdc(&env, &admin);
-
-        client.init(&admin, &usdc_address);
-        fund_pool(&usdc_admin, &pool_addr, 100);
-
-        let mut payments: Vec<(Address, i128)> = Vec::new(&env);
-        payments.push_back((dev1.clone(), 60_i128));
-        payments.push_back((dev2.clone(), 60_i128)); // total 120 > balance 100
-
-        let result = client.try_batch_distribute(&admin, &payments);
-        assert!(result.is_err());
-
-        // balance unchanged
-        assert_eq!(client.balance(), 100);
-    }
-
-    // ---------------------------------------------------------------------------
-    // get_admin() and get_usdc_token() getter tests  (Issue #265)
-    // ---------------------------------------------------------------------------
-
-    #[test]
-    fn get_admin_returns_correct_address() {
-        let env = Env::default();
-        env.mock_all_auths();
-        let admin = Address::generate(&env);
-        let (_, client) = create_pool(&env);
-        let (usdc, _, _) = create_usdc(&env, &admin);
-
-        client.init(&admin, &usdc);
-
-        assert_eq!(client.get_admin(), admin);
-    }
-
-    #[test]
-    fn get_admin_reflects_updated_admin_after_transfer() {
-        let env = Env::default();
-        env.mock_all_auths();
-        let admin = Address::generate(&env);
-        let new_admin = Address::generate(&env);
-        let (_, client) = create_pool(&env);
-        let (usdc, _, _) = create_usdc(&env, &admin);
-
-        client.init(&admin, &usdc);
-        assert_eq!(client.get_admin(), admin);
-
-        // Pending phase: get_admin() still returns old admin
-        client.set_admin(&admin, &new_admin);
-        assert_eq!(client.get_admin(), admin);
-
-        // After claim: admin updated
-        client.claim_admin(&new_admin);
-        assert_eq!(client.get_admin(), new_admin);
-    }
-
-    #[test]
-    #[should_panic(expected = "revenue pool not initialized")]
-    fn get_admin_before_init_panics() {
-        let env = Env::default();
-        env.mock_all_auths();
-        let (_, client) = create_pool(&env);
-
-        client.get_admin();
-    }
-
-    #[test]
-    fn get_usdc_token_returns_correct_address() {
-        let env = Env::default();
-        env.mock_all_auths();
-        let admin = Address::generate(&env);
-        let (_, client) = create_pool(&env);
-        let (usdc, _, _) = create_usdc(&env, &admin);
-
-        client.init(&admin, &usdc);
-
-        assert_eq!(client.get_usdc_token(), usdc);
-    }
-
-    #[test]
-    fn get_usdc_token_is_immutable_after_init() {
-        // The USDC token address must never change after initialization —
-        // this test guards against accidental mutation.
-        let env = Env::default();
-        env.mock_all_auths();
-        let admin = Address::generate(&env);
-        let new_admin = Address::generate(&env);
-        let (_, client) = create_pool(&env);
-        let (usdc, _, _) = create_usdc(&env, &admin);
-
-        client.init(&admin, &usdc);
-        let token_before = client.get_usdc_token();
-
-        // Admin transfer must not affect the token address
-        client.set_admin(&admin, &new_admin);
-        client.claim_admin(&new_admin);
-
-        assert_eq!(client.get_usdc_token(), token_before);
-    }
-
-    #[test]
-    #[should_panic(expected = "revenue pool not initialized")]
-    fn get_usdc_token_before_init_panics() {
-        let env = Env::default();
-        env.mock_all_auths();
-        let (_, client) = create_pool(&env);
-
-        client.get_usdc_token();
-    }
-
-    // ---------------------------------------------------------------------------
-    // batch_distribute length-cap tests (resource exhaustion prevention)
-    // ---------------------------------------------------------------------------
-
-    #[test]
-    #[should_panic(expected = "batch_distribute requires at least one payment")]
-    fn batch_distribute_empty_panics() {
-        let env = Env::default();
-        env.mock_all_auths();
-        let admin = Address::generate(&env);
-        let (_, client) = create_pool(&env);
-        let (usdc_address, _, _) = create_usdc(&env, &admin);
-
-        client.init(&admin, &usdc_address);
-
-        let payments: Vec<(Address, i128)> = Vec::new(&env);
-        client.batch_distribute(&admin, &payments);
-    }
-
-    #[test]
-    #[should_panic(expected = "batch too large")]
-    fn batch_distribute_too_large_panics() {
-        let env = Env::default();
-        env.mock_all_auths();
-        let admin = Address::generate(&env);
-        let (pool_addr, client) = create_pool(&env);
-        let (usdc_address, _, usdc_admin) = create_usdc(&env, &admin);
-
-        client.init(&admin, &usdc_address);
-        fund_pool(&usdc_admin, &pool_addr, 100_000);
-
-        // Build a batch of MAX_BATCH_SIZE + 1 entries
-        let mut payments: Vec<(Address, i128)> = Vec::new(&env);
-        for _ in 0..=crate::MAX_BATCH_SIZE {
-            payments.push_back((Address::generate(&env), 1_i128));
-        }
-        client.batch_distribute(&admin, &payments);
-    }
-
-    #[test]
-    fn batch_distribute_at_max_size_succeeds() {
-        let env = Env::default();
-        env.mock_all_auths();
-        let admin = Address::generate(&env);
-        let (pool_addr, client) = create_pool(&env);
-        let (usdc_address, usdc_client, usdc_admin) = create_usdc(&env, &admin);
-
-        client.init(&admin, &usdc_address);
-        let amount_per = 10_i128;
-        let total = amount_per * (crate::MAX_BATCH_SIZE as i128);
-        fund_pool(&usdc_admin, &pool_addr, total);
-
-        // Build a batch of exactly MAX_BATCH_SIZE entries
-        let mut payments: Vec<(Address, i128)> = Vec::new(&env);
-        for _ in 0..crate::MAX_BATCH_SIZE {
-            payments.push_back((Address::generate(&env), amount_per));
-        }
-        client.batch_distribute(&admin, &payments);
-
-        // Pool should be drained
-        assert_eq!(usdc_client.balance(&pool_addr), 0);
-    }
-
-    #[test]
-    #[should_panic(expected = "amount must be positive")]
-    fn batch_distribute_negative_amount_panics() {
-        let env = Env::default();
-        env.mock_all_auths();
-        let admin = Address::generate(&env);
-        let dev = Address::generate(&env);
-        let (_, client) = create_pool(&env);
-        let (usdc_address, _, _) = create_usdc(&env, &admin);
-
-        client.init(&admin, &usdc_address);
-
-        let mut payments: Vec<(Address, i128)> = Vec::new(&env);
-        payments.push_back((dev, -100));
-        client.batch_distribute(&admin, &payments);
-    }
-
-    #[test]
-    #[should_panic(expected = "unauthorized: caller is not admin")]
-    fn batch_distribute_unauthorized_panics() {
-        let env = Env::default();
-        env.mock_all_auths();
-        let admin = Address::generate(&env);
-        let attacker = Address::generate(&env);
-        let dev = Address::generate(&env);
-        let (pool_addr, client) = create_pool(&env);
-        let (usdc_address, _, usdc_admin) = create_usdc(&env, &admin);
-
-        client.init(&admin, &usdc_address);
-        fund_pool(&usdc_admin, &pool_addr, 1000);
-
-        let mut payments: Vec<(Address, i128)> = Vec::new(&env);
-        payments.push_back((dev, 100));
-        client.batch_distribute(&attacker, &payments);
-    }
-
-    #[test]
-    #[should_panic(expected = "invalid recipient: cannot distribute to the contract itself")]
-    fn batch_distribute_self_recipient_panics() {
-        let env = Env::default();
-        env.mock_all_auths();
-        let admin = Address::generate(&env);
-        let (pool_addr, client) = create_pool(&env);
-        let (usdc_address, _, usdc_admin) = create_usdc(&env, &admin);
-
-        client.init(&admin, &usdc_address);
-        fund_pool(&usdc_admin, &pool_addr, 1000);
-
-        let mut payments: Vec<(Address, i128)> = Vec::new(&env);
-        payments.push_back((pool_addr, 100));
-        client.batch_distribute(&admin, &payments);
-    }
-
     let address = contract_address.address();
     let client = token::Client::new(env, &address);
     let admin_client = token::StellarAssetClient::new(env, &address);
@@ -1078,7 +58,6 @@ fn init_emits_event() {
 }
 
 #[test]
-#[should_panic(expected = "revenue pool already initialized")]
 fn init_double_panics() {
     let env = Env::default();
     env.mock_all_auths();
@@ -1087,11 +66,11 @@ fn init_double_panics() {
     let (usdc, _, _) = create_usdc(&env, &admin);
 
     client.init(&admin, &usdc);
-    client.init(&admin, &usdc);
+    let result = client.try_init(&admin, &usdc);
+    assert!(result.is_err());
 }
 
 #[test]
-#[should_panic(expected = "revenue pool already initialized")]
 fn init_double_different_admin_panics() {
     let env = Env::default();
     env.mock_all_auths();
@@ -1102,31 +81,30 @@ fn init_double_different_admin_panics() {
     let (usdc2, _, _) = create_usdc(&env, &other_admin);
 
     client.init(&admin, &usdc);
-    client.init(&other_admin, &usdc2);
+    let result = client.try_init(&other_admin, &usdc2);
+    assert!(result.is_err());
 }
 
 #[test]
-#[should_panic(expected = "invalid config: usdc_token cannot be the contract itself")]
 fn init_usdc_token_is_contract_panics() {
     let env = Env::default();
     env.mock_all_auths();
     let admin = Address::generate(&env);
     let (pool_addr, client) = create_pool(&env);
 
-    // Passing the contract's own address as usdc_token should be rejected.
-    client.init(&admin, &pool_addr);
+    let result = client.try_init(&admin, &pool_addr);
+    assert!(result.is_err());
 }
 
 #[test]
-#[should_panic(expected = "invalid config: usdc_token cannot be the admin address")]
 fn init_usdc_token_is_admin_panics() {
     let env = Env::default();
     env.mock_all_auths();
     let admin = Address::generate(&env);
     let (_, client) = create_pool(&env);
 
-    // Passing the admin address as usdc_token should be rejected.
-    client.init(&admin, &admin);
+    let result = client.try_init(&admin, &admin);
+    assert!(result.is_err());
 }
 
 #[test]
@@ -1147,7 +125,6 @@ fn distribute_success() {
 }
 
 #[test]
-#[should_panic(expected = "amount must be positive")]
 fn distribute_zero_panics() {
     let env = Env::default();
     env.mock_all_auths();
@@ -1157,11 +134,11 @@ fn distribute_zero_panics() {
     let (usdc, _, _) = create_usdc(&env, &admin);
 
     client.init(&admin, &usdc);
-    client.distribute(&admin, &developer, &0);
+    let result = client.try_distribute(&admin, &developer, &0);
+    assert!(result.is_err());
 }
 
 #[test]
-#[should_panic(expected = "insufficient USDC balance")]
 fn distribute_excess_panics() {
     let env = Env::default();
     env.mock_all_auths();
@@ -1172,7 +149,8 @@ fn distribute_excess_panics() {
 
     client.init(&admin, &usdc_address);
     fund_pool(&usdc_admin, &pool_addr, 100);
-    client.distribute(&admin, &developer, &101);
+    let result = client.try_distribute(&admin, &developer, &101);
+    assert!(result.is_err());
 }
 
 #[test]
@@ -1199,7 +177,6 @@ fn set_admin_two_step_transfers_control() {
 }
 
 #[test]
-#[should_panic(expected = "unauthorized: caller is not admin")]
 fn set_admin_unauthorized_panics() {
     let env = Env::default();
     env.mock_all_auths();
@@ -1210,11 +187,11 @@ fn set_admin_unauthorized_panics() {
     let (usdc, _, _) = create_usdc(&env, &admin);
 
     client.init(&admin, &usdc);
-    client.set_admin(&attacker, &new_admin);
+    let result = client.try_set_admin(&attacker, &new_admin);
+    assert!(result.is_err());
 }
 
 #[test]
-#[should_panic(expected = "unauthorized: caller is not pending admin")]
 fn claim_admin_wrong_address_panics() {
     let env = Env::default();
     env.mock_all_auths();
@@ -1226,7 +203,8 @@ fn claim_admin_wrong_address_panics() {
 
     client.init(&admin, &usdc);
     client.set_admin(&admin, &new_admin);
-    client.claim_admin(&attacker);
+    let result = client.try_claim_admin(&attacker);
+    assert!(result.is_err());
 }
 
 #[test]
@@ -1285,7 +263,6 @@ fn receive_payment_emits_event() {
 }
 
 #[test]
-#[should_panic(expected = "unauthorized: caller is not admin")]
 fn receive_payment_non_admin_panics() {
     let env = Env::default();
     env.mock_all_auths();
@@ -1295,7 +272,8 @@ fn receive_payment_non_admin_panics() {
     let (usdc, _, _) = create_usdc(&env, &admin);
 
     client.init(&admin, &usdc);
-    client.receive_payment(&attacker, &250, &true);
+    let result = client.try_receive_payment(&attacker, &250, &true);
+    assert!(result.is_err());
 }
 
 #[test]
@@ -1404,7 +382,6 @@ fn receive_payment_emits_event_for_admin() {
 }
 
 #[test]
-#[should_panic(expected = "no pending admin")]
 fn claim_admin_without_pending_panics() {
     let env = Env::default();
     env.mock_all_auths();
@@ -1414,11 +391,11 @@ fn claim_admin_without_pending_panics() {
     let (usdc, _, _) = create_usdc(&env, &admin);
 
     client.init(&admin, &usdc);
-    client.claim_admin(&candidate);
+    let result = client.try_claim_admin(&candidate);
+    assert!(result.is_err());
 }
 
 #[test]
-#[should_panic(expected = "unauthorized: caller is not pending admin")]
 fn claim_admin_wrong_caller_panics() {
     let env = Env::default();
     env.mock_all_auths();
@@ -1430,11 +407,11 @@ fn claim_admin_wrong_caller_panics() {
 
     client.init(&admin, &usdc);
     client.set_admin(&admin, &pending_admin);
-    client.claim_admin(&attacker);
+    let result = client.try_claim_admin(&attacker);
+    assert!(result.is_err());
 }
 
 #[test]
-#[should_panic(expected = "invalid recipient: cannot distribute to the contract itself")]
 fn distribute_to_self_panics() {
     let env = Env::default();
     env.mock_all_auths();
@@ -1444,11 +421,11 @@ fn distribute_to_self_panics() {
 
     client.init(&admin, &usdc_address);
     fund_pool(&usdc_admin, &pool_addr, 100);
-    client.distribute(&admin, &pool_addr, &50);
+    let result = client.try_distribute(&admin, &pool_addr, &50);
+    assert!(result.is_err());
 }
 
 #[test]
-#[should_panic(expected = "amount must be positive")]
 fn batch_distribute_zero_amount_panics() {
     let env = Env::default();
     env.mock_all_auths();
@@ -1461,7 +438,8 @@ fn batch_distribute_zero_amount_panics() {
 
     let mut payments: Vec<(Address, i128)> = Vec::new(&env);
     payments.push_back((dev, 0));
-    client.batch_distribute(&admin, &payments);
+    let result = client.try_batch_distribute(&admin, &payments);
+    assert!(result.is_err());
 }
 
 // ---------------------------------------------------------------------------
@@ -1734,13 +712,13 @@ fn get_admin_reflects_updated_admin_after_transfer() {
 }
 
 #[test]
-#[should_panic(expected = "revenue pool not initialized")]
 fn get_admin_before_init_panics() {
     let env = Env::default();
     env.mock_all_auths();
     let (_, client) = create_pool(&env);
 
-    client.get_admin();
+    let result = client.try_get_admin();
+    assert!(result.is_err());
 }
 
 #[test]
@@ -1778,13 +756,13 @@ fn get_usdc_token_is_immutable_after_init() {
 }
 
 #[test]
-#[should_panic(expected = "revenue pool not initialized")]
 fn get_usdc_token_before_init_panics() {
     let env = Env::default();
     env.mock_all_auths();
     let (_, client) = create_pool(&env);
 
-    client.get_usdc_token();
+    let result = client.try_get_usdc_token();
+    assert!(result.is_err());
 }
 
 // ---------------------------------------------------------------------------
@@ -1792,7 +770,6 @@ fn get_usdc_token_before_init_panics() {
 // ---------------------------------------------------------------------------
 
 #[test]
-#[should_panic(expected = "batch_distribute requires at least one payment")]
 fn batch_distribute_empty_panics() {
     let env = Env::default();
     env.mock_all_auths();
@@ -1803,11 +780,11 @@ fn batch_distribute_empty_panics() {
     client.init(&admin, &usdc_address);
 
     let payments: Vec<(Address, i128)> = Vec::new(&env);
-    client.batch_distribute(&admin, &payments);
+    let result = client.try_batch_distribute(&admin, &payments);
+    assert!(result.is_err());
 }
 
 #[test]
-#[should_panic(expected = "batch too large")]
 fn batch_distribute_too_large_panics() {
     let env = Env::default();
     env.mock_all_auths();
@@ -1823,7 +800,8 @@ fn batch_distribute_too_large_panics() {
     for _ in 0..=crate::MAX_BATCH_SIZE {
         payments.push_back((Address::generate(&env), 1_i128));
     }
-    client.batch_distribute(&admin, &payments);
+    let result = client.try_batch_distribute(&admin, &payments);
+    assert!(result.is_err());
 }
 
 #[test]
@@ -1856,7 +834,7 @@ fn upgrade_requires_admin() {
     env.mock_all_auths();
     let admin = Address::generate(&env);
     let attacker = Address::generate(&env);
-    let (pool_addr, client) = create_pool(&env);
+    let (_, client) = create_pool(&env);
     let (usdc_address, _, _) = create_usdc(&env, &admin);
 
     client.init(&admin, &usdc_address);
@@ -1873,7 +851,7 @@ fn upgrade_sets_version_and_emits_event() {
     let env = Env::default();
     env.mock_all_auths();
     let admin = Address::generate(&env);
-    let (pool_addr, client) = create_pool(&env);
+    let (_, client) = create_pool(&env);
     let (usdc_address, _, _) = create_usdc(&env, &admin);
 
     client.init(&admin, &usdc_address);
@@ -1894,7 +872,6 @@ fn upgrade_sets_version_and_emits_event() {
 }
 
 #[test]
-#[should_panic(expected = "amount must be positive")]
 fn batch_distribute_negative_amount_panics() {
     let env = Env::default();
     env.mock_all_auths();
@@ -1907,11 +884,11 @@ fn batch_distribute_negative_amount_panics() {
 
     let mut payments: Vec<(Address, i128)> = Vec::new(&env);
     payments.push_back((dev, -100));
-    client.batch_distribute(&admin, &payments);
+    let result = client.try_batch_distribute(&admin, &payments);
+    assert!(result.is_err());
 }
 
 #[test]
-#[should_panic(expected = "unauthorized: caller is not admin")]
 fn batch_distribute_unauthorized_panics() {
     let env = Env::default();
     env.mock_all_auths();
@@ -1926,11 +903,11 @@ fn batch_distribute_unauthorized_panics() {
 
     let mut payments: Vec<(Address, i128)> = Vec::new(&env);
     payments.push_back((dev, 100));
-    client.batch_distribute(&attacker, &payments);
+    let result = client.try_batch_distribute(&attacker, &payments);
+    assert!(result.is_err());
 }
 
 #[test]
-#[should_panic(expected = "invalid recipient: cannot distribute to the contract itself")]
 fn batch_distribute_self_recipient_panics() {
     let env = Env::default();
     env.mock_all_auths();
@@ -1943,7 +920,8 @@ fn batch_distribute_self_recipient_panics() {
 
     let mut payments: Vec<(Address, i128)> = Vec::new(&env);
     payments.push_back((pool_addr, 100));
-    client.batch_distribute(&admin, &payments);
+    let result = client.try_batch_distribute(&admin, &payments);
+    assert!(result.is_err());
 }
 
 // ---------------------------------------------------------------------------
@@ -2028,7 +1006,6 @@ fn views_do_not_trigger_ttl_bump() {
 // ---------------------------------------------------------------------------
 
 #[test]
-#[should_panic(expected = "duplicate recipient in batch")]
 fn batch_distribute_duplicate_recipient_panics() {
     // A batch where the same developer appears twice must be rejected entirely.
     let env = Env::default();
@@ -2045,7 +1022,8 @@ fn batch_distribute_duplicate_recipient_panics() {
     payments.push_back((dev.clone(), 100_i128));
     payments.push_back((dev.clone(), 200_i128)); // duplicate
 
-    client.batch_distribute(&admin, &payments);
+    let result = client.try_batch_distribute(&admin, &payments);
+    assert!(result.is_err());
 }
 
 #[test]
@@ -2116,7 +1094,6 @@ fn batch_distribute_duplicate_does_not_emit_events() {
 }
 
 #[test]
-#[should_panic(expected = "duplicate recipient in batch")]
 fn batch_distribute_duplicate_at_end_panics() {
     // Duplicate at position n-1 (last entry) must still be caught.
     let env = Env::default();
@@ -2137,7 +1114,8 @@ fn batch_distribute_duplicate_at_end_panics() {
     payments.push_back((dev3.clone(), 150_i128));
     payments.push_back((dev1.clone(), 50_i128)); // dev1 again at the end
 
-    client.batch_distribute(&admin, &payments);
+    let result = client.try_batch_distribute(&admin, &payments);
+    assert!(result.is_err());
 }
 
 #[test]
@@ -2169,7 +1147,6 @@ fn batch_distribute_unique_recipients_succeeds() {
 }
 
 #[test]
-#[should_panic(expected = "duplicate recipient in batch")]
 fn batch_distribute_duplicate_detected_before_balance_check() {
     // Duplicate detection must fire even when the pool has insufficient balance,
     // proving it runs in Phase 1 (before the Phase 2 balance check).
@@ -2189,5 +1166,6 @@ fn batch_distribute_duplicate_detected_before_balance_check() {
     payments.push_back((dev.clone(), 100_i128));
     payments.push_back((dev.clone(), 200_i128));
 
-    client.batch_distribute(&admin, &payments);
+    let result = client.try_batch_distribute(&admin, &payments);
+    assert!(result.is_err());
 }

--- a/contracts/revenue_pool/src/test_balance.rs
+++ b/contracts/revenue_pool/src/test_balance.rs
@@ -2,18 +2,16 @@ use crate::{RevenuePool, RevenuePoolClient};
 use soroban_sdk::{testutils::Address as _, Address, Env};
 
 #[test]
-#[should_panic(expected = "revenue pool not initialized")]
 fn test_balance_uninitialized_panics() {
     let env = Env::default();
     let addr = env.register(RevenuePool, ());
     let client = RevenuePoolClient::new(&env, &addr);
 
-    // Calling balance before init should panic
-    client.balance();
+    let result = client.try_balance();
+    assert!(result.is_err());
 }
 
 #[test]
-#[should_panic(expected = "unauthorized: caller is not admin")]
 fn test_receive_payment_unauthorized_panics() {
     let env = Env::default();
     env.mock_all_auths();
@@ -27,6 +25,6 @@ fn test_receive_payment_unauthorized_panics() {
 
     client.init(&admin, &usdc);
 
-    // Call from unauthorized address should panic
-    client.receive_payment(&attacker, &100, &false);
+    let result = client.try_receive_payment(&attacker, &100, &false);
+    assert!(result.is_err());
 }

--- a/contracts/settlement/src/lib.rs
+++ b/contracts/settlement/src/lib.rs
@@ -1,6 +1,8 @@
 #![no_std]
 
-use soroban_sdk::{contract, contracterror, contractimpl, contracttype, token, Address, Env, Symbol, Vec};
+use soroban_sdk::{
+    contract, contracterror, contractimpl, contracttype, token, Address, Env, Symbol, Vec,
+};
 
 /// Maximum number of items allowed in a single `batch_receive_payment` call.
 pub const MAX_BATCH_SIZE: u32 = 50;
@@ -32,18 +34,18 @@ pub const MAX_DEVELOPER_BALANCES_PAGE_SIZE: u32 = 100;
 #[derive(Clone, Copy, Debug, PartialEq)]
 #[repr(u32)]
 pub enum SettlementError {
-    NotInitialized               = 1,
-    AlreadyInitialized           = 2,
-    Unauthorized                 = 3,
-    AmountNotPositive            = 4,
-    DeveloperRequired            = 5,
-    DeveloperMustBeNone          = 6,
-    PoolOverflow                 = 7,
-    DeveloperOverflow            = 8,
-    UsdcTokenNotConfigured       = 9,
+    NotInitialized = 1,
+    AlreadyInitialized = 2,
+    Unauthorized = 3,
+    AmountNotPositive = 4,
+    DeveloperRequired = 5,
+    DeveloperMustBeNone = 6,
+    PoolOverflow = 7,
+    DeveloperOverflow = 8,
+    UsdcTokenNotConfigured = 9,
     InsufficientDeveloperBalance = 10,
-    DeveloperBalanceUnderflow    = 11,
-    InsufficientContractBalance  = 12,
+    DeveloperBalanceUnderflow = 11,
+    InsufficientContractBalance = 12,
 }
 
 /// Persistent storage keys for settlement contract
@@ -127,7 +129,6 @@ pub struct DeveloperWithdrawEvent {
     pub amount: i128,
     pub remaining_balance: i128,
 }
-
 
 #[contract]
 pub struct CalloraSettlement;
@@ -245,7 +246,7 @@ impl CalloraSettlement {
             let new_balance = current_balance
                 .checked_add(amount)
                 .unwrap_or_else(|| env.panic_with_error(SettlementError::DeveloperOverflow));
-            
+
             // Write to persistent storage with TTL extension
             env.storage().persistent().set(
                 &StorageKey::DeveloperBalance(dev_address.clone()),
@@ -341,9 +342,11 @@ impl CalloraSettlement {
             env.storage()
                 .persistent()
                 .set(&StorageKey::DeveloperBalance(dev.clone()), &new_balance);
-            env.storage()
-                .persistent()
-                .extend_ttl(&StorageKey::DeveloperBalance(dev.clone()), 50000, 50000);
+            env.storage().persistent().extend_ttl(
+                &StorageKey::DeveloperBalance(dev.clone()),
+                50000,
+                50000,
+            );
             // Add to index if not already present
             let mut index: Vec<Address> = inst
                 .get(&StorageKey::DeveloperIndex)
@@ -472,12 +475,15 @@ impl CalloraSettlement {
 
         usdc.transfer(&contract_address, &developer, &amount);
 
-        env.storage()
-            .persistent()
-            .set(&StorageKey::DeveloperBalance(developer.clone()), &new_balance);
-        env.storage()
-            .persistent()
-            .extend_ttl(&StorageKey::DeveloperBalance(developer.clone()), 50000, 50000);
+        env.storage().persistent().set(
+            &StorageKey::DeveloperBalance(developer.clone()),
+            &new_balance,
+        );
+        env.storage().persistent().extend_ttl(
+            &StorageKey::DeveloperBalance(developer.clone()),
+            50000,
+            50000,
+        );
 
         env.events().publish(
             (Symbol::new(&env, "developer_withdraw"), developer.clone()),
@@ -615,9 +621,7 @@ impl CalloraSettlement {
     /// # Returns
     /// `Some(Address)` of the nominated admin, or `None` when no transfer is pending.
     pub fn get_pending_admin(env: Env) -> Option<Address> {
-        env.storage()
-            .instance()
-            .get(&StorageKey::PendingAdmin)
+        env.storage().instance().get(&StorageKey::PendingAdmin)
     }
 
     /// Nominate a new admin (admin only).

--- a/contracts/settlement/src/test.rs
+++ b/contracts/settlement/src/test.rs
@@ -270,8 +270,14 @@ mod settlement_tests {
         let result = client.try_withdraw_developer_balance(&developer, &100i128);
         assert!(result.is_ok());
         assert_eq!(client.get_developer_balance(&developer), 0i128);
-        assert_eq!(token::Client::new(&env, &usdc_address).balance(&addr), 0i128);
-        assert_eq!(token::Client::new(&env, &usdc_address).balance(&developer), 100i128);
+        assert_eq!(
+            token::Client::new(&env, &usdc_address).balance(&addr),
+            0i128
+        );
+        assert_eq!(
+            token::Client::new(&env, &usdc_address).balance(&developer),
+            100i128
+        );
     }
 
     #[test]
@@ -955,9 +961,10 @@ mod settlement_tests {
         client.init(&admin, &vault);
 
         env.as_contract(&addr, || {
-            env.storage()
-                .persistent()
-                .set(&crate::StorageKey::DeveloperBalance(developer.clone()), &i128::MAX);
+            env.storage().persistent().set(
+                &crate::StorageKey::DeveloperBalance(developer.clone()),
+                &i128::MAX,
+            );
         });
 
         let result = client.try_receive_payment(&vault, &1i128, &false, &Some(developer));
@@ -1008,17 +1015,29 @@ mod settlement_tests {
         }
 
         let cases = [
-            Case { name: "vault address succeeds",  role: CallerRole::Vault,      should_succeed: true  },
-            Case { name: "admin address succeeds",  role: CallerRole::Admin,      should_succeed: true  },
-            Case { name: "third party fails",       role: CallerRole::ThirdParty, should_succeed: false },
+            Case {
+                name: "vault address succeeds",
+                role: CallerRole::Vault,
+                should_succeed: true,
+            },
+            Case {
+                name: "admin address succeeds",
+                role: CallerRole::Admin,
+                should_succeed: true,
+            },
+            Case {
+                name: "third party fails",
+                role: CallerRole::ThirdParty,
+                should_succeed: false,
+            },
         ];
 
         for case in cases {
             let (env, addr, admin, vault, third_party) = setup_contract();
             let client = CalloraSettlementClient::new(&env, &addr);
             let caller = match case.role {
-                CallerRole::Vault      => vault,
-                CallerRole::Admin      => admin,
+                CallerRole::Vault => vault,
+                CallerRole::Admin => admin,
                 CallerRole::ThirdParty => third_party,
             };
 

--- a/contracts/vault/src/lib.rs
+++ b/contracts/vault/src/lib.rs
@@ -440,10 +440,7 @@ impl CalloraVault {
     }
 
     /// Set or clear the authorized caller for `deduct`/`batch_deduct` (owner only).
-    pub fn set_authorized_caller(
-        env: Env,
-        new_caller: Option<Address>,
-    ) -> Result<(), VaultError> {
+    pub fn set_authorized_caller(env: Env, new_caller: Option<Address>) -> Result<(), VaultError> {
         let mut meta = Self::get_meta(env.clone())?;
         meta.owner.require_auth();
         let old = meta.authorized_caller.clone();
@@ -594,8 +591,11 @@ impl CalloraVault {
         // Transfer USDC from caller to vault. If this panics, the Soroban host
         // reverts the entire transaction — the Effects above are atomically rolled
         // back, leaving no inconsistent state.
-        token::Client::new(&env, &usdc_addr)
-            .transfer(&caller, &env.current_contract_address(), &amount);
+        token::Client::new(&env, &usdc_addr).transfer(
+            &caller,
+            &env.current_contract_address(),
+            &amount,
+        );
 
         Ok(meta.balance)
     }
@@ -651,14 +651,14 @@ impl CalloraVault {
             .instance()
             .get(&StorageKey::UsdcToken)
             .ok_or(VaultError::NotInitialized)?;
-        
-        // SECURITY: Perform all external operations FIRST. 
+
+        // SECURITY: Perform all external operations FIRST.
         // Although this is a CEI violation (Check-Effect-Interaction), re-entry is
         // blocked by Soroban's authorization model. Each call to `deduct` requires
-        // `caller.require_auth()`, which prevents recursive calls from stealing 
+        // `caller.require_auth()`, which prevents recursive calls from stealing
         // authorization unless the user explicitly signs a nested call.
         Self::transfer_funds(&env, &ut, &settlement, amount);
-        
+
         // Create a settlement client and call receive_payment to credit the global pool
         let settlement_client = SettlementClient::new(&env, &settlement);
         settlement_client.receive_payment(
@@ -667,7 +667,7 @@ impl CalloraVault {
             &true, // to_pool = true: credit global pool
             &None, // no specific developer
         );
-        
+
         // Now that external operations succeeded, update internal state
         let mut meta = Self::get_meta(env.clone())?;
         meta.balance = meta
@@ -682,7 +682,7 @@ impl CalloraVault {
         if let Some(ref rid) = request_id {
             Self::mark_request_processed(&env, rid);
         }
-        
+
         let rid = request_id.unwrap_or(Symbol::new(&env, ""));
         env.events().publish(
             (Symbol::new(&env, "deduct"), caller, rid),
@@ -750,7 +750,9 @@ impl CalloraVault {
                 }
                 seen_in_batch.push_back(rid.clone());
             }
-            running = running.checked_sub(item.amount).ok_or(VaultError::Overflow)?;
+            running = running
+                .checked_sub(item.amount)
+                .ok_or(VaultError::Overflow)?;
             total = total.checked_add(item.amount).ok_or(VaultError::Overflow)?;
         }
         let settlement = Self::require_settlement(&env)?;
@@ -759,11 +761,11 @@ impl CalloraVault {
             .instance()
             .get(&StorageKey::UsdcToken)
             .ok_or(VaultError::NotInitialized)?;
-        
+
         // SECURITY: External operations performed before internal state update.
         // Protected by `require_auth` and Soroban invocation semantics.
         Self::transfer_funds(&env, &ut, &settlement, total);
-        
+
         // Create a settlement client and call receive_payment to credit the global pool
         let settlement_client = SettlementClient::new(&env, &settlement);
         settlement_client.receive_payment(
@@ -772,7 +774,7 @@ impl CalloraVault {
             &true, // to_pool = true: credit global pool
             &None, // no specific developer
         );
-        
+
         // Now that external operations succeeded, update internal state
         let mut meta = Self::get_meta(env.clone())?;
         meta.balance = running;
@@ -786,7 +788,7 @@ impl CalloraVault {
                 Self::mark_request_processed(&env, rid);
             }
         }
-        
+
         for item in items.iter() {
             let rid = item.request_id.unwrap_or(Symbol::new(&env, ""));
             env.events().publish(
@@ -856,7 +858,10 @@ impl CalloraVault {
             &meta.owner,
             &amount,
         );
-        meta.balance = meta.balance.checked_sub(amount).ok_or(VaultError::Overflow)?;
+        meta.balance = meta
+            .balance
+            .checked_sub(amount)
+            .ok_or(VaultError::Overflow)?;
         env.storage().instance().set(&StorageKey::MetaKey, &meta);
         env.storage()
             .instance()
@@ -883,13 +888,20 @@ impl CalloraVault {
             .get(&StorageKey::UsdcToken)
             .ok_or(VaultError::NotInitialized)?;
         token::Client::new(&env, &ua).transfer(&env.current_contract_address(), &to, &amount);
-        meta.balance = meta.balance.checked_sub(amount).ok_or(VaultError::Overflow)?;
+        meta.balance = meta
+            .balance
+            .checked_sub(amount)
+            .ok_or(VaultError::Overflow)?;
         env.storage().instance().set(&StorageKey::MetaKey, &meta);
         env.storage()
             .instance()
             .extend_ttl(INSTANCE_BUMP_THRESHOLD, INSTANCE_BUMP_AMOUNT);
         env.events().publish(
-            (Symbol::new(&env, "withdraw_to"), meta.owner.clone(), to.clone()),
+            (
+                Symbol::new(&env, "withdraw_to"),
+                meta.owner.clone(),
+                to.clone(),
+            ),
             (amount, meta.balance),
         );
         Ok(meta.balance)
@@ -1019,7 +1031,12 @@ impl CalloraVault {
     /// # Errors
     /// - `VaultError::OfferingIdTooLong` when `offering_id` exceeds maximum length.
     /// - `VaultError::PriceParseError` when `price` cannot be parsed to a positive i128.
-    pub fn set_price(env: Env, caller: Address, offering_id: String, price: String) -> Result<(), VaultError> {
+    pub fn set_price(
+        env: Env,
+        caller: Address,
+        offering_id: String,
+        price: String,
+    ) -> Result<(), VaultError> {
         caller.require_auth();
         Self::require_owner(env.clone(), caller.clone())?;
         if offering_id.len() > MAX_OFFERING_ID_LEN {
@@ -1128,12 +1145,12 @@ impl CalloraVault {
     /// See UPGRADE.md for the complete operational flow.
     pub fn upgrade(env: Env, caller: Address, new_wasm_hash: BytesN<32>) {
         caller.require_auth();
-        let admin = Self::get_admin(env.clone())
-            .expect("vault must be initialized before upgrade");
+        let admin = Self::get_admin(env.clone()).expect("vault must be initialized before upgrade");
 
         // Perform the on-chain upgrade via the deployer interface.
         // This is a host operation and may only succeed in the live environment.
-        env.deployer().update_current_contract_wasm(new_wasm_hash.clone());
+        env.deployer()
+            .update_current_contract_wasm(new_wasm_hash.clone());
 
         // Persist the version marker for on-chain queries.
         env.storage()
@@ -1149,9 +1166,7 @@ impl CalloraVault {
     ///
     /// Returns `None` if no upgrade has been performed yet (initial deployment).
     pub fn version(env: Env) -> Option<BytesN<32>> {
-        env.storage()
-            .instance()
-            .get(&StorageKey::ContractVersion)
+        env.storage().instance().get(&StorageKey::ContractVersion)
     }
 
     // -----------------------------------------------------------------------
@@ -1195,9 +1210,11 @@ impl CalloraVault {
     fn mark_request_processed(env: &Env, request_id: &Symbol) {
         let key = StorageKey::ProcessedRequest(request_id.clone());
         env.storage().temporary().set(&key, &true);
-        env.storage()
-            .temporary()
-            .extend_ttl(&key, REQUEST_ID_BUMP_THRESHOLD, REQUEST_ID_BUMP_AMOUNT);
+        env.storage().temporary().extend_ttl(
+            &key,
+            REQUEST_ID_BUMP_THRESHOLD,
+            REQUEST_ID_BUMP_AMOUNT,
+        );
     }
 
     fn transfer_funds(env: &Env, usdc_token: &Address, to: &Address, amount: i128) {

--- a/contracts/vault/src/test.rs
+++ b/contracts/vault/src/test.rs
@@ -31,7 +31,8 @@ fn create_vault(env: &Env) -> (Address, CalloraVaultClient<'_>) {
 /// Register and initialize the settlement contract.
 fn create_settlement(env: &Env, admin: &Address, vault_address: &Address) -> Address {
     let settlement_address = env.register(CalloraSettlement, ());
-    let settlement_client = callora_settlement::CalloraSettlementClient::new(env, &settlement_address);
+    let settlement_client =
+        callora_settlement::CalloraSettlementClient::new(env, &settlement_address);
     env.mock_all_auths();
     settlement_client.init(admin, vault_address);
     settlement_address
@@ -5844,7 +5845,6 @@ fn test_reentry_repeated_attempts() {
     assert_eq!(vault_client.balance(), 400);
 }
 
-
 // ---------------------------------------------------------------------------
 // Upgrade tests (Issue #331)
 // ---------------------------------------------------------------------------
@@ -5894,13 +5894,13 @@ fn upgrade_sets_version_and_emits_event() {
     let events = env.events().all();
     let ev = events.last().unwrap();
     assert_eq!(ev.0, vault_address);
-    
+
     let name: Symbol = ev.1.get(0).unwrap().into_val(&env);
     assert_eq!(name, Symbol::new(&env, "upgraded"));
-    
+
     let admin_topic: Address = ev.1.get(1).unwrap().into_val(&env);
     assert_eq!(admin_topic, owner);
-    
+
     let data: BytesN<32> = ev.2.into_val(&env);
     assert_eq!(data, new_hash);
 }
@@ -5952,7 +5952,10 @@ fn upgrade_owner_not_admin_fails() {
 
     // owner (no longer admin) should fail
     let res = client.try_upgrade(&owner, &new_hash);
-    assert!(res.is_err(), "owner without admin role should not be able to upgrade");
+    assert!(
+        res.is_err(),
+        "owner without admin role should not be able to upgrade"
+    );
 }
 
 #[test]
@@ -6022,10 +6025,16 @@ impl BudgetSnapshot {
     /// Calculate delta between two snapshots (after - before).
     fn delta(&self, before: &BudgetSnapshot) -> BudgetSnapshot {
         BudgetSnapshot {
-            cpu_instructions: self.cpu_instructions.saturating_sub(before.cpu_instructions),
+            cpu_instructions: self
+                .cpu_instructions
+                .saturating_sub(before.cpu_instructions),
             memory_bytes: self.memory_bytes.saturating_sub(before.memory_bytes),
-            ledger_read_bytes: self.ledger_read_bytes.saturating_sub(before.ledger_read_bytes),
-            ledger_write_bytes: self.ledger_write_bytes.saturating_sub(before.ledger_write_bytes),
+            ledger_read_bytes: self
+                .ledger_read_bytes
+                .saturating_sub(before.ledger_read_bytes),
+            ledger_write_bytes: self
+                .ledger_write_bytes
+                .saturating_sub(before.ledger_write_bytes),
         }
     }
 }
@@ -6038,7 +6047,15 @@ fn setup_vault_for_deduct(env: &Env, initial_balance: i128) -> (Address, Callora
 
     env.mock_all_auths();
     fund_vault(&usdc_admin, &vault_address, initial_balance);
-    client.init(&owner, &usdc, &Some(initial_balance), &None, &None, &None, &None);
+    client.init(
+        &owner,
+        &usdc,
+        &Some(initial_balance),
+        &None,
+        &None,
+        &None,
+        &None,
+    );
     let settlement = create_settlement(env, &owner, &vault_address);
     client.set_settlement(&owner, &settlement);
 
@@ -6186,15 +6203,15 @@ fn budget_measure_batch_deduct_size_50() {
 #[ignore]
 fn budget_measure_all() {
     std::println!("\n=== VAULT BUDGET MEASUREMENT SUITE ===\n");
-    
+
     // Single deduct baseline
     budget_measure_single_deduct();
-    
+
     // Batch deduct at various sizes
     budget_measure_batch_deduct_size_1();
     budget_measure_batch_deduct_size_10();
     budget_measure_batch_deduct_size_25();
     budget_measure_batch_deduct_size_50();
-    
+
     std::println!("\n=== END VAULT BUDGET MEASUREMENTS ===\n");
 }

--- a/contracts/vault/src/test_idempotency.rs
+++ b/contracts/vault/src/test_idempotency.rs
@@ -43,7 +43,8 @@ fn create_vault(env: &Env) -> (Address, CalloraVaultClient<'_>) {
 /// Register and initialize the settlement contract.
 fn create_settlement(env: &Env, admin: &Address, vault_address: &Address) -> Address {
     let settlement_address = env.register(CalloraSettlement, ());
-    let settlement_client = callora_settlement::CalloraSettlementClient::new(env, &settlement_address);
+    let settlement_client =
+        callora_settlement::CalloraSettlementClient::new(env, &settlement_address);
     settlement_client.init(admin, vault_address);
     settlement_address
 }
@@ -86,13 +87,14 @@ fn deduct_duplicate_request_id_rejected() {
 
     // Second call with same request_id — must be rejected.
     let result = client.try_deduct(&owner, &100, &Some(rid.clone()));
-    assert!(
-        result.is_err(),
-        "duplicate request_id must be rejected"
-    );
+    assert!(result.is_err(), "duplicate request_id must be rejected");
 
     // Balance must be unchanged after the rejected retry.
-    assert_eq!(client.balance(), 900, "balance must not change on duplicate");
+    assert_eq!(
+        client.balance(),
+        900,
+        "balance must not change on duplicate"
+    );
 }
 
 /// Two distinct `request_id` values each succeed independently.
@@ -241,7 +243,11 @@ fn batch_deduct_duplicate_request_id_rejected_atomically() {
     assert!(result.is_err(), "batch with duplicate id must be rejected");
 
     // Balance must be unchanged — full atomicity.
-    assert_eq!(client.balance(), 900, "balance must not change on duplicate batch");
+    assert_eq!(
+        client.balance(),
+        900,
+        "balance must not change on duplicate batch"
+    );
 }
 
 /// A batch where two items share the same new `request_id` is rejected.
@@ -381,7 +387,10 @@ fn deduct_retry_with_different_amount_still_rejected() {
 
     // Retry with a different amount — still rejected.
     let result = client.try_deduct(&owner, &50, &Some(rid.clone()));
-    assert!(result.is_err(), "retry with different amount must be rejected");
+    assert!(
+        result.is_err(),
+        "retry with different amount must be rejected"
+    );
     assert_eq!(client.balance(), 900);
 }
 

--- a/contracts/vault/src/test_reentrancy.rs
+++ b/contracts/vault/src/test_reentrancy.rs
@@ -1,8 +1,8 @@
 extern crate std;
 
+use crate::{CalloraVault, CalloraVaultClient, DeductItem};
 use soroban_sdk::testutils::{Address as _, Events as _};
 use soroban_sdk::{contract, contractimpl, Address, Env, IntoVal, Symbol, Vec};
-use crate::{CalloraVault, CalloraVaultClient, DeductItem};
 
 // ---------------------------------------------------------------------------
 // Malicious Token Mock
@@ -15,32 +15,51 @@ pub struct MaliciousToken;
 impl MaliciousToken {
     pub fn transfer(env: Env, from: Address, _to: Address, _amount: i128) {
         from.require_auth();
-        
-        let vault_addr: Option<Address> = env.storage().instance().get(&Symbol::new(&env, "vault_addr"));
-        let attack_active: bool = env.storage().instance().get(&Symbol::new(&env, "attack_active")).unwrap_or(false);
-        
+
+        let vault_addr: Option<Address> = env
+            .storage()
+            .instance()
+            .get(&Symbol::new(&env, "vault_addr"));
+        let attack_active: bool = env
+            .storage()
+            .instance()
+            .get(&Symbol::new(&env, "attack_active"))
+            .unwrap_or(false);
+
         if attack_active {
             if let Some(vault) = vault_addr {
                 // Prevent infinite recursion in the mock
-                env.storage().instance().set(&Symbol::new(&env, "attack_active"), &false);
-                
-                let caller: Address = env.storage().instance().get(&Symbol::new(&env, "attack_caller")).unwrap();
+                env.storage()
+                    .instance()
+                    .set(&Symbol::new(&env, "attack_active"), &false);
+
+                let caller: Address = env
+                    .storage()
+                    .instance()
+                    .get(&Symbol::new(&env, "attack_caller"))
+                    .unwrap();
                 let client = CalloraVaultClient::new(&env, &vault);
-                
+
                 // Attempt re-entry into deduct
                 let _ = client.try_deduct(&caller, &1, &Some(Symbol::new(&env, "reentry_token")));
             }
         }
     }
 
-    pub fn balance(_env: Env, _id: Address) -> i128 { 
-        1_000_000_000 
+    pub fn balance(_env: Env, _id: Address) -> i128 {
+        1_000_000_000
     }
 
     pub fn set_token_attack_config(env: Env, vault: Address, caller: Address, active: bool) {
-        env.storage().instance().set(&Symbol::new(&env, "vault_addr"), &vault);
-        env.storage().instance().set(&Symbol::new(&env, "attack_caller"), &caller);
-        env.storage().instance().set(&Symbol::new(&env, "attack_active"), &active);
+        env.storage()
+            .instance()
+            .set(&Symbol::new(&env, "vault_addr"), &vault);
+        env.storage()
+            .instance()
+            .set(&Symbol::new(&env, "attack_caller"), &caller);
+        env.storage()
+            .instance()
+            .set(&Symbol::new(&env, "attack_active"), &active);
     }
 }
 
@@ -53,26 +72,51 @@ pub struct MaliciousSettlement;
 
 #[contractimpl]
 impl MaliciousSettlement {
-    pub fn receive_payment(env: Env, _caller: Address, _amount: i128, _to_pool: bool, _developer: Option<Address>) {
-        let vault_addr: Option<Address> = env.storage().instance().get(&Symbol::new(&env, "vault_addr"));
-        let attack_active: bool = env.storage().instance().get(&Symbol::new(&env, "attack_active")).unwrap_or(false);
-        
+    pub fn receive_payment(
+        env: Env,
+        _caller: Address,
+        _amount: i128,
+        _to_pool: bool,
+        _developer: Option<Address>,
+    ) {
+        let vault_addr: Option<Address> = env
+            .storage()
+            .instance()
+            .get(&Symbol::new(&env, "vault_addr"));
+        let attack_active: bool = env
+            .storage()
+            .instance()
+            .get(&Symbol::new(&env, "attack_active"))
+            .unwrap_or(false);
+
         if attack_active {
             if let Some(vault) = vault_addr {
-                env.storage().instance().set(&Symbol::new(&env, "attack_active"), &false);
-                let caller: Address = env.storage().instance().get(&Symbol::new(&env, "attack_caller")).unwrap();
+                env.storage()
+                    .instance()
+                    .set(&Symbol::new(&env, "attack_active"), &false);
+                let caller: Address = env
+                    .storage()
+                    .instance()
+                    .get(&Symbol::new(&env, "attack_caller"))
+                    .unwrap();
                 let client = CalloraVaultClient::new(&env, &vault);
-                
+
                 // Attempt re-entry into deduct
                 let _ = client.try_deduct(&caller, &1, &Some(Symbol::new(&env, "reentry_settle")));
             }
         }
     }
-    
+
     pub fn set_settle_attack_config(env: Env, vault: Address, caller: Address, active: bool) {
-        env.storage().instance().set(&Symbol::new(&env, "vault_addr"), &vault);
-        env.storage().instance().set(&Symbol::new(&env, "attack_caller"), &caller);
-        env.storage().instance().set(&Symbol::new(&env, "attack_active"), &active);
+        env.storage()
+            .instance()
+            .set(&Symbol::new(&env, "vault_addr"), &vault);
+        env.storage()
+            .instance()
+            .set(&Symbol::new(&env, "attack_caller"), &caller);
+        env.storage()
+            .instance()
+            .set(&Symbol::new(&env, "attack_active"), &active);
     }
 }
 
@@ -84,177 +128,243 @@ fn setup_reentrancy_test(env: &Env) -> (Address, CalloraVaultClient, Address, Ad
     let owner = Address::generate(env);
     let vault_addr = env.register(CalloraVault, ());
     let vault_client = CalloraVaultClient::new(env, &vault_addr);
-    
+
     let token_addr = env.register(MaliciousToken, ());
     let settlement_addr = env.register(MaliciousSettlement, ());
-    
+
     env.mock_all_auths();
-    
+
     // Init vault with the malicious token
     vault_client.init(&owner, &token_addr, &Some(1000), &None, &None, &None, &None);
     vault_client.set_settlement(&owner, &settlement_addr);
-    
+
     (vault_addr, vault_client, token_addr, settlement_addr, owner)
 }
 
 #[test]
 fn test_reentrancy_via_token_transfer_is_blocked_by_auth() {
     let env = Env::default();
-    let (vault_addr, vault_client, token_addr, _settlement_addr, owner) = setup_reentrancy_test(&env);
-    
+    let (vault_addr, vault_client, token_addr, _settlement_addr, owner) =
+        setup_reentrancy_test(&env);
+
     let token_mock = MaliciousTokenClient::new(&env, &token_addr);
     token_mock.set_token_attack_config(&vault_addr, &owner, &true);
-    
+
     let initial_balance = vault_client.balance();
     assert_eq!(initial_balance, 1000);
-    
+
     // Trigger deduct -> calls token.transfer -> calls vault.deduct (re-entry)
     let result = vault_client.try_deduct(&owner, &100, &Some(Symbol::new(&env, "first_call")));
-    
+
     assert!(result.is_ok(), "First deduct should succeed");
-    assert_eq!(vault_client.balance(), 900, "Balance should only be deducted once");
-    
+    assert_eq!(
+        vault_client.balance(),
+        900,
+        "Balance should only be deducted once"
+    );
+
     // Check if the re-entry event was published (it shouldn't be if it failed)
     let events = env.events().all();
     let mut reentry_count = 0;
     for e in events.iter() {
-        if e.0 != vault_addr { continue; }
+        if e.0 != vault_addr {
+            continue;
+        }
         let topics = &e.1;
-        if topics.len() < 3 { continue; }
+        if topics.len() < 3 {
+            continue;
+        }
         let rid: Symbol = topics.get(2).unwrap().into_val(&env);
         if rid == Symbol::new(&env, "reentry_token") {
             reentry_count += 1;
         }
     }
-    
+
     assert_eq!(reentry_count, 0, "Re-entry should not have succeeded");
 }
 
 #[test]
 fn test_reentrancy_via_settlement_callback_is_blocked() {
     let env = Env::default();
-    let (vault_addr, vault_client, _token_addr, settlement_addr, owner) = setup_reentrancy_test(&env);
-    
+    let (vault_addr, vault_client, _token_addr, settlement_addr, owner) =
+        setup_reentrancy_test(&env);
+
     let settlement_mock = MaliciousSettlementClient::new(&env, &settlement_addr);
     settlement_mock.set_settle_attack_config(&vault_addr, &owner, &true);
-    
+
     let initial_balance = vault_client.balance();
     assert_eq!(initial_balance, 1000);
-    
+
     // Trigger deduct -> calls settlement.receive_payment -> calls vault.deduct (re-entry)
     let result = vault_client.try_deduct(&owner, &100, &Some(Symbol::new(&env, "first_call")));
-    
+
     assert!(result.is_ok(), "First deduct should succeed");
-    assert_eq!(vault_client.balance(), 900, "Balance should only be deducted once");
-    
+    assert_eq!(
+        vault_client.balance(),
+        900,
+        "Balance should only be deducted once"
+    );
+
     let events = env.events().all();
     let mut reentry_count = 0;
     for e in events.iter() {
-        if e.0 != vault_addr { continue; }
+        if e.0 != vault_addr {
+            continue;
+        }
         let topics = &e.1;
-        if topics.len() < 3 { continue; }
+        if topics.len() < 3 {
+            continue;
+        }
         let rid: Symbol = topics.get(2).unwrap().into_val(&env);
         if rid == Symbol::new(&env, "reentry_settle") {
             reentry_count += 1;
         }
     }
-    
-    assert_eq!(reentry_count, 0, "Re-entry via settlement should not have succeeded");
+
+    assert_eq!(
+        reentry_count, 0,
+        "Re-entry via settlement should not have succeeded"
+    );
 }
 
 #[test]
 fn test_batch_deduct_reentrancy_via_token() {
     let env = Env::default();
-    let (vault_addr, vault_client, token_addr, _settlement_addr, owner) = setup_reentrancy_test(&env);
-    
+    let (vault_addr, vault_client, token_addr, _settlement_addr, owner) =
+        setup_reentrancy_test(&env);
+
     let token_mock = MaliciousTokenClient::new(&env, &token_addr);
     token_mock.set_token_attack_config(&vault_addr, &owner, &true);
-    
-    let items = Vec::from_array(&env, [
-        DeductItem { amount: 50, request_id: Some(Symbol::new(&env, "item1")) },
-        DeductItem { amount: 50, request_id: Some(Symbol::new(&env, "item2")) },
-    ]);
-    
+
+    let items = Vec::from_array(
+        &env,
+        [
+            DeductItem {
+                amount: 50,
+                request_id: Some(Symbol::new(&env, "item1")),
+            },
+            DeductItem {
+                amount: 50,
+                request_id: Some(Symbol::new(&env, "item2")),
+            },
+        ],
+    );
+
     let result = vault_client.try_batch_deduct(&owner, &items);
-    
+
     assert!(result.is_ok(), "Batch deduct should succeed");
-    assert_eq!(vault_client.balance(), 900, "Balance should only be deducted by batch amount");
-    
+    assert_eq!(
+        vault_client.balance(),
+        900,
+        "Balance should only be deducted by batch amount"
+    );
+
     let events = env.events().all();
     let mut reentry_count = 0;
     for e in events.iter() {
-        if e.0 != vault_addr { continue; }
+        if e.0 != vault_addr {
+            continue;
+        }
         let topics = &e.1;
-        if topics.len() < 3 { continue; }
+        if topics.len() < 3 {
+            continue;
+        }
         let rid: Symbol = topics.get(2).unwrap().into_val(&env);
         if rid == Symbol::new(&env, "reentry_token") {
             reentry_count += 1;
         }
     }
-    
-    assert_eq!(reentry_count, 0, "Re-entry during batch should not have succeeded");
+
+    assert_eq!(
+        reentry_count, 0,
+        "Re-entry during batch should not have succeeded"
+    );
 }
 
 #[test]
 fn test_reentrancy_by_authorized_attacker() {
     let env = Env::default();
-    let (vault_addr, vault_client, token_addr, _settlement_addr, _owner) = setup_reentrancy_test(&env);
-    
+    let (vault_addr, vault_client, token_addr, _settlement_addr, _owner) =
+        setup_reentrancy_test(&env);
+
     let attacker = Address::generate(&env);
     vault_client.set_authorized_caller(&Some(attacker.clone()));
-    
+
     let token_mock = MaliciousTokenClient::new(&env, &token_addr);
     token_mock.set_token_attack_config(&vault_addr, &attacker, &true);
-    
+
     let initial_balance = vault_client.balance();
     assert_eq!(initial_balance, 1000);
-    
+
     // Attacker calls deduct -> token.transfer -> attacker calls vault.deduct (re-entry)
     let result = vault_client.try_deduct(&attacker, &100, &Some(Symbol::new(&env, "first_call")));
-    
+
     assert!(result.is_ok(), "First deduct should succeed");
-    assert_eq!(vault_client.balance(), 900, "Balance should only be deducted once");
-    
+    assert_eq!(
+        vault_client.balance(),
+        900,
+        "Balance should only be deducted once"
+    );
+
     let events = env.events().all();
     let mut reentry_count = 0;
     for e in events.iter() {
-        if e.0 != vault_addr { continue; }
+        if e.0 != vault_addr {
+            continue;
+        }
         let topics = &e.1;
-        if topics.len() < 3 { continue; }
+        if topics.len() < 3 {
+            continue;
+        }
         let rid: Symbol = topics.get(2).unwrap().into_val(&env);
         if rid == Symbol::new(&env, "reentry_token") {
             reentry_count += 1;
         }
     }
-    
-    assert_eq!(reentry_count, 0, "Re-entry by authorized attacker should still fail or be blocked");
+
+    assert_eq!(
+        reentry_count, 0,
+        "Re-entry by authorized attacker should still fail or be blocked"
+    );
 }
 
 #[test]
 fn test_withdraw_reentrancy_via_token() {
     let env = Env::default();
-    let (vault_addr, vault_client, token_addr, _settlement_addr, owner) = setup_reentrancy_test(&env);
-    
+    let (vault_addr, vault_client, token_addr, _settlement_addr, owner) =
+        setup_reentrancy_test(&env);
+
     let token_mock = MaliciousTokenClient::new(&env, &token_addr);
     // Withdraw calls token.transfer. We attempt to call deduct() during withdraw's transfer.
     token_mock.set_token_attack_config(&vault_addr, &owner, &true);
-    
+
     let result = vault_client.try_withdraw(&100);
-    
+
     assert!(result.is_ok(), "Withdraw should succeed");
-    assert_eq!(vault_client.balance(), 900, "Balance should only be deducted by withdraw amount");
-    
+    assert_eq!(
+        vault_client.balance(),
+        900,
+        "Balance should only be deducted by withdraw amount"
+    );
+
     let events = env.events().all();
     let mut reentry_count = 0;
     for e in events.iter() {
-        if e.0 != vault_addr { continue; }
+        if e.0 != vault_addr {
+            continue;
+        }
         let topics = &e.1;
-        if topics.len() < 3 { continue; }
+        if topics.len() < 3 {
+            continue;
+        }
         let rid: Symbol = topics.get(2).unwrap().into_val(&env);
         if rid == Symbol::new(&env, "reentry_token") {
             reentry_count += 1;
         }
     }
-    
-    assert_eq!(reentry_count, 0, "Re-entry during withdraw should not have succeeded");
+
+    assert_eq!(
+        reentry_count, 0,
+        "Re-entry during withdraw should not have succeeded"
+    );
 }

--- a/contracts/vault/src/test_setter_validation.rs
+++ b/contracts/vault/src/test_setter_validation.rs
@@ -1,7 +1,7 @@
 extern crate std;
+use super::*;
 use soroban_sdk::testutils::{Address as _, Events as _};
 use soroban_sdk::{token, Address, Env, IntoVal, String, Symbol};
-use super::*;
 
 fn create_usdc<'a>(env: &'a Env, admin: &'a Address) -> (Address, token::StellarAssetClient<'a>) {
     let ca = env.register_stellar_asset_contract_v2(admin.clone());
@@ -28,21 +28,33 @@ fn set_price_offering_id_too_long() {
     let env = Env::default();
     let (_, client, _, admin) = setup(&env);
     let long_id = "a".repeat((MAX_OFFERING_ID_LEN + 1) as usize);
-    client.set_price(&admin, &String::from_str(&env, &long_id), &String::from_str(&env, "100"));
+    client.set_price(
+        &admin,
+        &String::from_str(&env, &long_id),
+        &String::from_str(&env, "100"),
+    );
 }
 
 #[test]
 fn set_price_zero_price() {
     let env = Env::default();
     let (_, client, _, admin) = setup(&env);
-    client.set_price(&admin, &String::from_str(&env, "off1"), &String::from_str(&env, "0"));
+    client.set_price(
+        &admin,
+        &String::from_str(&env, "off1"),
+        &String::from_str(&env, "0"),
+    );
 }
 
 #[test]
 fn set_price_successful() {
     let env = Env::default();
     let (_, client, _, admin) = setup(&env);
-    client.set_price(&admin, &String::from_str(&env, "off1"), &String::from_str(&env, "1000"));
+    client.set_price(
+        &admin,
+        &String::from_str(&env, "off1"),
+        &String::from_str(&env, "1000"),
+    );
     // Verify readback
     let stored = client.get_price(&String::from_str(&env, "off1"));
     assert_eq!(stored, Some(String::from_str(&env, "1000")));


### PR DESCRIPTION
Add RevenuePoolError enum with 21 typed variants (contracterror, repr(u32)). Replace all panic!() and .expect() calls with env.panic_with_error(RevenuePoolError::*). Add missing PAUSED_KEY constant. Remove obsolete ERR_* string constants. Fix test.rs broken duplicate section. Convert should_panic tests to try_* + is_err(). Run cargo fmt across workspace.

closes: #423 