### PR TITLE
feat(settlement): cursor-based pagination for developer balances - Ad…

### DIFF
--- a/contracts/settlement/src/lib.rs
+++ b/contracts/settlement/src/lib.rs
@@ -28,6 +28,7 @@ pub const MAX_DEVELOPER_BALANCES_PAGE_SIZE: u32 = 100;
 /// | 10   | InsufficientDeveloperBalance | Developer balance is less than withdrawal amount  |
 /// | 11   | DeveloperBalanceUnderflow    | Developer balance subtraction would overflow      |
 /// | 12   | InsufficientContractBalance  | Settlement contract lacks on-ledger USDC          |
+/// | 13   | GasExhaustionRisk            | Index too large for safe full scan; use pagination|
 #[contracterror]
 #[derive(Clone, Copy, Debug, PartialEq)]
 #[repr(u32)]
@@ -44,6 +45,7 @@ pub enum SettlementError {
     InsufficientDeveloperBalance = 10,
     DeveloperBalanceUnderflow    = 11,
     InsufficientContractBalance  = 12,
+    GasExhaustionRisk            = 13,
 }
 
 /// Persistent storage keys for settlement contract
@@ -259,14 +261,12 @@ impl CalloraSettlement {
                 50000,
             );
 
-            // Add developer to index if not already present
+            // Add developer to index in sorted order if not already present
             let mut index: Vec<Address> = inst
                 .get(&StorageKey::DeveloperIndex)
                 .unwrap_or_else(|| Vec::new(&env));
-            if !index.iter().any(|addr| addr == dev_address) {
-                index.push_back(dev_address.clone());
-                inst.set(&StorageKey::DeveloperIndex, &index);
-            }
+            Self::sorted_insert(&env, &mut index, dev_address.clone());
+            inst.set(&StorageKey::DeveloperIndex, &index);
 
             env.events().publish(
                 (Symbol::new(&env, "payment_received"), caller.clone()),
@@ -344,14 +344,12 @@ impl CalloraSettlement {
             env.storage()
                 .persistent()
                 .extend_ttl(&StorageKey::DeveloperBalance(dev.clone()), 50000, 50000);
-            // Add to index if not already present
+            // Add to index in sorted order if not already present
             let mut index: Vec<Address> = inst
                 .get(&StorageKey::DeveloperIndex)
                 .unwrap_or_else(|| Vec::new(&env));
-            if !index.iter().any(|a| a == dev) {
-                index.push_back(dev.clone());
-                inst.set(&StorageKey::DeveloperIndex, &index);
-            }
+            Self::sorted_insert(&env, &mut index, dev.clone());
+            inst.set(&StorageKey::DeveloperIndex, &index);
             env.events().publish(
                 (Symbol::new(&env, "balance_credited"), dev.clone()),
                 BalanceCreditedEvent {
@@ -540,13 +538,18 @@ impl CalloraSettlement {
             .get(&StorageKey::DeveloperIndex)
             .unwrap_or_else(|| Vec::new(&env));
 
+        // Guard against unbounded iteration on large indexes.
+        // Callers with > 100 developers must use `get_developer_balances_page` instead.
+        if index.len() > MAX_DEVELOPER_BALANCES_PAGE_SIZE {
+            return Err(SettlementError::GasExhaustionRisk);
+        }
+
         let mut result = Vec::new(&env);
         for address in index.iter() {
-            let address_key = address.clone();
             let balance: i128 = env
                 .storage()
                 .persistent()
-                .get(&StorageKey::DeveloperBalance(address_key))
+                .get(&StorageKey::DeveloperBalance(address.clone()))
                 .unwrap_or(0i128);
             result.push_back(DeveloperBalance {
                 address: address.clone(),
@@ -605,6 +608,114 @@ impl CalloraSettlement {
             cursor += 1;
         }
         Ok(result)
+    }
+
+    /// Cursor-based paginated developer balances (admin only).
+    ///
+    /// Returns up to `limit` developer balance records starting **after** the
+    /// supplied `cursor` address (exclusive), or from the beginning of the
+    /// sorted index when `cursor` is `None`.  The index is maintained in
+    /// deterministic ascending order by address bytes, so pages are stable
+    /// across interleaved `receive_payment` calls for developers that sort
+    /// **after** the cursor.
+    ///
+    /// # Arguments
+    /// * `caller`  – Must be the current admin; must authorize.
+    /// * `cursor`  – Exclusive start position.  Pass `None` for the first page;
+    ///               pass the `next_cursor` returned by the previous call for
+    ///               subsequent pages.
+    /// * `limit`   – Maximum records to return; capped at
+    ///               [`MAX_DEVELOPER_BALANCES_PAGE_SIZE`] (100).
+    ///
+    /// # Returns
+    /// `(page, next_cursor)` where:
+    /// * `page`         – Vec of [`DeveloperBalance`] for this page (may be empty).
+    /// * `next_cursor`  – `Some(address)` of the last record returned, which can be
+    ///                    passed as `cursor` on the next call; `None` when this is the
+    ///                    last page.
+    ///
+    /// # Access Control
+    /// Admin only.
+    ///
+    /// # Errors
+    /// * [`SettlementError::NotInitialized`] – contract not yet initialised.
+    /// * [`SettlementError::Unauthorized`]   – caller is not the admin.
+    ///
+    /// # Example
+    /// ```text
+    /// // First page
+    /// let (page1, next) = client.get_developer_balances_cursor(&admin, &None, &10u32);
+    /// // Second page
+    /// let (page2, next) = client.get_developer_balances_cursor(&admin, &next, &10u32);
+    /// ```
+    pub fn get_developer_balances_cursor(
+        env: Env,
+        caller: Address,
+        cursor: Option<Address>,
+        limit: u32,
+    ) -> (Vec<DeveloperBalance>, Option<Address>) {
+        caller.require_auth();
+        let admin = Self::get_admin(env.clone());
+        if caller != admin {
+            env.panic_with_error(SettlementError::Unauthorized);
+        }
+
+        // Cap limit to the maximum safe page size.
+        let effective_limit = if limit == 0 {
+            return (Vec::new(&env), None);
+        } else {
+            limit.min(MAX_DEVELOPER_BALANCES_PAGE_SIZE)
+        };
+
+        let inst = env.storage().instance();
+        let index: Vec<Address> = inst
+            .get(&StorageKey::DeveloperIndex)
+            .unwrap_or_else(|| Vec::new(&env));
+
+        let mut result: Vec<DeveloperBalance> = Vec::new(&env);
+        // When a cursor is supplied we skip addresses up to and including it.
+        // `past_cursor` becomes true once we have consumed the cursor entry (or
+        // immediately when cursor is None).
+        let mut past_cursor = cursor.is_none();
+        let mut last_address: Option<Address> = None;
+
+        for address in index.iter() {
+            if !past_cursor {
+                if let Some(ref c) = cursor {
+                    if &address == c {
+                        // We've reached the cursor entry; start collecting from next.
+                        past_cursor = true;
+                    }
+                }
+                continue;
+            }
+
+            let balance: i128 = env
+                .storage()
+                .persistent()
+                .get(&StorageKey::DeveloperBalance(address.clone()))
+                .unwrap_or(0i128);
+            result.push_back(DeveloperBalance {
+                address: address.clone(),
+                balance,
+            });
+            last_address = Some(address.clone());
+
+            if result.len() >= effective_limit {
+                break;
+            }
+        }
+
+        // next_cursor is the address of the last record returned, provided the
+        // page is full (meaning there may be more records).  When the page is
+        // not full we have reached the end of the index.
+        let next_cursor = if result.len() >= effective_limit {
+            last_address
+        } else {
+            None
+        };
+
+        (result, next_cursor)
     }
 
     /// Return the pending admin address, or `None` if no transfer is in progress.
@@ -790,6 +901,34 @@ impl CalloraSettlement {
         if caller != vault && caller != admin {
             env.panic_with_error(SettlementError::Unauthorized);
         }
+    }
+
+    /// Insert `addr` into `index` in sorted order (ascending by raw bytes).
+    ///
+    /// Soroban's `Vec` does not expose a binary-search API, so we do a linear
+    /// scan to find the insertion point.  The index is expected to be small
+    /// (≤ `MAX_DEVELOPER_BALANCES_PAGE_SIZE`), so the O(n) cost is acceptable
+    /// and the result is a deterministic, stable ordering that cursors can rely on.
+    ///
+    /// If `addr` is already present the index is left unchanged.
+    fn sorted_insert(env: &Env, index: &mut Vec<Address>, addr: Address) {
+        // Check for duplicates and find insertion position in one pass.
+        let mut insert_pos: Option<u32> = None;
+        for (i, existing) in index.iter().enumerate() {
+            if existing == addr {
+                // Already in index – nothing to do.
+                return;
+            }
+            if insert_pos.is_none() && addr < existing {
+                insert_pos = Some(i as u32);
+            }
+        }
+
+        match insert_pos {
+            Some(pos) => index.insert(pos, addr),
+            None => index.push_back(addr),
+        }
+        let _ = env; // env available for future use
     }
 }
 

--- a/contracts/settlement/src/test.rs
+++ b/contracts/settlement/src/test.rs
@@ -1680,4 +1680,272 @@ mod settlement_tests {
             "Conservation invariant violated: total credits must equal pool + developer balances"
         );
     }
+
+    // ── cursor-based pagination tests ────────────────────────────────────────
+
+    /// First page with cursor=None returns up to `limit` records from the
+    /// beginning of the sorted index and yields a non-None next_cursor when the
+    /// index has more entries.
+    #[test]
+    fn test_cursor_first_page_returns_records_and_next_cursor() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let admin = Address::generate(&env);
+        let vault = Address::generate(&env);
+        let addr = env.register(CalloraSettlement, ());
+        let client = CalloraSettlementClient::new(&env, &addr);
+        client.init(&admin, &vault);
+
+        let dev1 = Address::generate(&env);
+        let dev2 = Address::generate(&env);
+        let dev3 = Address::generate(&env);
+        client.receive_payment(&vault, &100i128, &false, &Some(dev1.clone()));
+        client.receive_payment(&vault, &200i128, &false, &Some(dev2.clone()));
+        client.receive_payment(&vault, &300i128, &false, &Some(dev3.clone()));
+
+        let (page, next) = client.get_developer_balances_cursor(&admin, &None, &2u32);
+
+        assert_eq!(page.len(), 2, "first page must contain exactly limit records");
+        // next_cursor must point at the last record on this page so the caller
+        // can continue from there.
+        assert!(next.is_some(), "next_cursor must be Some when more records exist");
+        assert_eq!(
+            next.as_ref().unwrap(),
+            &page.get(1).unwrap().address,
+            "next_cursor must equal the last address on the page"
+        );
+    }
+
+    /// Subsequent page retrieved via next_cursor returns the remaining records.
+    #[test]
+    fn test_cursor_subsequent_page_returns_remaining_records() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let admin = Address::generate(&env);
+        let vault = Address::generate(&env);
+        let addr = env.register(CalloraSettlement, ());
+        let client = CalloraSettlementClient::new(&env, &addr);
+        client.init(&admin, &vault);
+
+        let dev1 = Address::generate(&env);
+        let dev2 = Address::generate(&env);
+        let dev3 = Address::generate(&env);
+        client.receive_payment(&vault, &10i128, &false, &Some(dev1.clone()));
+        client.receive_payment(&vault, &20i128, &false, &Some(dev2.clone()));
+        client.receive_payment(&vault, &30i128, &false, &Some(dev3.clone()));
+
+        // Page 1
+        let (page1, next1) = client.get_developer_balances_cursor(&admin, &None, &2u32);
+        assert_eq!(page1.len(), 2);
+        assert!(next1.is_some());
+
+        // Page 2 — use next_cursor from page 1
+        let (page2, next2) = client.get_developer_balances_cursor(&admin, &next1, &2u32);
+        assert_eq!(page2.len(), 1, "last page must contain the remaining record");
+        // Reached the end of the index.
+        assert!(next2.is_none(), "next_cursor must be None on the last page");
+
+        // Together the two pages must cover all three developers exactly once.
+        let mut all_addrs: std::vec::Vec<Address> = std::vec::Vec::new();
+        for r in page1.iter() { all_addrs.push(r.address.clone()); }
+        for r in page2.iter() { all_addrs.push(r.address.clone()); }
+        assert_eq!(all_addrs.len(), 3);
+        assert!(all_addrs.contains(&dev1));
+        assert!(all_addrs.contains(&dev2));
+        assert!(all_addrs.contains(&dev3));
+    }
+
+    /// Cursor pointing past the last entry returns an empty page and None.
+    #[test]
+    fn test_cursor_past_last_entry_returns_empty_page() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let admin = Address::generate(&env);
+        let vault = Address::generate(&env);
+        let addr = env.register(CalloraSettlement, ());
+        let client = CalloraSettlementClient::new(&env, &addr);
+        client.init(&admin, &vault);
+
+        let dev1 = Address::generate(&env);
+        let dev2 = Address::generate(&env);
+        client.receive_payment(&vault, &1i128, &false, &Some(dev1.clone()));
+        client.receive_payment(&vault, &2i128, &false, &Some(dev2.clone()));
+
+        // Exhaust the index with a large limit to find the last cursor.
+        let (full_page, last_cursor) = client.get_developer_balances_cursor(&admin, &None, &100u32);
+        assert_eq!(full_page.len(), 2);
+        assert!(last_cursor.is_none());
+
+        // Use the address of the last record as the cursor — nothing should follow.
+        let last_addr = full_page.get(full_page.len() - 1).unwrap().address;
+        let (empty_page, next) =
+            client.get_developer_balances_cursor(&admin, &Some(last_addr), &10u32);
+        assert_eq!(empty_page.len(), 0, "page after last cursor must be empty");
+        assert!(next.is_none());
+    }
+
+    /// Cursor stability: credits to developers that sort **after** the cursor do
+    /// not disturb already-returned pages.
+    #[test]
+    fn test_cursor_stable_across_interleaved_credits() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let admin = Address::generate(&env);
+        let vault = Address::generate(&env);
+        let addr = env.register(CalloraSettlement, ());
+        let client = CalloraSettlementClient::new(&env, &addr);
+        client.init(&admin, &vault);
+
+        // Pre-populate three developers so the sorted index is stable.
+        let dev_a = Address::generate(&env);
+        let dev_b = Address::generate(&env);
+        let dev_c = Address::generate(&env);
+        client.receive_payment(&vault, &1i128, &false, &Some(dev_a.clone()));
+        client.receive_payment(&vault, &1i128, &false, &Some(dev_b.clone()));
+        client.receive_payment(&vault, &1i128, &false, &Some(dev_c.clone()));
+
+        // Fetch first page (limit=1) to get the cursor.
+        let (page1, cursor_after_first) =
+            client.get_developer_balances_cursor(&admin, &None, &1u32);
+        assert_eq!(page1.len(), 1);
+        let first_addr = page1.get(0).unwrap().address.clone();
+
+        // Credit the first developer again — this must NOT shift remaining pages.
+        client.receive_payment(&vault, &999i128, &false, &Some(first_addr.clone()));
+
+        // Continue pagination from the saved cursor.
+        let (page2, _) =
+            client.get_developer_balances_cursor(&admin, &cursor_after_first, &10u32);
+        assert_eq!(page2.len(), 2, "two records must remain after the cursor");
+
+        // The first developer must not appear again in page2.
+        for rec in page2.iter() {
+            assert_ne!(
+                rec.address, first_addr,
+                "already-paged developer must not re-appear"
+            );
+        }
+    }
+
+    /// Limit is capped at MAX_DEVELOPER_BALANCES_PAGE_SIZE even if caller
+    /// passes a larger value.
+    #[test]
+    fn test_cursor_limit_is_capped_at_max_page_size() {
+        use crate::MAX_DEVELOPER_BALANCES_PAGE_SIZE;
+        let env = Env::default();
+        env.mock_all_auths();
+        let admin = Address::generate(&env);
+        let vault = Address::generate(&env);
+        let addr = env.register(CalloraSettlement, ());
+        let client = CalloraSettlementClient::new(&env, &addr);
+        client.init(&admin, &vault);
+
+        // Insert more developers than MAX_DEVELOPER_BALANCES_PAGE_SIZE.
+        for _ in 0..(MAX_DEVELOPER_BALANCES_PAGE_SIZE + 10) {
+            let dev = Address::generate(&env);
+            client.receive_payment(&vault, &1i128, &false, &Some(dev));
+        }
+
+        // Request more than the cap.
+        let (page, _) =
+            client.get_developer_balances_cursor(&admin, &None, &(MAX_DEVELOPER_BALANCES_PAGE_SIZE + 50));
+        assert_eq!(
+            page.len(),
+            MAX_DEVELOPER_BALANCES_PAGE_SIZE,
+            "page must be capped at MAX_DEVELOPER_BALANCES_PAGE_SIZE"
+        );
+    }
+
+    /// limit=0 returns an empty page and None immediately.
+    #[test]
+    fn test_cursor_zero_limit_returns_empty() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let admin = Address::generate(&env);
+        let vault = Address::generate(&env);
+        let addr = env.register(CalloraSettlement, ());
+        let client = CalloraSettlementClient::new(&env, &addr);
+        client.init(&admin, &vault);
+
+        let dev = Address::generate(&env);
+        client.receive_payment(&vault, &1i128, &false, &Some(dev));
+
+        let (page, next) = client.get_developer_balances_cursor(&admin, &None, &0u32);
+        assert_eq!(page.len(), 0);
+        assert!(next.is_none());
+    }
+
+    /// Cursor on an empty index returns an empty page and None.
+    #[test]
+    fn test_cursor_empty_index_returns_empty_page() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let admin = Address::generate(&env);
+        let vault = Address::generate(&env);
+        let addr = env.register(CalloraSettlement, ());
+        let client = CalloraSettlementClient::new(&env, &addr);
+        client.init(&admin, &vault);
+
+        let (page, next) = client.get_developer_balances_cursor(&admin, &None, &10u32);
+        assert_eq!(page.len(), 0);
+        assert!(next.is_none());
+    }
+
+    /// Non-admin caller is rejected with Unauthorized.
+    #[test]
+    fn test_cursor_unauthorized_caller_rejected() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let admin = Address::generate(&env);
+        let vault = Address::generate(&env);
+        let addr = env.register(CalloraSettlement, ());
+        let client = CalloraSettlementClient::new(&env, &addr);
+        client.init(&admin, &vault);
+
+        let result = client.try_get_developer_balances_cursor(&vault, &None, &10u32);
+        assert!(
+            is_error(result, SettlementError::Unauthorized),
+            "non-admin caller must be rejected with Unauthorized"
+        );
+    }
+
+    /// Sorted order: DeveloperIndex stays sorted; cursor pages come out in the
+    /// same deterministic order regardless of credit sequence.
+    #[test]
+    fn test_cursor_sorted_order_is_deterministic() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let admin = Address::generate(&env);
+        let vault = Address::generate(&env);
+        let addr = env.register(CalloraSettlement, ());
+        let client = CalloraSettlementClient::new(&env, &addr);
+        client.init(&admin, &vault);
+
+        // Generate addresses in arbitrary order and credit them.
+        let mut devs: std::vec::Vec<Address> = (0..5).map(|_| Address::generate(&env)).collect();
+        for dev in &devs {
+            client.receive_payment(&vault, &1i128, &false, &Some(dev.clone()));
+        }
+
+        // Collect all balances via cursor pagination.
+        let mut cursor_pages: std::vec::Vec<Address> = std::vec::Vec::new();
+        let mut next: Option<Address> = None;
+        loop {
+            let (page, nc) = client.get_developer_balances_cursor(&admin, &next, &2u32);
+            for r in page.iter() {
+                cursor_pages.push(r.address.clone());
+            }
+            next = nc;
+            if next.is_none() { break; }
+        }
+
+        assert_eq!(cursor_pages.len(), 5, "all developers must be returned across pages");
+
+        // The cursor pages must be in sorted order (ascending by address).
+        devs.sort();
+        assert_eq!(
+            cursor_pages, devs,
+            "cursor pages must iterate in deterministic sorted order"
+        );
+    }
 }

--- a/contracts/settlement/src/test_views.rs
+++ b/contracts/settlement/src/test_views.rs
@@ -76,3 +76,20 @@ fn test_get_developer_balance_returns_zero_when_not_stored() {
     let balance = client.get_developer_balance(&dev);
     assert_eq!(balance, 0);
 }
+
+/// `get_developer_balances_cursor` called before `init` must return
+/// `NotInitialized` (it calls `get_admin` internally).
+#[test]
+fn test_get_developer_balances_cursor_uninitialized() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let addr = env.register(CalloraSettlement, ());
+    let client = CalloraSettlementClient::new(&env, &addr);
+    let dummy = Address::generate(&env);
+
+    let result = client.try_get_developer_balances_cursor(&dummy, &None, &10u32);
+    assert!(
+        is_not_initialized(result),
+        "expected NotInitialized before init"
+    );
+}

--- a/docs/interfaces/settlement.json
+++ b/docs/interfaces/settlement.json
@@ -8,14 +8,19 @@
   "errors": {
     "description": "Typed error codes emitted via env.panic_with_error(). Callers and indexers match on the u32 code rather than parsing raw strings.",
     "variants": [
-      { "code": 1, "name": "NotInitialized",      "when": "A function is called before init." },
-      { "code": 2, "name": "AlreadyInitialized",  "when": "init is called more than once." },
-      { "code": 3, "name": "Unauthorized",         "when": "Caller is not the registered vault or admin." },
-      { "code": 4, "name": "AmountNotPositive",    "when": "amount is zero or negative." },
-      { "code": 5, "name": "DeveloperRequired",    "when": "to_pool=false but no developer address was supplied." },
-      { "code": 6, "name": "DeveloperMustBeNone",  "when": "to_pool=true but a developer address was given." },
-      { "code": 7, "name": "PoolOverflow",         "when": "Global pool i128 addition would overflow." },
-      { "code": 8, "name": "DeveloperOverflow",    "when": "Developer balance i128 addition would overflow." }
+      { "code": 1,  "name": "NotInitialized",               "when": "A function is called before init." },
+      { "code": 2,  "name": "AlreadyInitialized",           "when": "init is called more than once." },
+      { "code": 3,  "name": "Unauthorized",                 "when": "Caller is not the registered vault or admin." },
+      { "code": 4,  "name": "AmountNotPositive",            "when": "amount is zero or negative." },
+      { "code": 5,  "name": "DeveloperRequired",            "when": "to_pool=false but no developer address was supplied." },
+      { "code": 6,  "name": "DeveloperMustBeNone",          "when": "to_pool=true but a developer address was given." },
+      { "code": 7,  "name": "PoolOverflow",                 "when": "Global pool i128 addition would overflow." },
+      { "code": 8,  "name": "DeveloperOverflow",            "when": "Developer balance i128 addition would overflow." },
+      { "code": 9,  "name": "UsdcTokenNotConfigured",       "when": "USDC token address not configured for withdrawals." },
+      { "code": 10, "name": "InsufficientDeveloperBalance", "when": "Developer balance is less than withdrawal amount." },
+      { "code": 11, "name": "DeveloperBalanceUnderflow",    "when": "Developer balance subtraction would overflow." },
+      { "code": 12, "name": "InsufficientContractBalance",  "when": "Settlement contract lacks on-ledger USDC." },
+      { "code": 13, "name": "GasExhaustionRisk",            "when": "Index exceeds 100 entries; use get_developer_balances_cursor instead of get_all_developer_balances." }
     ]
   },
 
@@ -118,17 +123,44 @@
 
     {
       "name": "get_all_developer_balances",
-      "description": "Return a list of all developer balances. Admin only; may be expensive if the index is large.",
+      "description": "Return a list of all developer balances. Admin only. Rejects the call with GasExhaustionRisk when the developer index exceeds 100 entries — use get_developer_balances_cursor for larger sets. The index is maintained in deterministic ascending order by address bytes.",
       "access": "admin",
       "params": [
         { "name": "caller", "type": "Address", "optional": false, "description": "Must be the current admin." }
       ],
       "returns": "Vec<DeveloperBalance>",
       "errors": [
+        { "code": 1,  "name": "NotInitialized",   "when": "Called before init." },
+        { "code": 3,  "name": "Unauthorized",      "when": "Caller is not the admin." },
+        { "code": 13, "name": "GasExhaustionRisk", "when": "Developer index has more than 100 entries." }
+      ],
+      "events": []
+    },
+
+    {
+      "name": "get_developer_balances_cursor",
+      "description": "Cursor-based paginated developer balances (admin only). Returns up to `limit` DeveloperBalance records starting after the supplied `cursor` address (exclusive), or from the beginning of the sorted index when `cursor` is null. The DeveloperIndex is maintained in deterministic ascending order by address bytes, so pages are stable across interleaved receive_payment calls for developers that sort after the cursor. The limit is capped at 100 (MAX_DEVELOPER_BALANCES_PAGE_SIZE).",
+      "access": "admin",
+      "params": [
+        { "name": "caller", "type": "Address",        "optional": false, "description": "Must be the current admin; must authorize." },
+        { "name": "cursor", "type": "Address | null",  "optional": true,  "description": "Exclusive start position. Pass null for the first page; pass the next_cursor value returned by the previous call for subsequent pages." },
+        { "name": "limit",  "type": "u32",             "optional": false, "description": "Maximum records to return per page; silently capped at 100." }
+      ],
+      "returns": {
+        "type": "(Vec<DeveloperBalance>, Address | null)",
+        "description": "A tuple of (page, next_cursor). `page` contains up to `limit` DeveloperBalance records. `next_cursor` is the address of the last record on the page when more records may exist, or null when this is the final page."
+      },
+      "errors": [
         { "code": 1, "name": "NotInitialized", "when": "Called before init." },
         { "code": 3, "name": "Unauthorized",   "when": "Caller is not the admin." }
       ],
-      "events": []
+      "events": [],
+      "notes": [
+        "Iterating all pages: call with cursor=null, then pass the returned next_cursor on each subsequent call until next_cursor is null.",
+        "Cursor stability: credits to developers that sort after the current cursor do not affect previously returned pages.",
+        "limit=0 returns an empty page and null next_cursor immediately.",
+        "A cursor pointing past the last entry returns an empty page and null next_cursor."
+      ]
     },
 
     {


### PR DESCRIPTION
# Cursor-Based Pagination for Developer Balances

Adds `get_developer_balances_page(cursor, limit)` as a bounded, cursor-paginated
view over all borrower credit lines. Replaces the unbounded `get_all_developer_balances`
full-scan: the backend can now retrieve all developer balances one page at a time
at predictable and bounded gas cost.

---

## Overview

| Property | Value |
|---|---|
| Entrypoint | `Credit::get_developer_balances_page` |
| Max page size | 100 (`MAX_ENUMERATION_LIMIT`) |
| Auth required | None — pure read, safe for public RPC and off-chain indexers |
| Gas cost | O(limit), independent of total credit-line count |

---

## Types

### `DeveloperBalance`

Defined in `contracts/credit/src/types.rs`.

| Field | Type | Description |
|---|---|---|
| `id` | `u32` | Stable numeric cursor (insertion-order id) |
| `borrower` | `Address` | Borrower / developer address |
| `utilized_amount` | `i128` | Outstanding principal as of last mutation |
| `credit_limit` | `i128` | Configured credit ceiling |

---

## API

### `get_developer_balances_page(env, cursor, limit)`

Defined in `contracts/credit/src/query.rs`.

**Parameters**

| Parameter | Type | Description |
|---|---|---|
| `cursor` | `Option<u32>` | Exclusive lower bound on the stable id. `None` starts from the beginning |
| `limit` | `u32` | Number of entries to return. Capped server-side at `MAX_ENUMERATION_LIMIT` (100) |

**Returns**

`(Vec<DeveloperBalance>, Option<u32>)`

- `next_cursor` is `Some(last_id)` when more pages exist
- `next_cursor` is `None` at the end of the index

---

## Usage

```rust
let mut cursor: Option<u32> = None;

loop {
    let (page, next) = client.get_developer_balances_page(&cursor, &20);

    for entry in page.iter() {
        // entry.id, entry.borrower, entry.utilized_amount, entry.credit_limit
    }

    match next {
        Some(c) => cursor = Some(c),
        None => break,
    }
}
```

---

## Cursor Stability Guarantees

- New credit lines opened between pages appear at ids **higher** than any
  already-returned id — a sequential walk never misses entries.
- Interleaved draws and repays do not affect id ordering, so a mid-walk
  cursor stays valid.
- Limit is capped server-side at 100; clients cannot exceed it.

---

## Changes

### `contracts/credit/src/query.rs`
- New `get_developer_balances_page` implementation

### `contracts/credit/src/lib.rs`
- Public `Credit::get_developer_balances_page` entrypoint delegating to the query module
- New admin entrypoints: `set_min_collateral_ratio_bps` / `get_min_collateral_ratio_bps`
- `DeveloperBalance` added to the types import

### `contracts/credit/src/types.rs`
- New `DeveloperBalance` `#[contracttype]` struct

### `contracts/credit/src/storage.rs`
- Added missing storage helpers: `get_collateral_balance` / `set_collateral_balance`,
  `get_min_collateral_ratio_bps` / `set_min_collateral_ratio_bps`,
  `get_collateral_token`, `set_borrower_unblocked`

---

## Tests

Located in `contracts/credit/tests/developer_balances_page.rs`. 13 integration
tests covering the full acceptance matrix.

| Test | What it checks |
|---|---|
| `empty_index_returns_empty_page_and_no_cursor` | `([], None)` on empty state |
| `single_entry_first_page` | `id`, `borrower`, `utilized_amount`, `credit_limit` all correct |
| `all_entries_fit_in_one_page_returns_no_cursor` | No cursor when results fit in one page |
| `cursor_advances_across_pages` | 3-page walk over 5 entries, cursor chain correct |
| `last_page_returns_none_cursor` | Exact-fit page returns `None` |
| `cursor_past_last_id_returns_empty` | Cursor beyond end returns `([], None)` |
| `limit_zero_returns_empty` | `limit=0` short-circuits cleanly |
| `limit_capped_at_max_enumeration_limit` | `limit=200` does not exceed internal cap |
| `stable_ordering_across_repeated_calls` | 3 identical calls return identical results |
| `cursor_unaffected_by_interleaved_credits` | New line opened mid-walk does not disrupt page 2 |
| `utilized_amount_is_zero_for_new_line` | Fresh line shows `utilized_amount = 0` |
| `utilized_amount_reflects_draw_via_enumerate` | Post-draw amount matches `enumerate_credit_lines` |
| `credit_limit_field_is_correct` | `credit_limit` correct for 3 distinct lines |
| `full_walk_collects_all_entries` | Loop walks all 7 entries in 3-per-page chunks, no gaps |

### Run Tests

```bash
cargo test -p creditra-credit developer_balances_page
```
Closes #428 