### PR TITLE
feat(vault): expand VaultError taxonomy with variants 30-33

### DIFF
--- a/contracts/revenue_pool/src/lib.rs
+++ b/contracts/revenue_pool/src/lib.rs
@@ -23,6 +23,8 @@ const ERR_UNAUTHORIZED: &str = "unauthorized: caller is not admin";
 const ERR_INSUFFICIENT_BALANCE: &str = "insufficient USDC balance";
 const ERR_NOT_INITIALIZED: &str = "revenue pool not initialized";
 const ERR_DUPLICATE_RECIPIENT: &str = "duplicate recipient in batch";
+const ERR_PAUSED: &str = "revenue pool is paused";
+const PAUSED_KEY: &str = "paused";
 const VERSION_KEY: &str = "version";
 
 pub const DEFAULT_MAX_DISTRIBUTE: i128 = i128::MAX;

--- a/contracts/vault/src/lib.rs
+++ b/contracts/vault/src/lib.rs
@@ -101,6 +101,14 @@ pub enum VaultError {
     PriceParseError = 28,
     /// Duplicate request ID detected (code 29).
     DuplicateRequestId = 29,
+    /// Withdraw recipient is invalid (e.g., the vault itself) (code 30).
+    WithdrawRecipientInvalid = 30,
+    /// Allowed-depositor list has reached maximum capacity (code 31).
+    DepositorListFull = 31,
+    /// Price has not been set for the offering (code 32).
+    PriceNotSet = 32,
+    /// Price update is below the minimum floor (code 33).
+    PriceUpdateBelowFloor = 33,
 }
 
 #[contracttype]
@@ -171,6 +179,7 @@ pub const DEFAULT_MIN_DEPOSIT: i128 = 1;
 pub const MAX_BATCH_SIZE: u32 = 50;
 pub const MAX_METADATA_LEN: u32 = 256;
 pub const MAX_OFFERING_ID_LEN: u32 = 64;
+pub const MAX_ALLOWED_DEPOSITORS: u32 = 100;
 
 // ~17 280 ledgers per day at 5-second close time.
 // Bump when fewer than 30 days remain; extend to 60 days.
@@ -440,10 +449,7 @@ impl CalloraVault {
     }
 
     /// Set or clear the authorized caller for `deduct`/`batch_deduct` (owner only).
-    pub fn set_authorized_caller(
-        env: Env,
-        new_caller: Option<Address>,
-    ) -> Result<(), VaultError> {
+    pub fn set_authorized_caller(env: Env, new_caller: Option<Address>) -> Result<(), VaultError> {
         let mut meta = Self::get_meta(env.clone())?;
         meta.owner.require_auth();
         let old = meta.authorized_caller.clone();
@@ -495,6 +501,9 @@ impl CalloraVault {
                     .get(&StorageKey::DepositorList)
                     .unwrap_or(Vec::new(&env));
                 if !list.contains(&d) {
+                    if list.len() >= MAX_ALLOWED_DEPOSITORS {
+                        return Err(VaultError::DepositorListFull);
+                    }
                     list.push_back(d);
                 }
                 env.storage()
@@ -594,8 +603,11 @@ impl CalloraVault {
         // Transfer USDC from caller to vault. If this panics, the Soroban host
         // reverts the entire transaction — the Effects above are atomically rolled
         // back, leaving no inconsistent state.
-        token::Client::new(&env, &usdc_addr)
-            .transfer(&caller, &env.current_contract_address(), &amount);
+        token::Client::new(&env, &usdc_addr).transfer(
+            &caller,
+            &env.current_contract_address(),
+            &amount,
+        );
 
         Ok(meta.balance)
     }
@@ -651,14 +663,14 @@ impl CalloraVault {
             .instance()
             .get(&StorageKey::UsdcToken)
             .ok_or(VaultError::NotInitialized)?;
-        
-        // SECURITY: Perform all external operations FIRST. 
+
+        // SECURITY: Perform all external operations FIRST.
         // Although this is a CEI violation (Check-Effect-Interaction), re-entry is
         // blocked by Soroban's authorization model. Each call to `deduct` requires
-        // `caller.require_auth()`, which prevents recursive calls from stealing 
+        // `caller.require_auth()`, which prevents recursive calls from stealing
         // authorization unless the user explicitly signs a nested call.
         Self::transfer_funds(&env, &ut, &settlement, amount);
-        
+
         // Create a settlement client and call receive_payment to credit the global pool
         let settlement_client = SettlementClient::new(&env, &settlement);
         settlement_client.receive_payment(
@@ -667,7 +679,7 @@ impl CalloraVault {
             &true, // to_pool = true: credit global pool
             &None, // no specific developer
         );
-        
+
         // Now that external operations succeeded, update internal state
         let mut meta = Self::get_meta(env.clone())?;
         meta.balance = meta
@@ -682,7 +694,7 @@ impl CalloraVault {
         if let Some(ref rid) = request_id {
             Self::mark_request_processed(&env, rid);
         }
-        
+
         let rid = request_id.unwrap_or(Symbol::new(&env, ""));
         env.events().publish(
             (Symbol::new(&env, "deduct"), caller, rid),
@@ -750,7 +762,9 @@ impl CalloraVault {
                 }
                 seen_in_batch.push_back(rid.clone());
             }
-            running = running.checked_sub(item.amount).ok_or(VaultError::Overflow)?;
+            running = running
+                .checked_sub(item.amount)
+                .ok_or(VaultError::Overflow)?;
             total = total.checked_add(item.amount).ok_or(VaultError::Overflow)?;
         }
         let settlement = Self::require_settlement(&env)?;
@@ -759,11 +773,11 @@ impl CalloraVault {
             .instance()
             .get(&StorageKey::UsdcToken)
             .ok_or(VaultError::NotInitialized)?;
-        
+
         // SECURITY: External operations performed before internal state update.
         // Protected by `require_auth` and Soroban invocation semantics.
         Self::transfer_funds(&env, &ut, &settlement, total);
-        
+
         // Create a settlement client and call receive_payment to credit the global pool
         let settlement_client = SettlementClient::new(&env, &settlement);
         settlement_client.receive_payment(
@@ -772,7 +786,7 @@ impl CalloraVault {
             &true, // to_pool = true: credit global pool
             &None, // no specific developer
         );
-        
+
         // Now that external operations succeeded, update internal state
         let mut meta = Self::get_meta(env.clone())?;
         meta.balance = running;
@@ -786,7 +800,7 @@ impl CalloraVault {
                 Self::mark_request_processed(&env, rid);
             }
         }
-        
+
         for item in items.iter() {
             let rid = item.request_id.unwrap_or(Symbol::new(&env, ""));
             env.events().publish(
@@ -856,7 +870,10 @@ impl CalloraVault {
             &meta.owner,
             &amount,
         );
-        meta.balance = meta.balance.checked_sub(amount).ok_or(VaultError::Overflow)?;
+        meta.balance = meta
+            .balance
+            .checked_sub(amount)
+            .ok_or(VaultError::Overflow)?;
         env.storage().instance().set(&StorageKey::MetaKey, &meta);
         env.storage()
             .instance()
@@ -877,19 +894,32 @@ impl CalloraVault {
         if meta.balance < amount {
             return Err(VaultError::InsufficientBalance);
         }
+        if to == env.current_contract_address() {
+            return Err(VaultError::WithdrawRecipientInvalid);
+        }
         let ua: Address = env
             .storage()
             .instance()
             .get(&StorageKey::UsdcToken)
             .ok_or(VaultError::NotInitialized)?;
+        if to == ua {
+            return Err(VaultError::WithdrawRecipientInvalid);
+        }
         token::Client::new(&env, &ua).transfer(&env.current_contract_address(), &to, &amount);
-        meta.balance = meta.balance.checked_sub(amount).ok_or(VaultError::Overflow)?;
+        meta.balance = meta
+            .balance
+            .checked_sub(amount)
+            .ok_or(VaultError::Overflow)?;
         env.storage().instance().set(&StorageKey::MetaKey, &meta);
         env.storage()
             .instance()
             .extend_ttl(INSTANCE_BUMP_THRESHOLD, INSTANCE_BUMP_AMOUNT);
         env.events().publish(
-            (Symbol::new(&env, "withdraw_to"), meta.owner.clone(), to.clone()),
+            (
+                Symbol::new(&env, "withdraw_to"),
+                meta.owner.clone(),
+                to.clone(),
+            ),
             (amount, meta.balance),
         );
         Ok(meta.balance)
@@ -909,6 +939,7 @@ impl CalloraVault {
     /// # Errors
     /// - `VaultError::Unauthorized` — caller is not the admin.
     /// - `VaultError::AmountNotPositive` — `amount <= 0`.
+    /// - `VaultError::WithdrawRecipientInvalid` — `to` is the vault itself.
     /// - `VaultError::InsufficientBalance` — vault lacks on-ledger USDC for transfer.
     pub fn distribute(
         env: Env,
@@ -923,6 +954,9 @@ impl CalloraVault {
         }
         if amount <= 0 {
             return Err(VaultError::AmountNotPositive);
+        }
+        if to == env.current_contract_address() {
+            return Err(VaultError::WithdrawRecipientInvalid);
         }
         let usdc_addr: Address = env
             .storage()
@@ -1014,24 +1048,46 @@ impl CalloraVault {
         Ok(metadata)
     }
 
+    fn parse_price_string(_env: &Env, price: &String) -> Result<i128, VaultError> {
+        let len = price.len() as usize;
+        let mut buf = [0u8; 64];
+        let slice = &mut buf[..len];
+        price.copy_into_slice(slice);
+        let s = core::str::from_utf8(slice).map_err(|_| VaultError::PriceParseError)?;
+        let n: i128 = s.parse().map_err(|_| VaultError::PriceParseError)?;
+        if n <= 0 {
+            return Err(VaultError::PriceParseError);
+        }
+        Ok(n)
+    }
+
     /// Set price for an offering (owner only).
     ///
     /// # Errors
     /// - `VaultError::OfferingIdTooLong` when `offering_id` exceeds maximum length.
     /// - `VaultError::PriceParseError` when `price` cannot be parsed to a positive i128.
-    pub fn set_price(env: Env, caller: Address, offering_id: String, price: String) -> Result<(), VaultError> {
+    /// - `VaultError::PriceUpdateBelowFloor` when updating to a price below the existing one.
+    pub fn set_price(
+        env: Env,
+        caller: Address,
+        offering_id: String,
+        price: String,
+    ) -> Result<(), VaultError> {
         caller.require_auth();
         Self::require_owner(env.clone(), caller.clone())?;
         if offering_id.len() > MAX_OFFERING_ID_LEN {
             return Err(VaultError::OfferingIdTooLong);
         }
-        let mut price_buf = [0u8; 64];
-        price.copy_into_slice(&mut price_buf);
-        let price_str = core::str::from_utf8(&price_buf[..price.len() as usize])
-            .map_err(|_| VaultError::PriceParseError)?;
-        let price_i128: i128 = price_str.parse().map_err(|_| VaultError::PriceParseError)?;
-        if price_i128 <= 0 {
-            return Err(VaultError::PriceParseError);
+        let price_i128 = Self::parse_price_string(&env, &price)?;
+        if let Some(existing) = env
+            .storage()
+            .instance()
+            .get::<_, String>(&StorageKey::Price(offering_id.clone()))
+        {
+            let existing_i128 = Self::parse_price_string(&env, &existing)?;
+            if price_i128 < existing_i128 {
+                return Err(VaultError::PriceUpdateBelowFloor);
+            }
         }
         env.storage()
             .instance()
@@ -1048,6 +1104,14 @@ impl CalloraVault {
         env.storage()
             .instance()
             .get(&StorageKey::Price(offering_id))
+    }
+
+    /// Get stored price for an offering, returning `PriceNotSet` if absent.
+    pub fn require_price(env: Env, offering_id: String) -> Result<String, VaultError> {
+        env.storage()
+            .instance()
+            .get(&StorageKey::Price(offering_id.clone()))
+            .ok_or(VaultError::PriceNotSet)
     }
 
     pub fn update_metadata(
@@ -1128,12 +1192,12 @@ impl CalloraVault {
     /// See UPGRADE.md for the complete operational flow.
     pub fn upgrade(env: Env, caller: Address, new_wasm_hash: BytesN<32>) {
         caller.require_auth();
-        let admin = Self::get_admin(env.clone())
-            .expect("vault must be initialized before upgrade");
+        let admin = Self::get_admin(env.clone()).expect("vault must be initialized before upgrade");
 
         // Perform the on-chain upgrade via the deployer interface.
         // This is a host operation and may only succeed in the live environment.
-        env.deployer().update_current_contract_wasm(new_wasm_hash.clone());
+        env.deployer()
+            .update_current_contract_wasm(new_wasm_hash.clone());
 
         // Persist the version marker for on-chain queries.
         env.storage()
@@ -1149,9 +1213,7 @@ impl CalloraVault {
     ///
     /// Returns `None` if no upgrade has been performed yet (initial deployment).
     pub fn version(env: Env) -> Option<BytesN<32>> {
-        env.storage()
-            .instance()
-            .get(&StorageKey::ContractVersion)
+        env.storage().instance().get(&StorageKey::ContractVersion)
     }
 
     // -----------------------------------------------------------------------
@@ -1195,9 +1257,11 @@ impl CalloraVault {
     fn mark_request_processed(env: &Env, request_id: &Symbol) {
         let key = StorageKey::ProcessedRequest(request_id.clone());
         env.storage().temporary().set(&key, &true);
-        env.storage()
-            .temporary()
-            .extend_ttl(&key, REQUEST_ID_BUMP_THRESHOLD, REQUEST_ID_BUMP_AMOUNT);
+        env.storage().temporary().extend_ttl(
+            &key,
+            REQUEST_ID_BUMP_THRESHOLD,
+            REQUEST_ID_BUMP_AMOUNT,
+        );
     }
 
     fn transfer_funds(env: &Env, usdc_token: &Address, to: &Address, amount: i128) {
@@ -1244,6 +1308,9 @@ impl CalloraVault {
             .get(&StorageKey::DepositorList)
             .unwrap_or(Vec::new(&env));
         if !list.contains(&depositor) {
+            if list.len() >= MAX_ALLOWED_DEPOSITORS {
+                return Err(VaultError::DepositorListFull);
+            }
             list.push_back(depositor.clone());
         }
         env.storage()

--- a/contracts/vault/src/test.rs
+++ b/contracts/vault/src/test.rs
@@ -31,7 +31,8 @@ fn create_vault(env: &Env) -> (Address, CalloraVaultClient<'_>) {
 /// Register and initialize the settlement contract.
 fn create_settlement(env: &Env, admin: &Address, vault_address: &Address) -> Address {
     let settlement_address = env.register(CalloraSettlement, ());
-    let settlement_client = callora_settlement::CalloraSettlementClient::new(env, &settlement_address);
+    let settlement_client =
+        callora_settlement::CalloraSettlementClient::new(env, &settlement_address);
     env.mock_all_auths();
     settlement_client.init(admin, vault_address);
     settlement_address
@@ -641,6 +642,30 @@ fn set_allowed_depositor_duplicate_is_ignored() {
     usdc_admin.mint(&depositor, &50);
     usdc_client.approve(&depositor, &vault_address, &50, &1000);
     assert_eq!(client.deposit(&depositor, &50), 150);
+}
+
+#[test]
+fn set_allowed_depositor_list_full_fails() {
+    let env = Env::default();
+    let owner = Address::generate(&env);
+    let (vault_address, client) = create_vault(&env);
+    let (usdc, _, usdc_admin) = create_usdc(&env, &owner);
+
+    env.mock_all_auths();
+    fund_vault(&usdc_admin, &vault_address, 100);
+    client.init(&owner, &usdc, &Some(100), &None, &None, &None, &None);
+
+    // Fill the depositor list to the cap
+    for _ in 0..MAX_ALLOWED_DEPOSITORS {
+        let d = Address::generate(&env);
+        client.set_allowed_depositor(&owner, &Some(d));
+    }
+
+    // Next addition should fail
+    let extra = Address::generate(&env);
+    let result = client.try_set_allowed_depositor(&owner, &Some(extra));
+    assert!(result.is_err());
+    assert_eq!(result.unwrap_err(), Ok(VaultError::DepositorListFull));
 }
 
 #[test]
@@ -1457,7 +1482,6 @@ fn withdraw_to_insufficient_balance_fails() {
 }
 
 #[test]
-#[should_panic(expected = "cannot withdraw to vault address")]
 fn withdraw_to_vault_address_fails() {
     let env = Env::default();
     let owner = Address::generate(&env);
@@ -1469,11 +1493,15 @@ fn withdraw_to_vault_address_fails() {
     client.init(&owner, &usdc, &Some(1000), &None, &None, &None, &None);
 
     // Attempt to withdraw to the vault itself
-    client.withdraw_to(&vault_address, &100);
+    let result = client.try_withdraw_to(&vault_address, &100);
+    assert!(result.is_err());
+    assert_eq!(
+        result.unwrap_err(),
+        Ok(crate::VaultError::WithdrawRecipientInvalid)
+    );
 }
 
 #[test]
-#[should_panic(expected = "cannot withdraw to token address")]
 fn withdraw_to_token_address_fails() {
     let env = Env::default();
     let owner = Address::generate(&env);
@@ -1485,7 +1513,12 @@ fn withdraw_to_token_address_fails() {
     client.init(&owner, &usdc, &Some(1000), &None, &None, &None, &None);
 
     // Attempt to withdraw to the USDC token contract
-    client.withdraw_to(&usdc, &100);
+    let result = client.try_withdraw_to(&usdc, &100);
+    assert!(result.is_err());
+    assert_eq!(
+        result.unwrap_err(),
+        Ok(crate::VaultError::WithdrawRecipientInvalid)
+    );
 }
 
 #[test]
@@ -1688,6 +1721,25 @@ fn distribute_zero_amount_fails() {
 
     let result = client.try_distribute(&admin, &developer, &0);
     assert!(result.is_err(), "expected error for zero amount");
+}
+
+#[test]
+fn distribute_to_vault_address_fails() {
+    let env = Env::default();
+    let admin = Address::generate(&env);
+    let (vault_address, client) = create_vault(&env);
+    let (usdc, _, usdc_admin) = create_usdc(&env, &admin);
+
+    env.mock_all_auths();
+    fund_vault(&usdc_admin, &vault_address, 1000);
+    client.init(&admin, &usdc, &Some(0), &None, &None, &None, &None);
+
+    let result = client.try_distribute(&admin, &vault_address, &100);
+    assert!(result.is_err());
+    assert_eq!(
+        result.unwrap_err(),
+        Ok(VaultError::WithdrawRecipientInvalid)
+    );
 }
 
 #[test]
@@ -5844,7 +5896,6 @@ fn test_reentry_repeated_attempts() {
     assert_eq!(vault_client.balance(), 400);
 }
 
-
 // ---------------------------------------------------------------------------
 // Upgrade tests (Issue #331)
 // ---------------------------------------------------------------------------
@@ -5894,13 +5945,13 @@ fn upgrade_sets_version_and_emits_event() {
     let events = env.events().all();
     let ev = events.last().unwrap();
     assert_eq!(ev.0, vault_address);
-    
+
     let name: Symbol = ev.1.get(0).unwrap().into_val(&env);
     assert_eq!(name, Symbol::new(&env, "upgraded"));
-    
+
     let admin_topic: Address = ev.1.get(1).unwrap().into_val(&env);
     assert_eq!(admin_topic, owner);
-    
+
     let data: BytesN<32> = ev.2.into_val(&env);
     assert_eq!(data, new_hash);
 }
@@ -5952,7 +6003,10 @@ fn upgrade_owner_not_admin_fails() {
 
     // owner (no longer admin) should fail
     let res = client.try_upgrade(&owner, &new_hash);
-    assert!(res.is_err(), "owner without admin role should not be able to upgrade");
+    assert!(
+        res.is_err(),
+        "owner without admin role should not be able to upgrade"
+    );
 }
 
 #[test]
@@ -6022,10 +6076,16 @@ impl BudgetSnapshot {
     /// Calculate delta between two snapshots (after - before).
     fn delta(&self, before: &BudgetSnapshot) -> BudgetSnapshot {
         BudgetSnapshot {
-            cpu_instructions: self.cpu_instructions.saturating_sub(before.cpu_instructions),
+            cpu_instructions: self
+                .cpu_instructions
+                .saturating_sub(before.cpu_instructions),
             memory_bytes: self.memory_bytes.saturating_sub(before.memory_bytes),
-            ledger_read_bytes: self.ledger_read_bytes.saturating_sub(before.ledger_read_bytes),
-            ledger_write_bytes: self.ledger_write_bytes.saturating_sub(before.ledger_write_bytes),
+            ledger_read_bytes: self
+                .ledger_read_bytes
+                .saturating_sub(before.ledger_read_bytes),
+            ledger_write_bytes: self
+                .ledger_write_bytes
+                .saturating_sub(before.ledger_write_bytes),
         }
     }
 }
@@ -6038,7 +6098,15 @@ fn setup_vault_for_deduct(env: &Env, initial_balance: i128) -> (Address, Callora
 
     env.mock_all_auths();
     fund_vault(&usdc_admin, &vault_address, initial_balance);
-    client.init(&owner, &usdc, &Some(initial_balance), &None, &None, &None, &None);
+    client.init(
+        &owner,
+        &usdc,
+        &Some(initial_balance),
+        &None,
+        &None,
+        &None,
+        &None,
+    );
     let settlement = create_settlement(env, &owner, &vault_address);
     client.set_settlement(&owner, &settlement);
 
@@ -6186,15 +6254,15 @@ fn budget_measure_batch_deduct_size_50() {
 #[ignore]
 fn budget_measure_all() {
     std::println!("\n=== VAULT BUDGET MEASUREMENT SUITE ===\n");
-    
+
     // Single deduct baseline
     budget_measure_single_deduct();
-    
+
     // Batch deduct at various sizes
     budget_measure_batch_deduct_size_1();
     budget_measure_batch_deduct_size_10();
     budget_measure_batch_deduct_size_25();
     budget_measure_batch_deduct_size_50();
-    
+
     std::println!("\n=== END VAULT BUDGET MEASUREMENTS ===\n");
 }

--- a/contracts/vault/src/test_idempotency.rs
+++ b/contracts/vault/src/test_idempotency.rs
@@ -43,7 +43,8 @@ fn create_vault(env: &Env) -> (Address, CalloraVaultClient<'_>) {
 /// Register and initialize the settlement contract.
 fn create_settlement(env: &Env, admin: &Address, vault_address: &Address) -> Address {
     let settlement_address = env.register(CalloraSettlement, ());
-    let settlement_client = callora_settlement::CalloraSettlementClient::new(env, &settlement_address);
+    let settlement_client =
+        callora_settlement::CalloraSettlementClient::new(env, &settlement_address);
     settlement_client.init(admin, vault_address);
     settlement_address
 }
@@ -86,13 +87,14 @@ fn deduct_duplicate_request_id_rejected() {
 
     // Second call with same request_id — must be rejected.
     let result = client.try_deduct(&owner, &100, &Some(rid.clone()));
-    assert!(
-        result.is_err(),
-        "duplicate request_id must be rejected"
-    );
+    assert!(result.is_err(), "duplicate request_id must be rejected");
 
     // Balance must be unchanged after the rejected retry.
-    assert_eq!(client.balance(), 900, "balance must not change on duplicate");
+    assert_eq!(
+        client.balance(),
+        900,
+        "balance must not change on duplicate"
+    );
 }
 
 /// Two distinct `request_id` values each succeed independently.
@@ -241,7 +243,11 @@ fn batch_deduct_duplicate_request_id_rejected_atomically() {
     assert!(result.is_err(), "batch with duplicate id must be rejected");
 
     // Balance must be unchanged — full atomicity.
-    assert_eq!(client.balance(), 900, "balance must not change on duplicate batch");
+    assert_eq!(
+        client.balance(),
+        900,
+        "balance must not change on duplicate batch"
+    );
 }
 
 /// A batch where two items share the same new `request_id` is rejected.
@@ -381,7 +387,10 @@ fn deduct_retry_with_different_amount_still_rejected() {
 
     // Retry with a different amount — still rejected.
     let result = client.try_deduct(&owner, &50, &Some(rid.clone()));
-    assert!(result.is_err(), "retry with different amount must be rejected");
+    assert!(
+        result.is_err(),
+        "retry with different amount must be rejected"
+    );
     assert_eq!(client.balance(), 900);
 }
 

--- a/contracts/vault/src/test_reentrancy.rs
+++ b/contracts/vault/src/test_reentrancy.rs
@@ -1,8 +1,8 @@
 extern crate std;
 
+use crate::{CalloraVault, CalloraVaultClient, DeductItem};
 use soroban_sdk::testutils::{Address as _, Events as _};
 use soroban_sdk::{contract, contractimpl, Address, Env, IntoVal, Symbol, Vec};
-use crate::{CalloraVault, CalloraVaultClient, DeductItem};
 
 // ---------------------------------------------------------------------------
 // Malicious Token Mock
@@ -15,32 +15,51 @@ pub struct MaliciousToken;
 impl MaliciousToken {
     pub fn transfer(env: Env, from: Address, _to: Address, _amount: i128) {
         from.require_auth();
-        
-        let vault_addr: Option<Address> = env.storage().instance().get(&Symbol::new(&env, "vault_addr"));
-        let attack_active: bool = env.storage().instance().get(&Symbol::new(&env, "attack_active")).unwrap_or(false);
-        
+
+        let vault_addr: Option<Address> = env
+            .storage()
+            .instance()
+            .get(&Symbol::new(&env, "vault_addr"));
+        let attack_active: bool = env
+            .storage()
+            .instance()
+            .get(&Symbol::new(&env, "attack_active"))
+            .unwrap_or(false);
+
         if attack_active {
             if let Some(vault) = vault_addr {
                 // Prevent infinite recursion in the mock
-                env.storage().instance().set(&Symbol::new(&env, "attack_active"), &false);
-                
-                let caller: Address = env.storage().instance().get(&Symbol::new(&env, "attack_caller")).unwrap();
+                env.storage()
+                    .instance()
+                    .set(&Symbol::new(&env, "attack_active"), &false);
+
+                let caller: Address = env
+                    .storage()
+                    .instance()
+                    .get(&Symbol::new(&env, "attack_caller"))
+                    .unwrap();
                 let client = CalloraVaultClient::new(&env, &vault);
-                
+
                 // Attempt re-entry into deduct
                 let _ = client.try_deduct(&caller, &1, &Some(Symbol::new(&env, "reentry_token")));
             }
         }
     }
 
-    pub fn balance(_env: Env, _id: Address) -> i128 { 
-        1_000_000_000 
+    pub fn balance(_env: Env, _id: Address) -> i128 {
+        1_000_000_000
     }
 
     pub fn set_token_attack_config(env: Env, vault: Address, caller: Address, active: bool) {
-        env.storage().instance().set(&Symbol::new(&env, "vault_addr"), &vault);
-        env.storage().instance().set(&Symbol::new(&env, "attack_caller"), &caller);
-        env.storage().instance().set(&Symbol::new(&env, "attack_active"), &active);
+        env.storage()
+            .instance()
+            .set(&Symbol::new(&env, "vault_addr"), &vault);
+        env.storage()
+            .instance()
+            .set(&Symbol::new(&env, "attack_caller"), &caller);
+        env.storage()
+            .instance()
+            .set(&Symbol::new(&env, "attack_active"), &active);
     }
 }
 
@@ -53,26 +72,51 @@ pub struct MaliciousSettlement;
 
 #[contractimpl]
 impl MaliciousSettlement {
-    pub fn receive_payment(env: Env, _caller: Address, _amount: i128, _to_pool: bool, _developer: Option<Address>) {
-        let vault_addr: Option<Address> = env.storage().instance().get(&Symbol::new(&env, "vault_addr"));
-        let attack_active: bool = env.storage().instance().get(&Symbol::new(&env, "attack_active")).unwrap_or(false);
-        
+    pub fn receive_payment(
+        env: Env,
+        _caller: Address,
+        _amount: i128,
+        _to_pool: bool,
+        _developer: Option<Address>,
+    ) {
+        let vault_addr: Option<Address> = env
+            .storage()
+            .instance()
+            .get(&Symbol::new(&env, "vault_addr"));
+        let attack_active: bool = env
+            .storage()
+            .instance()
+            .get(&Symbol::new(&env, "attack_active"))
+            .unwrap_or(false);
+
         if attack_active {
             if let Some(vault) = vault_addr {
-                env.storage().instance().set(&Symbol::new(&env, "attack_active"), &false);
-                let caller: Address = env.storage().instance().get(&Symbol::new(&env, "attack_caller")).unwrap();
+                env.storage()
+                    .instance()
+                    .set(&Symbol::new(&env, "attack_active"), &false);
+                let caller: Address = env
+                    .storage()
+                    .instance()
+                    .get(&Symbol::new(&env, "attack_caller"))
+                    .unwrap();
                 let client = CalloraVaultClient::new(&env, &vault);
-                
+
                 // Attempt re-entry into deduct
                 let _ = client.try_deduct(&caller, &1, &Some(Symbol::new(&env, "reentry_settle")));
             }
         }
     }
-    
+
     pub fn set_settle_attack_config(env: Env, vault: Address, caller: Address, active: bool) {
-        env.storage().instance().set(&Symbol::new(&env, "vault_addr"), &vault);
-        env.storage().instance().set(&Symbol::new(&env, "attack_caller"), &caller);
-        env.storage().instance().set(&Symbol::new(&env, "attack_active"), &active);
+        env.storage()
+            .instance()
+            .set(&Symbol::new(&env, "vault_addr"), &vault);
+        env.storage()
+            .instance()
+            .set(&Symbol::new(&env, "attack_caller"), &caller);
+        env.storage()
+            .instance()
+            .set(&Symbol::new(&env, "attack_active"), &active);
     }
 }
 
@@ -84,177 +128,243 @@ fn setup_reentrancy_test(env: &Env) -> (Address, CalloraVaultClient, Address, Ad
     let owner = Address::generate(env);
     let vault_addr = env.register(CalloraVault, ());
     let vault_client = CalloraVaultClient::new(env, &vault_addr);
-    
+
     let token_addr = env.register(MaliciousToken, ());
     let settlement_addr = env.register(MaliciousSettlement, ());
-    
+
     env.mock_all_auths();
-    
+
     // Init vault with the malicious token
     vault_client.init(&owner, &token_addr, &Some(1000), &None, &None, &None, &None);
     vault_client.set_settlement(&owner, &settlement_addr);
-    
+
     (vault_addr, vault_client, token_addr, settlement_addr, owner)
 }
 
 #[test]
 fn test_reentrancy_via_token_transfer_is_blocked_by_auth() {
     let env = Env::default();
-    let (vault_addr, vault_client, token_addr, _settlement_addr, owner) = setup_reentrancy_test(&env);
-    
+    let (vault_addr, vault_client, token_addr, _settlement_addr, owner) =
+        setup_reentrancy_test(&env);
+
     let token_mock = MaliciousTokenClient::new(&env, &token_addr);
     token_mock.set_token_attack_config(&vault_addr, &owner, &true);
-    
+
     let initial_balance = vault_client.balance();
     assert_eq!(initial_balance, 1000);
-    
+
     // Trigger deduct -> calls token.transfer -> calls vault.deduct (re-entry)
     let result = vault_client.try_deduct(&owner, &100, &Some(Symbol::new(&env, "first_call")));
-    
+
     assert!(result.is_ok(), "First deduct should succeed");
-    assert_eq!(vault_client.balance(), 900, "Balance should only be deducted once");
-    
+    assert_eq!(
+        vault_client.balance(),
+        900,
+        "Balance should only be deducted once"
+    );
+
     // Check if the re-entry event was published (it shouldn't be if it failed)
     let events = env.events().all();
     let mut reentry_count = 0;
     for e in events.iter() {
-        if e.0 != vault_addr { continue; }
+        if e.0 != vault_addr {
+            continue;
+        }
         let topics = &e.1;
-        if topics.len() < 3 { continue; }
+        if topics.len() < 3 {
+            continue;
+        }
         let rid: Symbol = topics.get(2).unwrap().into_val(&env);
         if rid == Symbol::new(&env, "reentry_token") {
             reentry_count += 1;
         }
     }
-    
+
     assert_eq!(reentry_count, 0, "Re-entry should not have succeeded");
 }
 
 #[test]
 fn test_reentrancy_via_settlement_callback_is_blocked() {
     let env = Env::default();
-    let (vault_addr, vault_client, _token_addr, settlement_addr, owner) = setup_reentrancy_test(&env);
-    
+    let (vault_addr, vault_client, _token_addr, settlement_addr, owner) =
+        setup_reentrancy_test(&env);
+
     let settlement_mock = MaliciousSettlementClient::new(&env, &settlement_addr);
     settlement_mock.set_settle_attack_config(&vault_addr, &owner, &true);
-    
+
     let initial_balance = vault_client.balance();
     assert_eq!(initial_balance, 1000);
-    
+
     // Trigger deduct -> calls settlement.receive_payment -> calls vault.deduct (re-entry)
     let result = vault_client.try_deduct(&owner, &100, &Some(Symbol::new(&env, "first_call")));
-    
+
     assert!(result.is_ok(), "First deduct should succeed");
-    assert_eq!(vault_client.balance(), 900, "Balance should only be deducted once");
-    
+    assert_eq!(
+        vault_client.balance(),
+        900,
+        "Balance should only be deducted once"
+    );
+
     let events = env.events().all();
     let mut reentry_count = 0;
     for e in events.iter() {
-        if e.0 != vault_addr { continue; }
+        if e.0 != vault_addr {
+            continue;
+        }
         let topics = &e.1;
-        if topics.len() < 3 { continue; }
+        if topics.len() < 3 {
+            continue;
+        }
         let rid: Symbol = topics.get(2).unwrap().into_val(&env);
         if rid == Symbol::new(&env, "reentry_settle") {
             reentry_count += 1;
         }
     }
-    
-    assert_eq!(reentry_count, 0, "Re-entry via settlement should not have succeeded");
+
+    assert_eq!(
+        reentry_count, 0,
+        "Re-entry via settlement should not have succeeded"
+    );
 }
 
 #[test]
 fn test_batch_deduct_reentrancy_via_token() {
     let env = Env::default();
-    let (vault_addr, vault_client, token_addr, _settlement_addr, owner) = setup_reentrancy_test(&env);
-    
+    let (vault_addr, vault_client, token_addr, _settlement_addr, owner) =
+        setup_reentrancy_test(&env);
+
     let token_mock = MaliciousTokenClient::new(&env, &token_addr);
     token_mock.set_token_attack_config(&vault_addr, &owner, &true);
-    
-    let items = Vec::from_array(&env, [
-        DeductItem { amount: 50, request_id: Some(Symbol::new(&env, "item1")) },
-        DeductItem { amount: 50, request_id: Some(Symbol::new(&env, "item2")) },
-    ]);
-    
+
+    let items = Vec::from_array(
+        &env,
+        [
+            DeductItem {
+                amount: 50,
+                request_id: Some(Symbol::new(&env, "item1")),
+            },
+            DeductItem {
+                amount: 50,
+                request_id: Some(Symbol::new(&env, "item2")),
+            },
+        ],
+    );
+
     let result = vault_client.try_batch_deduct(&owner, &items);
-    
+
     assert!(result.is_ok(), "Batch deduct should succeed");
-    assert_eq!(vault_client.balance(), 900, "Balance should only be deducted by batch amount");
-    
+    assert_eq!(
+        vault_client.balance(),
+        900,
+        "Balance should only be deducted by batch amount"
+    );
+
     let events = env.events().all();
     let mut reentry_count = 0;
     for e in events.iter() {
-        if e.0 != vault_addr { continue; }
+        if e.0 != vault_addr {
+            continue;
+        }
         let topics = &e.1;
-        if topics.len() < 3 { continue; }
+        if topics.len() < 3 {
+            continue;
+        }
         let rid: Symbol = topics.get(2).unwrap().into_val(&env);
         if rid == Symbol::new(&env, "reentry_token") {
             reentry_count += 1;
         }
     }
-    
-    assert_eq!(reentry_count, 0, "Re-entry during batch should not have succeeded");
+
+    assert_eq!(
+        reentry_count, 0,
+        "Re-entry during batch should not have succeeded"
+    );
 }
 
 #[test]
 fn test_reentrancy_by_authorized_attacker() {
     let env = Env::default();
-    let (vault_addr, vault_client, token_addr, _settlement_addr, _owner) = setup_reentrancy_test(&env);
-    
+    let (vault_addr, vault_client, token_addr, _settlement_addr, _owner) =
+        setup_reentrancy_test(&env);
+
     let attacker = Address::generate(&env);
     vault_client.set_authorized_caller(&Some(attacker.clone()));
-    
+
     let token_mock = MaliciousTokenClient::new(&env, &token_addr);
     token_mock.set_token_attack_config(&vault_addr, &attacker, &true);
-    
+
     let initial_balance = vault_client.balance();
     assert_eq!(initial_balance, 1000);
-    
+
     // Attacker calls deduct -> token.transfer -> attacker calls vault.deduct (re-entry)
     let result = vault_client.try_deduct(&attacker, &100, &Some(Symbol::new(&env, "first_call")));
-    
+
     assert!(result.is_ok(), "First deduct should succeed");
-    assert_eq!(vault_client.balance(), 900, "Balance should only be deducted once");
-    
+    assert_eq!(
+        vault_client.balance(),
+        900,
+        "Balance should only be deducted once"
+    );
+
     let events = env.events().all();
     let mut reentry_count = 0;
     for e in events.iter() {
-        if e.0 != vault_addr { continue; }
+        if e.0 != vault_addr {
+            continue;
+        }
         let topics = &e.1;
-        if topics.len() < 3 { continue; }
+        if topics.len() < 3 {
+            continue;
+        }
         let rid: Symbol = topics.get(2).unwrap().into_val(&env);
         if rid == Symbol::new(&env, "reentry_token") {
             reentry_count += 1;
         }
     }
-    
-    assert_eq!(reentry_count, 0, "Re-entry by authorized attacker should still fail or be blocked");
+
+    assert_eq!(
+        reentry_count, 0,
+        "Re-entry by authorized attacker should still fail or be blocked"
+    );
 }
 
 #[test]
 fn test_withdraw_reentrancy_via_token() {
     let env = Env::default();
-    let (vault_addr, vault_client, token_addr, _settlement_addr, owner) = setup_reentrancy_test(&env);
-    
+    let (vault_addr, vault_client, token_addr, _settlement_addr, owner) =
+        setup_reentrancy_test(&env);
+
     let token_mock = MaliciousTokenClient::new(&env, &token_addr);
     // Withdraw calls token.transfer. We attempt to call deduct() during withdraw's transfer.
     token_mock.set_token_attack_config(&vault_addr, &owner, &true);
-    
+
     let result = vault_client.try_withdraw(&100);
-    
+
     assert!(result.is_ok(), "Withdraw should succeed");
-    assert_eq!(vault_client.balance(), 900, "Balance should only be deducted by withdraw amount");
-    
+    assert_eq!(
+        vault_client.balance(),
+        900,
+        "Balance should only be deducted by withdraw amount"
+    );
+
     let events = env.events().all();
     let mut reentry_count = 0;
     for e in events.iter() {
-        if e.0 != vault_addr { continue; }
+        if e.0 != vault_addr {
+            continue;
+        }
         let topics = &e.1;
-        if topics.len() < 3 { continue; }
+        if topics.len() < 3 {
+            continue;
+        }
         let rid: Symbol = topics.get(2).unwrap().into_val(&env);
         if rid == Symbol::new(&env, "reentry_token") {
             reentry_count += 1;
         }
     }
-    
-    assert_eq!(reentry_count, 0, "Re-entry during withdraw should not have succeeded");
+
+    assert_eq!(
+        reentry_count, 0,
+        "Re-entry during withdraw should not have succeeded"
+    );
 }

--- a/contracts/vault/src/test_setter_validation.rs
+++ b/contracts/vault/src/test_setter_validation.rs
@@ -1,7 +1,7 @@
 extern crate std;
+use super::*;
 use soroban_sdk::testutils::{Address as _, Events as _};
 use soroban_sdk::{token, Address, Env, IntoVal, String, Symbol};
-use super::*;
 
 fn create_usdc<'a>(env: &'a Env, admin: &'a Address) -> (Address, token::StellarAssetClient<'a>) {
     let ca = env.register_stellar_asset_contract_v2(admin.clone());
@@ -28,21 +28,61 @@ fn set_price_offering_id_too_long() {
     let env = Env::default();
     let (_, client, _, admin) = setup(&env);
     let long_id = "a".repeat((MAX_OFFERING_ID_LEN + 1) as usize);
-    client.set_price(&admin, &String::from_str(&env, &long_id), &String::from_str(&env, "100"));
+    client.set_price(
+        &admin,
+        &String::from_str(&env, &long_id),
+        &String::from_str(&env, "100"),
+    );
 }
 
 #[test]
 fn set_price_zero_price() {
     let env = Env::default();
     let (_, client, _, admin) = setup(&env);
-    client.set_price(&admin, &String::from_str(&env, "off1"), &String::from_str(&env, "0"));
+    client.set_price(
+        &admin,
+        &String::from_str(&env, "off1"),
+        &String::from_str(&env, "0"),
+    );
+}
+
+#[test]
+fn require_price_not_set_fails() {
+    let env = Env::default();
+    let (_, client, _, admin) = setup(&env);
+    // Calling require_price for a non-existent offering should return PriceNotSet
+    let result = client.try_require_price(&String::from_str(&env, "nonexistent"));
+    assert!(result.is_err());
+    assert_eq!(result.unwrap_err(), Ok(VaultError::PriceNotSet));
+}
+
+#[test]
+fn set_price_below_existing_fails() {
+    let env = Env::default();
+    let (_, client, _, admin) = setup(&env);
+    client.set_price(
+        &admin,
+        &String::from_str(&env, "off1"),
+        &String::from_str(&env, "1000"),
+    );
+    let result = client.try_set_price(
+        &admin,
+        &String::from_str(&env, "off1"),
+        &String::from_str(&env, "500"),
+    );
+    assert!(result.is_err());
+    assert_eq!(result.unwrap_err(), Ok(VaultError::PriceUpdateBelowFloor));
 }
 
 #[test]
 fn set_price_successful() {
     let env = Env::default();
     let (_, client, _, admin) = setup(&env);
-    client.set_price(&admin, &String::from_str(&env, "off1"), &String::from_str(&env, "1000"));
+    client.set_price(
+        &admin,
+        &String::from_str(&env, "off1"),
+        &String::from_str(&env, "1000"),
+    );
     // Verify readback
     let stored = client.get_price(&String::from_str(&env, "off1"));
     assert_eq!(stored, Some(String::from_str(&env, "1000")));

--- a/docs/ACCESS_CONTROL.md
+++ b/docs/ACCESS_CONTROL.md
@@ -105,6 +105,44 @@ The implementation includes comprehensive tests covering:
 - ✅ Cancel functions fail for unauthorized callers
 - ✅ After cancellation, new nominations can be made
 
+## VaultError Codes
+
+| Code | Variant | Trigger Condition |
+|------|---------|-------------------|
+| 1 | `NotInitialized` | Contract not yet initialized |
+| 2 | `AlreadyInitialized` | `init` called a second time |
+| 3 | `Unauthorized` | Caller lacks required role |
+| 4 | `Paused` | Operation blocked by circuit breaker |
+| 5 | `InsufficientBalance` | Vault balance too low |
+| 6 | `AmountNotPositive` | Deposit/withdraw amount ≤ 0 |
+| 7 | `ExceedsMaxDeduct` | Deduct > configured max |
+| 8 | `BelowMinDeposit` | Deposit < configured min |
+| 9 | `Overflow` | Arithmetic overflow |
+| 10 | `InitialBalanceNegative` | Negative initial balance |
+| 11 | `MinDepositNotPositive` | Min deposit ≤ 0 |
+| 12 | `MaxDeductNotPositive` | Max deduct ≤ 0 |
+| 13 | `MinDepositExceedsMaxDeduct` | Min deposit > max deduct |
+| 14 | `UsdcTokenCannotBeVault` | USDC token set to vault address |
+| 15 | `RevenuePoolCannotBeVault` | Revenue pool set to vault address |
+| 16 | `AuthorizedCallerCannotBeVault` | Authorized caller set to vault address |
+| 17 | `InitialBalanceExceedsOnLedger` | On-ledger balance too low for init |
+| 18 | `AlreadyPaused` | `pause` when already paused |
+| 19 | `NotPaused` | `unpause` when not paused |
+| 20 | `SettlementNotSet` | Settlement address not configured |
+| 21 | `BatchEmpty` | Batch deduct has zero items |
+| 22 | `BatchTooLarge` | Batch exceeds size limit |
+| 23 | `NewOwnerSameAsCurrent` | Ownership transfer to same address |
+| 24 | `NoOwnershipTransferPending` | No pending ownership transfer |
+| 25 | `NoAdminTransferPending` | No pending admin transfer |
+| 26 | `OfferingIdTooLong` | Offering ID exceeds max length |
+| 27 | `MetadataTooLong` | Metadata exceeds max length |
+| 28 | `PriceParseError` | Price string cannot be parsed |
+| 29 | `DuplicateRequestId` | Deduplicated request ID |
+| 30 | `WithdrawRecipientInvalid` | Recipient is the vault or USDC token |
+| 31 | `DepositorListFull` | Allowed-depositor list at capacity |
+| 32 | `PriceNotSet` | Price queried but not yet set |
+| 33 | `PriceUpdateBelowFloor` | Price update would lower the existing price |
+
 Run tests with:
 ```bash
 cargo test -p callora-settlement


### PR DESCRIPTION
Add typed error variants:
- WithdrawRecipientInvalid (30) for vault/USDC token recipient checks
- DepositorListFull (31) when depositor list hits 100 cap
- PriceNotSet (32) via new require_price() helper
- PriceUpdateBelowFloor (33) preventing price decreases

closes: #414 