### PR TITLE
test: end-to-end vault -> settlement -> revenue_pool full cycle 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,9 @@
+[package]
+name = "callora-contracts-e2e"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
 [workspace]
 resolver = "2"
 members = [
@@ -13,6 +19,12 @@ default-members = [
 
 [workspace.dependencies]
 soroban-sdk = "22"
+
+[dev-dependencies]
+callora-vault = { path = "contracts/vault" }
+callora-settlement = { path = "contracts/settlement" }
+callora-revenue-pool = { path = "contracts/revenue_pool" }
+soroban-sdk = { workspace = true, features = ["testutils"] }
 
 [profile.dev]
 overflow-checks = true

--- a/build_output.txt
+++ b/build_output.txt
@@ -1,0 +1,1495 @@
+   Compiling callora-vault v0.0.1 (C:\Users\victo\Desktop\Test\Callora-Contracts\contracts\vault)
+   Compiling callora-revenue-pool v0.0.1 (C:\Users\victo\Desktop\Test\Callora-Contracts\contracts\revenue_pool)
+warning: cannot test inner items
+  --> contracts\revenue_pool\src\test.rs:48:5
+   |
+48 |     #[test]
+   |     ^^^^^^^
+   |
+   = note: `#[warn(unnameable_test_items)]` on by default
+
+warning: cannot test inner items
+  --> contracts\revenue_pool\src\test.rs:61:5
+   |
+61 |     #[test]
+   |     ^^^^^^^
+
+warning: cannot test inner items
+  --> contracts\revenue_pool\src\test.rs:77:5
+   |
+77 |     #[test]
+   |     ^^^^^^^
+
+warning: cannot test inner items
+  --> contracts\revenue_pool\src\test.rs:90:5
+   |
+90 |     #[test]
+   |     ^^^^^^^
+
+warning: cannot test inner items
+   --> contracts\revenue_pool\src\test.rs:105:5
+    |
+105 |     #[test]
+    |     ^^^^^^^
+
+warning: cannot test inner items
+   --> contracts\revenue_pool\src\test.rs:117:5
+    |
+117 |     #[test]
+    |     ^^^^^^^
+
+warning: cannot test inner items
+   --> contracts\revenue_pool\src\test.rs:129:5
+    |
+129 |     #[test]
+    |     ^^^^^^^
+
+warning: cannot test inner items
+   --> contracts\revenue_pool\src\test.rs:146:5
+    |
+146 |     #[test]
+    |     ^^^^^^^
+
+warning: cannot test inner items
+   --> contracts\revenue_pool\src\test.rs:165:5
+    |
+165 |     #[test]
+    |     ^^^^^^^
+
+warning: cannot test inner items
+   --> contracts\revenue_pool\src\test.rs:186:5
+    |
+186 |     #[test]
+    |     ^^^^^^^
+
+warning: cannot test inner items
+   --> contracts\revenue_pool\src\test.rs:200:5
+    |
+200 |     #[test]
+    |     ^^^^^^^
+
+warning: cannot test inner items
+   --> contracts\revenue_pool\src\test.rs:215:5
+    |
+215 |     #[test]
+    |     ^^^^^^^
+
+warning: cannot test inner items
+   --> contracts\revenue_pool\src\test.rs:228:5
+    |
+228 |     #[test]
+    |     ^^^^^^^
+
+warning: cannot test inner items
+   --> contracts\revenue_pool\src\test.rs:250:5
+    |
+250 |     #[test]
+    |     ^^^^^^^
+
+warning: cannot test inner items
+   --> contracts\revenue_pool\src\test.rs:264:5
+    |
+264 |     #[test]
+    |     ^^^^^^^
+
+warning: cannot test inner items
+   --> contracts\revenue_pool\src\test.rs:277:5
+    |
+277 |     #[test]
+    |     ^^^^^^^
+
+warning: cannot test inner items
+   --> contracts\revenue_pool\src\test.rs:293:5
+    |
+293 |     #[test]
+    |     ^^^^^^^
+
+warning: cannot test inner items
+   --> contracts\revenue_pool\src\test.rs:315:5
+    |
+315 |     #[test]
+    |     ^^^^^^^
+
+warning: cannot test inner items
+   --> contracts\revenue_pool\src\test.rs:338:5
+    |
+338 |     #[test]
+    |     ^^^^^^^
+
+warning: cannot test inner items
+   --> contracts\revenue_pool\src\test.rs:353:5
+    |
+353 |     #[test]
+    |     ^^^^^^^
+
+warning: cannot test inner items
+   --> contracts\revenue_pool\src\test.rs:369:5
+    |
+369 |     #[test]
+    |     ^^^^^^^
+
+warning: cannot test inner items
+   --> contracts\revenue_pool\src\test.rs:403:5
+    |
+403 |     #[test]
+    |     ^^^^^^^
+
+warning: cannot test inner items
+   --> contracts\revenue_pool\src\test.rs:425:5
+    |
+425 |     #[test]
+    |     ^^^^^^^
+
+warning: cannot test inner items
+   --> contracts\revenue_pool\src\test.rs:439:5
+    |
+439 |     #[test]
+    |     ^^^^^^^
+
+warning: cannot test inner items
+   --> contracts\revenue_pool\src\test.rs:464:5
+    |
+464 |     #[test]
+    |     ^^^^^^^
+
+warning: cannot test inner items
+   --> contracts\revenue_pool\src\test.rs:487:5
+    |
+487 |     #[test]
+    |     ^^^^^^^
+
+warning: cannot test inner items
+   --> contracts\revenue_pool\src\test.rs:520:5
+    |
+520 |     #[test]
+    |     ^^^^^^^
+
+warning: cannot test inner items
+   --> contracts\revenue_pool\src\test.rs:545:5
+    |
+545 |     #[test]
+    |     ^^^^^^^
+
+warning: cannot test inner items
+   --> contracts\revenue_pool\src\test.rs:559:5
+    |
+559 |     #[test]
+    |     ^^^^^^^
+
+warning: cannot test inner items
+   --> contracts\revenue_pool\src\test.rs:575:5
+    |
+575 |     #[test]
+    |     ^^^^^^^
+
+warning: cannot test inner items
+   --> contracts\revenue_pool\src\test.rs:589:5
+    |
+589 |     #[test]
+    |     ^^^^^^^
+
+warning: cannot test inner items
+   --> contracts\revenue_pool\src\test.rs:611:5
+    |
+611 |     #[test]
+    |     ^^^^^^^
+
+warning: cannot test inner items
+   --> contracts\revenue_pool\src\test.rs:637:5
+    |
+637 |     #[test]
+    |     ^^^^^^^
+
+warning: cannot test inner items
+   --> contracts\revenue_pool\src\test.rs:665:5
+    |
+665 |     #[test]
+    |     ^^^^^^^
+
+warning: cannot test inner items
+   --> contracts\revenue_pool\src\test.rs:695:5
+    |
+695 |     #[test]
+    |     ^^^^^^^
+
+warning: cannot test inner items
+   --> contracts\revenue_pool\src\test.rs:723:5
+    |
+723 |     #[test]
+    |     ^^^^^^^
+
+warning: cannot test inner items
+   --> contracts\revenue_pool\src\test.rs:751:5
+    |
+751 |     #[test]
+    |     ^^^^^^^
+
+warning: cannot test inner items
+   --> contracts\revenue_pool\src\test.rs:770:5
+    |
+770 |     #[test]
+    |     ^^^^^^^
+
+warning: cannot test inner items
+   --> contracts\revenue_pool\src\test.rs:799:5
+    |
+799 |     #[test]
+    |     ^^^^^^^
+
+warning: cannot test inner items
+   --> contracts\revenue_pool\src\test.rs:842:5
+    |
+842 |     #[test]
+    |     ^^^^^^^
+
+warning: cannot test inner items
+   --> contracts\revenue_pool\src\test.rs:871:5
+    |
+871 |     #[test]
+    |     ^^^^^^^
+
+warning: cannot test inner items
+   --> contracts\revenue_pool\src\test.rs:884:5
+    |
+884 |     #[test]
+    |     ^^^^^^^
+
+warning: cannot test inner items
+   --> contracts\revenue_pool\src\test.rs:905:5
+    |
+905 |     #[test]
+    |     ^^^^^^^
+
+warning: cannot test inner items
+   --> contracts\revenue_pool\src\test.rs:915:5
+    |
+915 |     #[test]
+    |     ^^^^^^^
+
+warning: cannot test inner items
+   --> contracts\revenue_pool\src\test.rs:928:5
+    |
+928 |     #[test]
+    |     ^^^^^^^
+
+warning: cannot test inner items
+   --> contracts\revenue_pool\src\test.rs:949:5
+    |
+949 |     #[test]
+    |     ^^^^^^^
+
+warning: cannot test inner items
+   --> contracts\revenue_pool\src\test.rs:963:5
+    |
+963 |     #[test]
+    |     ^^^^^^^
+
+warning: cannot test inner items
+   --> contracts\revenue_pool\src\test.rs:978:5
+    |
+978 |     #[test]
+    |     ^^^^^^^
+
+warning: cannot test inner items
+   --> contracts\revenue_pool\src\test.rs:998:5
+    |
+998 |     #[test]
+    |     ^^^^^^^
+
+warning: cannot test inner items
+    --> contracts\revenue_pool\src\test.rs:1022:5
+     |
+1022 |     #[test]
+     |     ^^^^^^^
+
+warning: cannot test inner items
+    --> contracts\revenue_pool\src\test.rs:1039:5
+     |
+1039 |     #[test]
+     |     ^^^^^^^
+
+warning: cannot test inner items
+    --> contracts\revenue_pool\src\test.rs:1058:5
+     |
+1058 |     #[test]
+     |     ^^^^^^^
+
+error[E0277]: the type `UnsafeCell<Generators>` may contain interior mutability and a reference may not be safely transferable across a catch_unwind boundary
+   --> contracts\revenue_pool\src\test.rs:161:47
+    |
+161 |         let result = std::panic::catch_unwind(|| client.distribute(&admin, &developer, &100));
+    |                      ------------------------ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `UnsafeCell<Generators>` may contain interior mutability and a reference may not be safely transferable across a catch_unwind boundary
+    |                      |
+    |                      required by a bound introduced by this call
+    |
+    = help: within `RefCell<Generators>`, the trait `RefUnwindSafe` is not implemented for `UnsafeCell<Generators>`
+note: required because it appears within the type `RefCell<Generators>`
+   --> C:\Users\victo\.rustup\toolchains\stable-x86_64-pc-windows-msvc\lib/rustlib/src/rust\library\core\src\cell.rs:849:12
+    |
+849 | pub struct RefCell<T: ?Sized> {
+    |            ^^^^^^^
+    = note: required for `Rc<RefCell<Generators>>` to implement `RefUnwindSafe`
+note: required because it appears within the type `soroban_sdk::env::EnvTestState`
+   --> C:\Users\victo\.cargo\registry\src\index.crates.io-1949cf8c6b5b557f\soroban-sdk-22.0.11\src\env.rs:244:8
+    |
+244 | struct EnvTestState {
+    |        ^^^^^^^^^^^^
+note: required because it appears within the type `Env`
+   --> C:\Users\victo\.cargo\registry\src\index.crates.io-1949cf8c6b5b557f\soroban-sdk-22.0.11\src\env.rs:222:12
+    |
+222 | pub struct Env {
+    |            ^^^
+note: required because it appears within the type `RevenuePoolClient<'_>`
+   --> contracts\revenue_pool\src\lib.rs:47:1
+    |
+ 47 | #[contract]
+    | ^^^^^^^^^^^
+    = note: required for `&RevenuePoolClient<'_>` to implement `UnwindSafe`
+note: required because it's used within this closure
+   --> contracts\revenue_pool\src\test.rs:161:47
+    |
+161 |         let result = std::panic::catch_unwind(|| client.distribute(&admin, &developer, &100));
+    |                                               ^^
+note: required by a bound in `test::std::panic::catch_unwind`
+   --> C:\Users\victo\.rustup\toolchains\stable-x86_64-pc-windows-msvc\lib/rustlib/src/rust\library\std\src\panic.rs:358:40
+    |
+358 | pub fn catch_unwind<F: FnOnce() -> R + UnwindSafe, R>(f: F) -> Result<R> {
+    |                                        ^^^^^^^^^^ required by this bound in `catch_unwind`
+    = note: this error originates in the attribute macro `contract` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the type `UnsafeCell<AuthSnapshot>` may contain interior mutability and a reference may not be safely transferable across a catch_unwind boundary
+   --> contracts\revenue_pool\src\test.rs:161:47
+    |
+161 |         let result = std::panic::catch_unwind(|| client.distribute(&admin, &developer, &100));
+    |                      ------------------------ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `UnsafeCell<AuthSnapshot>` may contain interior mutability and a reference may not be safely transferable across a catch_unwind boundary
+    |                      |
+    |                      required by a bound introduced by this call
+    |
+    = help: within `RefCell<AuthSnapshot>`, the trait `RefUnwindSafe` is not implemented for `UnsafeCell<AuthSnapshot>`
+note: required because it appears within the type `RefCell<AuthSnapshot>`
+   --> C:\Users\victo\.rustup\toolchains\stable-x86_64-pc-windows-msvc\lib/rustlib/src/rust\library\core\src\cell.rs:849:12
+    |
+849 | pub struct RefCell<T: ?Sized> {
+    |            ^^^^^^^
+    = note: required for `Rc<RefCell<AuthSnapshot>>` to implement `RefUnwindSafe`
+note: required because it appears within the type `soroban_sdk::env::EnvTestState`
+   --> C:\Users\victo\.cargo\registry\src\index.crates.io-1949cf8c6b5b557f\soroban-sdk-22.0.11\src\env.rs:244:8
+    |
+244 | struct EnvTestState {
+    |        ^^^^^^^^^^^^
+note: required because it appears within the type `Env`
+   --> C:\Users\victo\.cargo\registry\src\index.crates.io-1949cf8c6b5b557f\soroban-sdk-22.0.11\src\env.rs:222:12
+    |
+222 | pub struct Env {
+    |            ^^^
+note: required because it appears within the type `RevenuePoolClient<'_>`
+   --> contracts\revenue_pool\src\lib.rs:47:1
+    |
+ 47 | #[contract]
+    | ^^^^^^^^^^^
+    = note: required for `&RevenuePoolClient<'_>` to implement `UnwindSafe`
+note: required because it's used within this closure
+   --> contracts\revenue_pool\src\test.rs:161:47
+    |
+161 |         let result = std::panic::catch_unwind(|| client.distribute(&admin, &developer, &100));
+    |                                               ^^
+note: required by a bound in `test::std::panic::catch_unwind`
+   --> C:\Users\victo\.rustup\toolchains\stable-x86_64-pc-windows-msvc\lib/rustlib/src/rust\library\std\src\panic.rs:358:40
+    |
+358 | pub fn catch_unwind<F: FnOnce() -> R + UnwindSafe, R>(f: F) -> Result<R> {
+    |                                        ^^^^^^^^^^ required by this bound in `catch_unwind`
+    = note: this error originates in the attribute macro `contract` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the type `UnsafeCell<core::option::Option<soroban_env_host::vm::module_cache::ModuleCache>>` may contain interior mutability and a reference may not be safely transferable across a catch_unwind boundary
+   --> contracts\revenue_pool\src\test.rs:161:47
+    |
+161 |         let result = std::panic::catch_unwind(|| client.distribute(&admin, &developer, &100));
+    |                      ------------------------ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `UnsafeCell<core::option::Option<soroban_env_host::vm::module_cache::ModuleCache>>` may contain interior mutability and a reference may not be safely transferable across a catch_unwind boundary
+    |                      |
+    |                      required by a bound introduced by this call
+    |
+    = help: within `soroban_env_host::host::HostImpl`, the trait `RefUnwindSafe` is not implemented for `UnsafeCell<core::option::Option<soroban_env_host::vm::module_cache::ModuleCache>>`
+note: required because it appears within the type `RefCell<core::option::Option<soroban_env_host::vm::module_cache::ModuleCache>>`
+   --> C:\Users\victo\.rustup\toolchains\stable-x86_64-pc-windows-msvc\lib/rustlib/src/rust\library\core\src\cell.rs:849:12
+    |
+849 | pub struct RefCell<T: ?Sized> {
+    |            ^^^^^^^
+note: required because it appears within the type `soroban_env_host::host::HostImpl`
+   --> C:\Users\victo\.cargo\registry\src\index.crates.io-1949cf8c6b5b557f\soroban-env-host-22.1.3\src\host.rs:93:8
+    |
+ 93 | struct HostImpl {
+    |        ^^^^^^^^
+    = note: required for `Rc<soroban_env_host::host::HostImpl>` to implement `RefUnwindSafe`
+note: required because it appears within the type `soroban_env_host::host::Host`
+   --> C:\Users\victo\.cargo\registry\src\index.crates.io-1949cf8c6b5b557f\soroban-env-host-22.1.3\src\host.rs:181:12
+    |
+181 | pub struct Host(Rc<HostImpl>);
+    |            ^^^^
+note: required because it appears within the type `Env`
+   --> C:\Users\victo\.cargo\registry\src\index.crates.io-1949cf8c6b5b557f\soroban-sdk-22.0.11\src\env.rs:222:12
+    |
+222 | pub struct Env {
+    |            ^^^
+note: required because it appears within the type `RevenuePoolClient<'_>`
+   --> contracts\revenue_pool\src\lib.rs:47:1
+    |
+ 47 | #[contract]
+    | ^^^^^^^^^^^
+    = note: required for `&RevenuePoolClient<'_>` to implement `UnwindSafe`
+note: required because it's used within this closure
+   --> contracts\revenue_pool\src\test.rs:161:47
+    |
+161 |         let result = std::panic::catch_unwind(|| client.distribute(&admin, &developer, &100));
+    |                                               ^^
+note: required by a bound in `test::std::panic::catch_unwind`
+   --> C:\Users\victo\.rustup\toolchains\stable-x86_64-pc-windows-msvc\lib/rustlib/src/rust\library\std\src\panic.rs:358:40
+    |
+358 | pub fn catch_unwind<F: FnOnce() -> R + UnwindSafe, R>(f: F) -> Result<R> {
+    |                                        ^^^^^^^^^^ required by this bound in `catch_unwind`
+    = note: this error originates in the attribute macro `contract` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the type `UnsafeCell<core::option::Option<soroban_wasmi::linker::Linker<soroban_env_host::host::Host>>>` may contain interior mutability and a reference may not be safely transferable across a catch_unwind boundary
+   --> contracts\revenue_pool\src\test.rs:161:47
+    |
+161 |         let result = std::panic::catch_unwind(|| client.distribute(&admin, &developer, &100));
+    |                      ------------------------ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `UnsafeCell<core::option::Option<soroban_wasmi::linker::Linker<soroban_env_host::host::Host>>>` may contain interior mutability and a reference may not be safely transferable across a catch_unwind boundary
+    |                      |
+    |                      required by a bound introduced by this call
+    |
+    = help: within `soroban_env_host::host::HostImpl`, the trait `RefUnwindSafe` is not implemented for `UnsafeCell<core::option::Option<soroban_wasmi::linker::Linker<soroban_env_host::host::Host>>>`
+note: required because it appears within the type `RefCell<core::option::Option<soroban_wasmi::linker::Linker<soroban_env_host::host::Host>>>`
+   --> C:\Users\victo\.rustup\toolchains\stable-x86_64-pc-windows-msvc\lib/rustlib/src/rust\library\core\src\cell.rs:849:12
+    |
+849 | pub struct RefCell<T: ?Sized> {
+    |            ^^^^^^^
+note: required because it appears within the type `soroban_env_host::host::HostImpl`
+   --> C:\Users\victo\.cargo\registry\src\index.crates.io-1949cf8c6b5b557f\soroban-env-host-22.1.3\src\host.rs:93:8
+    |
+ 93 | struct HostImpl {
+    |        ^^^^^^^^
+    = note: required for `Rc<soroban_env_host::host::HostImpl>` to implement `RefUnwindSafe`
+note: required because it appears within the type `soroban_env_host::host::Host`
+   --> C:\Users\victo\.cargo\registry\src\index.crates.io-1949cf8c6b5b557f\soroban-env-host-22.1.3\src\host.rs:181:12
+    |
+181 | pub struct Host(Rc<HostImpl>);
+    |            ^^^^
+note: required because it appears within the type `Env`
+   --> C:\Users\victo\.cargo\registry\src\index.crates.io-1949cf8c6b5b557f\soroban-sdk-22.0.11\src\env.rs:222:12
+    |
+222 | pub struct Env {
+    |            ^^^
+note: required because it appears within the type `RevenuePoolClient<'_>`
+   --> contracts\revenue_pool\src\lib.rs:47:1
+    |
+ 47 | #[contract]
+    | ^^^^^^^^^^^
+    = note: required for `&RevenuePoolClient<'_>` to implement `UnwindSafe`
+note: required because it's used within this closure
+   --> contracts\revenue_pool\src\test.rs:161:47
+    |
+161 |         let result = std::panic::catch_unwind(|| client.distribute(&admin, &developer, &100));
+    |                                               ^^
+note: required by a bound in `test::std::panic::catch_unwind`
+   --> C:\Users\victo\.rustup\toolchains\stable-x86_64-pc-windows-msvc\lib/rustlib/src/rust\library\std\src\panic.rs:358:40
+    |
+358 | pub fn catch_unwind<F: FnOnce() -> R + UnwindSafe, R>(f: F) -> Result<R> {
+    |                                        ^^^^^^^^^^ required by this bound in `catch_unwind`
+    = note: this error originates in the attribute macro `contract` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the type `UnsafeCell<core::option::Option<soroban_sdk::xdr::AccountId>>` may contain interior mutability and a reference may not be safely transferable across a catch_unwind boundary
+   --> contracts\revenue_pool\src\test.rs:161:47
+    |
+161 |         let result = std::panic::catch_unwind(|| client.distribute(&admin, &developer, &100));
+    |                      ------------------------ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `UnsafeCell<core::option::Option<soroban_sdk::xdr::AccountId>>` may contain interior mutability and a reference may not be safely transferable across a catch_unwind boundary
+    |                      |
+    |                      required by a bound introduced by this call
+    |
+    = help: within `soroban_env_host::host::HostImpl`, the trait `RefUnwindSafe` is not implemented for `UnsafeCell<core::option::Option<soroban_sdk::xdr::AccountId>>`
+note: required because it appears within the type `RefCell<core::option::Option<soroban_sdk::xdr::AccountId>>`
+   --> C:\Users\victo\.rustup\toolchains\stable-x86_64-pc-windows-msvc\lib/rustlib/src/rust\library\core\src\cell.rs:849:12
+    |
+849 | pub struct RefCell<T: ?Sized> {
+    |            ^^^^^^^
+note: required because it appears within the type `soroban_env_host::host::HostImpl`
+   --> C:\Users\victo\.cargo\registry\src\index.crates.io-1949cf8c6b5b557f\soroban-env-host-22.1.3\src\host.rs:93:8
+    |
+ 93 | struct HostImpl {
+    |        ^^^^^^^^
+    = note: required for `Rc<soroban_env_host::host::HostImpl>` to implement `RefUnwindSafe`
+note: required because it appears within the type `soroban_env_host::host::Host`
+   --> C:\Users\victo\.cargo\registry\src\index.crates.io-1949cf8c6b5b557f\soroban-env-host-22.1.3\src\host.rs:181:12
+    |
+181 | pub struct Host(Rc<HostImpl>);
+    |            ^^^^
+note: required because it appears within the type `Env`
+   --> C:\Users\victo\.cargo\registry\src\index.crates.io-1949cf8c6b5b557f\soroban-sdk-22.0.11\src\env.rs:222:12
+    |
+222 | pub struct Env {
+    |            ^^^
+note: required because it appears within the type `RevenuePoolClient<'_>`
+   --> contracts\revenue_pool\src\lib.rs:47:1
+    |
+ 47 | #[contract]
+    | ^^^^^^^^^^^
+    = note: required for `&RevenuePoolClient<'_>` to implement `UnwindSafe`
+note: required because it's used within this closure
+   --> contracts\revenue_pool\src\test.rs:161:47
+    |
+161 |         let result = std::panic::catch_unwind(|| client.distribute(&admin, &developer, &100));
+    |                                               ^^
+note: required by a bound in `test::std::panic::catch_unwind`
+   --> C:\Users\victo\.rustup\toolchains\stable-x86_64-pc-windows-msvc\lib/rustlib/src/rust\library\std\src\panic.rs:358:40
+    |
+358 | pub fn catch_unwind<F: FnOnce() -> R + UnwindSafe, R>(f: F) -> Result<R> {
+    |                                        ^^^^^^^^^^ required by this bound in `catch_unwind`
+    = note: this error originates in the attribute macro `contract` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the type `UnsafeCell<core::option::Option<LedgerInfo>>` may contain interior mutability and a reference may not be safely transferable across a catch_unwind boundary
+   --> contracts\revenue_pool\src\test.rs:161:47
+    |
+161 |         let result = std::panic::catch_unwind(|| client.distribute(&admin, &developer, &100));
+    |                      ------------------------ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `UnsafeCell<core::option::Option<LedgerInfo>>` may contain interior mutability and a reference may not be safely transferable across a catch_unwind boundary
+    |                      |
+    |                      required by a bound introduced by this call
+    |
+    = help: within `soroban_env_host::host::HostImpl`, the trait `RefUnwindSafe` is not implemented for `UnsafeCell<core::option::Option<LedgerInfo>>`
+note: required because it appears within the type `RefCell<core::option::Option<LedgerInfo>>`
+   --> C:\Users\victo\.rustup\toolchains\stable-x86_64-pc-windows-msvc\lib/rustlib/src/rust\library\core\src\cell.rs:849:12
+    |
+849 | pub struct RefCell<T: ?Sized> {
+    |            ^^^^^^^
+note: required because it appears within the type `soroban_env_host::host::HostImpl`
+   --> C:\Users\victo\.cargo\registry\src\index.crates.io-1949cf8c6b5b557f\soroban-env-host-22.1.3\src\host.rs:93:8
+    |
+ 93 | struct HostImpl {
+    |        ^^^^^^^^
+    = note: required for `Rc<soroban_env_host::host::HostImpl>` to implement `RefUnwindSafe`
+note: required because it appears within the type `soroban_env_host::host::Host`
+   --> C:\Users\victo\.cargo\registry\src\index.crates.io-1949cf8c6b5b557f\soroban-env-host-22.1.3\src\host.rs:181:12
+    |
+181 | pub struct Host(Rc<HostImpl>);
+    |            ^^^^
+note: required because it appears within the type `Env`
+   --> C:\Users\victo\.cargo\registry\src\index.crates.io-1949cf8c6b5b557f\soroban-sdk-22.0.11\src\env.rs:222:12
+    |
+222 | pub struct Env {
+    |            ^^^
+note: required because it appears within the type `RevenuePoolClient<'_>`
+   --> contracts\revenue_pool\src\lib.rs:47:1
+    |
+ 47 | #[contract]
+    | ^^^^^^^^^^^
+    = note: required for `&RevenuePoolClient<'_>` to implement `UnwindSafe`
+note: required because it's used within this closure
+   --> contracts\revenue_pool\src\test.rs:161:47
+    |
+161 |         let result = std::panic::catch_unwind(|| client.distribute(&admin, &developer, &100));
+    |                                               ^^
+note: required by a bound in `test::std::panic::catch_unwind`
+   --> C:\Users\victo\.rustup\toolchains\stable-x86_64-pc-windows-msvc\lib/rustlib/src/rust\library\std\src\panic.rs:358:40
+    |
+358 | pub fn catch_unwind<F: FnOnce() -> R + UnwindSafe, R>(f: F) -> Result<R> {
+    |                                        ^^^^^^^^^^ required by this bound in `catch_unwind`
+    = note: this error originates in the attribute macro `contract` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the type `UnsafeCell<test::std::vec::Vec<soroban_env_host::host_object::HostObject>>` may contain interior mutability and a reference may not be safely transferable across a catch_unwind boundary
+   --> contracts\revenue_pool\src\test.rs:161:47
+    |
+161 |         let result = std::panic::catch_unwind(|| client.distribute(&admin, &developer, &100));
+    |                      ------------------------ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `UnsafeCell<test::std::vec::Vec<soroban_env_host::host_object::HostObject>>` may contain interior mutability and a reference may not be safely transferable across a catch_unwind boundary
+    |                      |
+    |                      required by a bound introduced by this call
+    |
+    = help: within `soroban_env_host::host::HostImpl`, the trait `RefUnwindSafe` is not implemented for `UnsafeCell<test::std::vec::Vec<soroban_env_host::host_object::HostObject>>`
+note: required because it appears within the type `RefCell<test::std::vec::Vec<soroban_env_host::host_object::HostObject>>`
+   --> C:\Users\victo\.rustup\toolchains\stable-x86_64-pc-windows-msvc\lib/rustlib/src/rust\library\core\src\cell.rs:849:12
+    |
+849 | pub struct RefCell<T: ?Sized> {
+    |            ^^^^^^^
+note: required because it appears within the type `soroban_env_host::host::HostImpl`
+   --> C:\Users\victo\.cargo\registry\src\index.crates.io-1949cf8c6b5b557f\soroban-env-host-22.1.3\src\host.rs:93:8
+    |
+ 93 | struct HostImpl {
+    |        ^^^^^^^^
+    = note: required for `Rc<soroban_env_host::host::HostImpl>` to implement `RefUnwindSafe`
+note: required because it appears within the type `soroban_env_host::host::Host`
+   --> C:\Users\victo\.cargo\registry\src\index.crates.io-1949cf8c6b5b557f\soroban-env-host-22.1.3\src\host.rs:181:12
+    |
+181 | pub struct Host(Rc<HostImpl>);
+    |            ^^^^
+note: required because it appears within the type `Env`
+   --> C:\Users\victo\.cargo\registry\src\index.crates.io-1949cf8c6b5b557f\soroban-sdk-22.0.11\src\env.rs:222:12
+    |
+222 | pub struct Env {
+    |            ^^^
+note: required because it appears within the type `RevenuePoolClient<'_>`
+   --> contracts\revenue_pool\src\lib.rs:47:1
+    |
+ 47 | #[contract]
+    | ^^^^^^^^^^^
+    = note: required for `&RevenuePoolClient<'_>` to implement `UnwindSafe`
+note: required because it's used within this closure
+   --> contracts\revenue_pool\src\test.rs:161:47
+    |
+161 |         let result = std::panic::catch_unwind(|| client.distribute(&admin, &developer, &100));
+    |                                               ^^
+note: required by a bound in `test::std::panic::catch_unwind`
+   --> C:\Users\victo\.rustup\toolchains\stable-x86_64-pc-windows-msvc\lib/rustlib/src/rust\library\std\src\panic.rs:358:40
+    |
+358 | pub fn catch_unwind<F: FnOnce() -> R + UnwindSafe, R>(f: F) -> Result<R> {
+    |                                        ^^^^^^^^^^ required by this bound in `catch_unwind`
+    = note: this error originates in the attribute macro `contract` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the type `UnsafeCell<soroban_env_host::storage::Storage>` may contain interior mutability and a reference may not be safely transferable across a catch_unwind boundary
+   --> contracts\revenue_pool\src\test.rs:161:47
+    |
+161 |         let result = std::panic::catch_unwind(|| client.distribute(&admin, &developer, &100));
+    |                      ------------------------ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `UnsafeCell<soroban_env_host::storage::Storage>` may contain interior mutability and a reference may not be safely transferable across a catch_unwind boundary
+    |                      |
+    |                      required by a bound introduced by this call
+    |
+    = help: within `soroban_env_host::host::HostImpl`, the trait `RefUnwindSafe` is not implemented for `UnsafeCell<soroban_env_host::storage::Storage>`
+note: required because it appears within the type `RefCell<soroban_env_host::storage::Storage>`
+   --> C:\Users\victo\.rustup\toolchains\stable-x86_64-pc-windows-msvc\lib/rustlib/src/rust\library\core\src\cell.rs:849:12
+    |
+849 | pub struct RefCell<T: ?Sized> {
+    |            ^^^^^^^
+note: required because it appears within the type `soroban_env_host::host::HostImpl`
+   --> C:\Users\victo\.cargo\registry\src\index.crates.io-1949cf8c6b5b557f\soroban-env-host-22.1.3\src\host.rs:93:8
+    |
+ 93 | struct HostImpl {
+    |        ^^^^^^^^
+    = note: required for `Rc<soroban_env_host::host::HostImpl>` to implement `RefUnwindSafe`
+note: required because it appears within the type `soroban_env_host::host::Host`
+   --> C:\Users\victo\.cargo\registry\src\index.crates.io-1949cf8c6b5b557f\soroban-env-host-22.1.3\src\host.rs:181:12
+    |
+181 | pub struct Host(Rc<HostImpl>);
+    |            ^^^^
+note: required because it appears within the type `Env`
+   --> C:\Users\victo\.cargo\registry\src\index.crates.io-1949cf8c6b5b557f\soroban-sdk-22.0.11\src\env.rs:222:12
+    |
+222 | pub struct Env {
+    |            ^^^
+note: required because it appears within the type `RevenuePoolClient<'_>`
+   --> contracts\revenue_pool\src\lib.rs:47:1
+    |
+ 47 | #[contract]
+    | ^^^^^^^^^^^
+    = note: required for `&RevenuePoolClient<'_>` to implement `UnwindSafe`
+note: required because it's used within this closure
+   --> contracts\revenue_pool\src\test.rs:161:47
+    |
+161 |         let result = std::panic::catch_unwind(|| client.distribute(&admin, &developer, &100));
+    |                                               ^^
+note: required by a bound in `test::std::panic::catch_unwind`
+   --> C:\Users\victo\.rustup\toolchains\stable-x86_64-pc-windows-msvc\lib/rustlib/src/rust\library\std\src\panic.rs:358:40
+    |
+358 | pub fn catch_unwind<F: FnOnce() -> R + UnwindSafe, R>(f: F) -> Result<R> {
+    |                                        ^^^^^^^^^^ required by this bound in `catch_unwind`
+    = note: this error originates in the attribute macro `contract` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the type `UnsafeCell<test::std::vec::Vec<soroban_env_host::host::frame::Context>>` may contain interior mutability and a reference may not be safely transferable across a catch_unwind boundary
+   --> contracts\revenue_pool\src\test.rs:161:47
+    |
+161 |         let result = std::panic::catch_unwind(|| client.distribute(&admin, &developer, &100));
+    |                      ------------------------ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `UnsafeCell<test::std::vec::Vec<soroban_env_host::host::frame::Context>>` may contain interior mutability and a reference may not be safely transferable across a catch_unwind boundary
+    |                      |
+    |                      required by a bound introduced by this call
+    |
+    = help: within `soroban_env_host::host::HostImpl`, the trait `RefUnwindSafe` is not implemented for `UnsafeCell<test::std::vec::Vec<soroban_env_host::host::frame::Context>>`
+note: required because it appears within the type `RefCell<test::std::vec::Vec<soroban_env_host::host::frame::Context>>`
+   --> C:\Users\victo\.rustup\toolchains\stable-x86_64-pc-windows-msvc\lib/rustlib/src/rust\library\core\src\cell.rs:849:12
+    |
+849 | pub struct RefCell<T: ?Sized> {
+    |            ^^^^^^^
+note: required because it appears within the type `soroban_env_host::host::HostImpl`
+   --> C:\Users\victo\.cargo\registry\src\index.crates.io-1949cf8c6b5b557f\soroban-env-host-22.1.3\src\host.rs:93:8
+    |
+ 93 | struct HostImpl {
+    |        ^^^^^^^^
+    = note: required for `Rc<soroban_env_host::host::HostImpl>` to implement `RefUnwindSafe`
+note: required because it appears within the type `soroban_env_host::host::Host`
+   --> C:\Users\victo\.cargo\registry\src\index.crates.io-1949cf8c6b5b557f\soroban-env-host-22.1.3\src\host.rs:181:12
+    |
+181 | pub struct Host(Rc<HostImpl>);
+    |            ^^^^
+note: required because it appears within the type `Env`
+   --> C:\Users\victo\.cargo\registry\src\index.crates.io-1949cf8c6b5b557f\soroban-sdk-22.0.11\src\env.rs:222:12
+    |
+222 | pub struct Env {
+    |            ^^^
+note: required because it appears within the type `RevenuePoolClient<'_>`
+   --> contracts\revenue_pool\src\lib.rs:47:1
+    |
+ 47 | #[contract]
+    | ^^^^^^^^^^^
+    = note: required for `&RevenuePoolClient<'_>` to implement `UnwindSafe`
+note: required because it's used within this closure
+   --> contracts\revenue_pool\src\test.rs:161:47
+    |
+161 |         let result = std::panic::catch_unwind(|| client.distribute(&admin, &developer, &100));
+    |                                               ^^
+note: required by a bound in `test::std::panic::catch_unwind`
+   --> C:\Users\victo\.rustup\toolchains\stable-x86_64-pc-windows-msvc\lib/rustlib/src/rust\library\std\src\panic.rs:358:40
+    |
+358 | pub fn catch_unwind<F: FnOnce() -> R + UnwindSafe, R>(f: F) -> Result<R> {
+    |                                        ^^^^^^^^^^ required by this bound in `catch_unwind`
+    = note: this error originates in the attribute macro `contract` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the type `UnsafeCell<soroban_env_host::events::internal::InternalEventsBuffer>` may contain interior mutability and a reference may not be safely transferable across a catch_unwind boundary
+   --> contracts\revenue_pool\src\test.rs:161:47
+    |
+161 |         let result = std::panic::catch_unwind(|| client.distribute(&admin, &developer, &100));
+    |                      ------------------------ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `UnsafeCell<soroban_env_host::events::internal::InternalEventsBuffer>` may contain interior mutability and a reference may not be safely transferable across a catch_unwind boundary
+    |                      |
+    |                      required by a bound introduced by this call
+    |
+    = help: within `soroban_env_host::host::HostImpl`, the trait `RefUnwindSafe` is not implemented for `UnsafeCell<soroban_env_host::events::internal::InternalEventsBuffer>`
+note: required because it appears within the type `RefCell<soroban_env_host::events::internal::InternalEventsBuffer>`
+   --> C:\Users\victo\.rustup\toolchains\stable-x86_64-pc-windows-msvc\lib/rustlib/src/rust\library\core\src\cell.rs:849:12
+    |
+849 | pub struct RefCell<T: ?Sized> {
+    |            ^^^^^^^
+note: required because it appears within the type `soroban_env_host::host::HostImpl`
+   --> C:\Users\victo\.cargo\registry\src\index.crates.io-1949cf8c6b5b557f\soroban-env-host-22.1.3\src\host.rs:93:8
+    |
+ 93 | struct HostImpl {
+    |        ^^^^^^^^
+    = note: required for `Rc<soroban_env_host::host::HostImpl>` to implement `RefUnwindSafe`
+note: required because it appears within the type `soroban_env_host::host::Host`
+   --> C:\Users\victo\.cargo\registry\src\index.crates.io-1949cf8c6b5b557f\soroban-env-host-22.1.3\src\host.rs:181:12
+    |
+181 | pub struct Host(Rc<HostImpl>);
+    |            ^^^^
+note: required because it appears within the type `Env`
+   --> C:\Users\victo\.cargo\registry\src\index.crates.io-1949cf8c6b5b557f\soroban-sdk-22.0.11\src\env.rs:222:12
+    |
+222 | pub struct Env {
+    |            ^^^
+note: required because it appears within the type `RevenuePoolClient<'_>`
+   --> contracts\revenue_pool\src\lib.rs:47:1
+    |
+ 47 | #[contract]
+    | ^^^^^^^^^^^
+    = note: required for `&RevenuePoolClient<'_>` to implement `UnwindSafe`
+note: required because it's used within this closure
+   --> contracts\revenue_pool\src\test.rs:161:47
+    |
+161 |         let result = std::panic::catch_unwind(|| client.distribute(&admin, &developer, &100));
+    |                                               ^^
+note: required by a bound in `test::std::panic::catch_unwind`
+   --> C:\Users\victo\.rustup\toolchains\stable-x86_64-pc-windows-msvc\lib/rustlib/src/rust\library\std\src\panic.rs:358:40
+    |
+358 | pub fn catch_unwind<F: FnOnce() -> R + UnwindSafe, R>(f: F) -> Result<R> {
+    |                                        ^^^^^^^^^^ required by this bound in `catch_unwind`
+    = note: this error originates in the attribute macro `contract` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the type `UnsafeCell<soroban_env_host::auth::AuthorizationManager>` may contain interior mutability and a reference may not be safely transferable across a catch_unwind boundary
+   --> contracts\revenue_pool\src\test.rs:161:47
+    |
+161 |         let result = std::panic::catch_unwind(|| client.distribute(&admin, &developer, &100));
+    |                      ------------------------ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `UnsafeCell<soroban_env_host::auth::AuthorizationManager>` may contain interior mutability and a reference may not be safely transferable across a catch_unwind boundary
+    |                      |
+    |                      required by a bound introduced by this call
+    |
+    = help: within `soroban_env_host::host::HostImpl`, the trait `RefUnwindSafe` is not implemented for `UnsafeCell<soroban_env_host::auth::AuthorizationManager>`
+note: required because it appears within the type `RefCell<soroban_env_host::auth::AuthorizationManager>`
+   --> C:\Users\victo\.rustup\toolchains\stable-x86_64-pc-windows-msvc\lib/rustlib/src/rust\library\core\src\cell.rs:849:12
+    |
+849 | pub struct RefCell<T: ?Sized> {
+    |            ^^^^^^^
+note: required because it appears within the type `soroban_env_host::host::HostImpl`
+   --> C:\Users\victo\.cargo\registry\src\index.crates.io-1949cf8c6b5b557f\soroban-env-host-22.1.3\src\host.rs:93:8
+    |
+ 93 | struct HostImpl {
+    |        ^^^^^^^^
+    = note: required for `Rc<soroban_env_host::host::HostImpl>` to implement `RefUnwindSafe`
+note: required because it appears within the type `soroban_env_host::host::Host`
+   --> C:\Users\victo\.cargo\registry\src\index.crates.io-1949cf8c6b5b557f\soroban-env-host-22.1.3\src\host.rs:181:12
+    |
+181 | pub struct Host(Rc<HostImpl>);
+    |            ^^^^
+note: required because it appears within the type `Env`
+   --> C:\Users\victo\.cargo\registry\src\index.crates.io-1949cf8c6b5b557f\soroban-sdk-22.0.11\src\env.rs:222:12
+    |
+222 | pub struct Env {
+    |            ^^^
+note: required because it appears within the type `RevenuePoolClient<'_>`
+   --> contracts\revenue_pool\src\lib.rs:47:1
+    |
+ 47 | #[contract]
+    | ^^^^^^^^^^^
+    = note: required for `&RevenuePoolClient<'_>` to implement `UnwindSafe`
+note: required because it's used within this closure
+   --> contracts\revenue_pool\src\test.rs:161:47
+    |
+161 |         let result = std::panic::catch_unwind(|| client.distribute(&admin, &developer, &100));
+    |                                               ^^
+note: required by a bound in `test::std::panic::catch_unwind`
+   --> C:\Users\victo\.rustup\toolchains\stable-x86_64-pc-windows-msvc\lib/rustlib/src/rust\library\std\src\panic.rs:358:40
+    |
+358 | pub fn catch_unwind<F: FnOnce() -> R + UnwindSafe, R>(f: F) -> Result<R> {
+    |                                        ^^^^^^^^^^ required by this bound in `catch_unwind`
+    = note: this error originates in the attribute macro `contract` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the type `UnsafeCell<soroban_env_host::events::diagnostic::DiagnosticLevel>` may contain interior mutability and a reference may not be safely transferable across a catch_unwind boundary
+   --> contracts\revenue_pool\src\test.rs:161:47
+    |
+161 |         let result = std::panic::catch_unwind(|| client.distribute(&admin, &developer, &100));
+    |                      ------------------------ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `UnsafeCell<soroban_env_host::events::diagnostic::DiagnosticLevel>` may contain interior mutability and a reference may not be safely transferable across a catch_unwind boundary
+    |                      |
+    |                      required by a bound introduced by this call
+    |
+    = help: within `soroban_env_host::host::HostImpl`, the trait `RefUnwindSafe` is not implemented for `UnsafeCell<soroban_env_host::events::diagnostic::DiagnosticLevel>`
+note: required because it appears within the type `RefCell<soroban_env_host::events::diagnostic::DiagnosticLevel>`
+   --> C:\Users\victo\.rustup\toolchains\stable-x86_64-pc-windows-msvc\lib/rustlib/src/rust\library\core\src\cell.rs:849:12
+    |
+849 | pub struct RefCell<T: ?Sized> {
+    |            ^^^^^^^
+note: required because it appears within the type `soroban_env_host::host::HostImpl`
+   --> C:\Users\victo\.cargo\registry\src\index.crates.io-1949cf8c6b5b557f\soroban-env-host-22.1.3\src\host.rs:93:8
+    |
+ 93 | struct HostImpl {
+    |        ^^^^^^^^
+    = note: required for `Rc<soroban_env_host::host::HostImpl>` to implement `RefUnwindSafe`
+note: required because it appears within the type `soroban_env_host::host::Host`
+   --> C:\Users\victo\.cargo\registry\src\index.crates.io-1949cf8c6b5b557f\soroban-env-host-22.1.3\src\host.rs:181:12
+    |
+181 | pub struct Host(Rc<HostImpl>);
+    |            ^^^^
+note: required because it appears within the type `Env`
+   --> C:\Users\victo\.cargo\registry\src\index.crates.io-1949cf8c6b5b557f\soroban-sdk-22.0.11\src\env.rs:222:12
+    |
+222 | pub struct Env {
+    |            ^^^
+note: required because it appears within the type `RevenuePoolClient<'_>`
+   --> contracts\revenue_pool\src\lib.rs:47:1
+    |
+ 47 | #[contract]
+    | ^^^^^^^^^^^
+    = note: required for `&RevenuePoolClient<'_>` to implement `UnwindSafe`
+note: required because it's used within this closure
+   --> contracts\revenue_pool\src\test.rs:161:47
+    |
+161 |         let result = std::panic::catch_unwind(|| client.distribute(&admin, &developer, &100));
+    |                                               ^^
+note: required by a bound in `test::std::panic::catch_unwind`
+   --> C:\Users\victo\.rustup\toolchains\stable-x86_64-pc-windows-msvc\lib/rustlib/src/rust\library\std\src\panic.rs:358:40
+    |
+358 | pub fn catch_unwind<F: FnOnce() -> R + UnwindSafe, R>(f: F) -> Result<R> {
+    |                                        ^^^^^^^^^^ required by this bound in `catch_unwind`
+    = note: this error originates in the attribute macro `contract` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the type `UnsafeCell<core::option::Option<soroban_env_host::host::prng::Prng>>` may contain interior mutability and a reference may not be safely transferable across a catch_unwind boundary
+   --> contracts\revenue_pool\src\test.rs:161:47
+    |
+161 |         let result = std::panic::catch_unwind(|| client.distribute(&admin, &developer, &100));
+    |                      ------------------------ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `UnsafeCell<core::option::Option<soroban_env_host::host::prng::Prng>>` may contain interior mutability and a reference may not be safely transferable across a catch_unwind boundary
+    |                      |
+    |                      required by a bound introduced by this call
+    |
+    = help: within `soroban_env_host::host::HostImpl`, the trait `RefUnwindSafe` is not implemented for `UnsafeCell<core::option::Option<soroban_env_host::host::prng::Prng>>`
+note: required because it appears within the type `RefCell<core::option::Option<soroban_env_host::host::prng::Prng>>`
+   --> C:\Users\victo\.rustup\toolchains\stable-x86_64-pc-windows-msvc\lib/rustlib/src/rust\library\core\src\cell.rs:849:12
+    |
+849 | pub struct RefCell<T: ?Sized> {
+    |            ^^^^^^^
+note: required because it appears within the type `soroban_env_host::host::HostImpl`
+   --> C:\Users\victo\.cargo\registry\src\index.crates.io-1949cf8c6b5b557f\soroban-env-host-22.1.3\src\host.rs:93:8
+    |
+ 93 | struct HostImpl {
+    |        ^^^^^^^^
+    = note: required for `Rc<soroban_env_host::host::HostImpl>` to implement `RefUnwindSafe`
+note: required because it appears within the type `soroban_env_host::host::Host`
+   --> C:\Users\victo\.cargo\registry\src\index.crates.io-1949cf8c6b5b557f\soroban-env-host-22.1.3\src\host.rs:181:12
+    |
+181 | pub struct Host(Rc<HostImpl>);
+    |            ^^^^
+note: required because it appears within the type `Env`
+   --> C:\Users\victo\.cargo\registry\src\index.crates.io-1949cf8c6b5b557f\soroban-sdk-22.0.11\src\env.rs:222:12
+    |
+222 | pub struct Env {
+    |            ^^^
+note: required because it appears within the type `RevenuePoolClient<'_>`
+   --> contracts\revenue_pool\src\lib.rs:47:1
+    |
+ 47 | #[contract]
+    | ^^^^^^^^^^^
+    = note: required for `&RevenuePoolClient<'_>` to implement `UnwindSafe`
+note: required because it's used within this closure
+   --> contracts\revenue_pool\src\test.rs:161:47
+    |
+161 |         let result = std::panic::catch_unwind(|| client.distribute(&admin, &developer, &100));
+    |                                               ^^
+note: required by a bound in `test::std::panic::catch_unwind`
+   --> C:\Users\victo\.rustup\toolchains\stable-x86_64-pc-windows-msvc\lib/rustlib/src/rust\library\std\src\panic.rs:358:40
+    |
+358 | pub fn catch_unwind<F: FnOnce() -> R + UnwindSafe, R>(f: F) -> Result<R> {
+    |                                        ^^^^^^^^^^ required by this bound in `catch_unwind`
+    = note: this error originates in the attribute macro `contract` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the type `UnsafeCell<core::option::Option<rand_chacha::chacha::ChaCha20Rng>>` may contain interior mutability and a reference may not be safely transferable across a catch_unwind boundary
+   --> contracts\revenue_pool\src\test.rs:161:47
+    |
+161 |         let result = std::panic::catch_unwind(|| client.distribute(&admin, &developer, &100));
+    |                      ------------------------ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `UnsafeCell<core::option::Option<rand_chacha::chacha::ChaCha20Rng>>` may contain interior mutability and a reference may not be safely transferable across a catch_unwind boundary
+    |                      |
+    |                      required by a bound introduced by this call
+    |
+    = help: within `soroban_env_host::host::HostImpl`, the trait `RefUnwindSafe` is not implemented for `UnsafeCell<core::option::Option<rand_chacha::chacha::ChaCha20Rng>>`
+note: required because it appears within the type `RefCell<core::option::Option<rand_chacha::chacha::ChaCha20Rng>>`
+   --> C:\Users\victo\.rustup\toolchains\stable-x86_64-pc-windows-msvc\lib/rustlib/src/rust\library\core\src\cell.rs:849:12
+    |
+849 | pub struct RefCell<T: ?Sized> {
+    |            ^^^^^^^
+note: required because it appears within the type `soroban_env_host::host::HostImpl`
+   --> C:\Users\victo\.cargo\registry\src\index.crates.io-1949cf8c6b5b557f\soroban-env-host-22.1.3\src\host.rs:93:8
+    |
+ 93 | struct HostImpl {
+    |        ^^^^^^^^
+    = note: required for `Rc<soroban_env_host::host::HostImpl>` to implement `RefUnwindSafe`
+note: required because it appears within the type `soroban_env_host::host::Host`
+   --> C:\Users\victo\.cargo\registry\src\index.crates.io-1949cf8c6b5b557f\soroban-env-host-22.1.3\src\host.rs:181:12
+    |
+181 | pub struct Host(Rc<HostImpl>);
+    |            ^^^^
+note: required because it appears within the type `Env`
+   --> C:\Users\victo\.cargo\registry\src\index.crates.io-1949cf8c6b5b557f\soroban-sdk-22.0.11\src\env.rs:222:12
+    |
+222 | pub struct Env {
+    |            ^^^
+note: required because it appears within the type `RevenuePoolClient<'_>`
+   --> contracts\revenue_pool\src\lib.rs:47:1
+    |
+ 47 | #[contract]
+    | ^^^^^^^^^^^
+    = note: required for `&RevenuePoolClient<'_>` to implement `UnwindSafe`
+note: required because it's used within this closure
+   --> contracts\revenue_pool\src\test.rs:161:47
+    |
+161 |         let result = std::panic::catch_unwind(|| client.distribute(&admin, &developer, &100));
+    |                                               ^^
+note: required by a bound in `test::std::panic::catch_unwind`
+   --> C:\Users\victo\.rustup\toolchains\stable-x86_64-pc-windows-msvc\lib/rustlib/src/rust\library\std\src\panic.rs:358:40
+    |
+358 | pub fn catch_unwind<F: FnOnce() -> R + UnwindSafe, R>(f: F) -> Result<R> {
+    |                                        ^^^^^^^^^^ required by this bound in `catch_unwind`
+    = note: this error originates in the attribute macro `contract` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the type `UnsafeCell<BTreeMap<Hash, Rc<dyn ContractFunctionSet>>>` may contain interior mutability and a reference may not be safely transferable across a catch_unwind boundary
+   --> contracts\revenue_pool\src\test.rs:161:47
+    |
+161 |         let result = std::panic::catch_unwind(|| client.distribute(&admin, &developer, &100));
+    |                      ------------------------ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `UnsafeCell<BTreeMap<Hash, Rc<dyn ContractFunctionSet>>>` may contain interior mutability and a reference may not be safely transferable across a catch_unwind boundary
+    |                      |
+    |                      required by a bound introduced by this call
+    |
+    = help: within `soroban_env_host::host::HostImpl`, the trait `RefUnwindSafe` is not implemented for `UnsafeCell<BTreeMap<Hash, Rc<dyn ContractFunctionSet>>>`
+note: required because it appears within the type `RefCell<BTreeMap<Hash, Rc<dyn ContractFunctionSet>>>`
+   --> C:\Users\victo\.rustup\toolchains\stable-x86_64-pc-windows-msvc\lib/rustlib/src/rust\library\core\src\cell.rs:849:12
+    |
+849 | pub struct RefCell<T: ?Sized> {
+    |            ^^^^^^^
+note: required because it appears within the type `soroban_env_host::host::HostImpl`
+   --> C:\Users\victo\.cargo\registry\src\index.crates.io-1949cf8c6b5b557f\soroban-env-host-22.1.3\src\host.rs:93:8
+    |
+ 93 | struct HostImpl {
+    |        ^^^^^^^^
+    = note: required for `Rc<soroban_env_host::host::HostImpl>` to implement `RefUnwindSafe`
+note: required because it appears within the type `soroban_env_host::host::Host`
+   --> C:\Users\victo\.cargo\registry\src\index.crates.io-1949cf8c6b5b557f\soroban-env-host-22.1.3\src\host.rs:181:12
+    |
+181 | pub struct Host(Rc<HostImpl>);
+    |            ^^^^
+note: required because it appears within the type `Env`
+   --> C:\Users\victo\.cargo\registry\src\index.crates.io-1949cf8c6b5b557f\soroban-sdk-22.0.11\src\env.rs:222:12
+    |
+222 | pub struct Env {
+    |            ^^^
+note: required because it appears within the type `RevenuePoolClient<'_>`
+   --> contracts\revenue_pool\src\lib.rs:47:1
+    |
+ 47 | #[contract]
+    | ^^^^^^^^^^^
+    = note: required for `&RevenuePoolClient<'_>` to implement `UnwindSafe`
+note: required because it's used within this closure
+   --> contracts\revenue_pool\src\test.rs:161:47
+    |
+161 |         let result = std::panic::catch_unwind(|| client.distribute(&admin, &developer, &100));
+    |                                               ^^
+note: required by a bound in `test::std::panic::catch_unwind`
+   --> C:\Users\victo\.rustup\toolchains\stable-x86_64-pc-windows-msvc\lib/rustlib/src/rust\library\std\src\panic.rs:358:40
+    |
+358 | pub fn catch_unwind<F: FnOnce() -> R + UnwindSafe, R>(f: F) -> Result<R> {
+    |                                        ^^^^^^^^^^ required by this bound in `catch_unwind`
+    = note: the full name for the type has been written to 'C:\Users\victo\Desktop\Test\Callora-Contracts\target\debug\deps\callora_revenue_pool-a15dc7498c584ddd.long-type-4364563647705035088.txt'
+    = note: consider using `--verbose` to print the full type name to the console
+    = note: this error originates in the attribute macro `contract` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the type `UnsafeCell<core::option::Option<soroban_env_host::auth::AuthorizationManager>>` may contain interior mutability and a reference may not be safely transferable across a catch_unwind boundary
+   --> contracts\revenue_pool\src\test.rs:161:47
+    |
+161 |         let result = std::panic::catch_unwind(|| client.distribute(&admin, &developer, &100));
+    |                      ------------------------ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `UnsafeCell<core::option::Option<soroban_env_host::auth::AuthorizationManager>>` may contain interior mutability and a reference may not be safely transferable across a catch_unwind boundary
+    |                      |
+    |                      required by a bound introduced by this call
+    |
+    = help: within `soroban_env_host::host::HostImpl`, the trait `RefUnwindSafe` is not implemented for `UnsafeCell<core::option::Option<soroban_env_host::auth::AuthorizationManager>>`
+note: required because it appears within the type `RefCell<core::option::Option<soroban_env_host::auth::AuthorizationManager>>`
+   --> C:\Users\victo\.rustup\toolchains\stable-x86_64-pc-windows-msvc\lib/rustlib/src/rust\library\core\src\cell.rs:849:12
+    |
+849 | pub struct RefCell<T: ?Sized> {
+    |            ^^^^^^^
+note: required because it appears within the type `soroban_env_host::host::HostImpl`
+   --> C:\Users\victo\.cargo\registry\src\index.crates.io-1949cf8c6b5b557f\soroban-env-host-22.1.3\src\host.rs:93:8
+    |
+ 93 | struct HostImpl {
+    |        ^^^^^^^^
+    = note: required for `Rc<soroban_env_host::host::HostImpl>` to implement `RefUnwindSafe`
+note: required because it appears within the type `soroban_env_host::host::Host`
+   --> C:\Users\victo\.cargo\registry\src\index.crates.io-1949cf8c6b5b557f\soroban-env-host-22.1.3\src\host.rs:181:12
+    |
+181 | pub struct Host(Rc<HostImpl>);
+    |            ^^^^
+note: required because it appears within the type `Env`
+   --> C:\Users\victo\.cargo\registry\src\index.crates.io-1949cf8c6b5b557f\soroban-sdk-22.0.11\src\env.rs:222:12
+    |
+222 | pub struct Env {
+    |            ^^^
+note: required because it appears within the type `RevenuePoolClient<'_>`
+   --> contracts\revenue_pool\src\lib.rs:47:1
+    |
+ 47 | #[contract]
+    | ^^^^^^^^^^^
+    = note: required for `&RevenuePoolClient<'_>` to implement `UnwindSafe`
+note: required because it's used within this closure
+   --> contracts\revenue_pool\src\test.rs:161:47
+    |
+161 |         let result = std::panic::catch_unwind(|| client.distribute(&admin, &developer, &100));
+    |                                               ^^
+note: required by a bound in `test::std::panic::catch_unwind`
+   --> C:\Users\victo\.rustup\toolchains\stable-x86_64-pc-windows-msvc\lib/rustlib/src/rust\library\std\src\panic.rs:358:40
+    |
+358 | pub fn catch_unwind<F: FnOnce() -> R + UnwindSafe, R>(f: F) -> Result<R> {
+    |                                        ^^^^^^^^^^ required by this bound in `catch_unwind`
+    = note: this error originates in the attribute macro `contract` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the type `UnsafeCell<Option<Rc<dyn Fn(&Host, TraceEvent<'a>) -> ...>>>` may contain interior mutability and a reference may not be safely transferable across a catch_unwind boundary
+   --> contracts\revenue_pool\src\test.rs:161:47
+    |
+161 |         let result = std::panic::catch_unwind(|| client.distribute(&admin, &developer, &100));
+    |                      ------------------------ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `UnsafeCell<Option<Rc<dyn Fn(&Host, TraceEvent<'a>) -> ...>>>` may contain interior mutability and a reference may not be safely transferable across a catch_unwind boundary
+    |                      |
+    |                      required by a bound introduced by this call
+    |
+    = help: within `soroban_env_host::host::HostImpl`, the trait `RefUnwindSafe` is not implemented for `UnsafeCell<Option<Rc<dyn Fn(&Host, TraceEvent<'a>) -> ...>>>`
+note: required because it appears within the type `RefCell<Option<Rc<dyn Fn(&Host, TraceEvent<'a>) -> Result<(), ...>>>>`
+   --> C:\Users\victo\.rustup\toolchains\stable-x86_64-pc-windows-msvc\lib/rustlib/src/rust\library\core\src\cell.rs:849:12
+    |
+849 | pub struct RefCell<T: ?Sized> {
+    |            ^^^^^^^
+note: required because it appears within the type `soroban_env_host::host::HostImpl`
+   --> C:\Users\victo\.cargo\registry\src\index.crates.io-1949cf8c6b5b557f\soroban-env-host-22.1.3\src\host.rs:93:8
+    |
+ 93 | struct HostImpl {
+    |        ^^^^^^^^
+    = note: required for `Rc<soroban_env_host::host::HostImpl>` to implement `RefUnwindSafe`
+note: required because it appears within the type `soroban_env_host::host::Host`
+   --> C:\Users\victo\.cargo\registry\src\index.crates.io-1949cf8c6b5b557f\soroban-env-host-22.1.3\src\host.rs:181:12
+    |
+181 | pub struct Host(Rc<HostImpl>);
+    |            ^^^^
+note: required because it appears within the type `Env`
+   --> C:\Users\victo\.cargo\registry\src\index.crates.io-1949cf8c6b5b557f\soroban-sdk-22.0.11\src\env.rs:222:12
+    |
+222 | pub struct Env {
+    |            ^^^
+note: required because it appears within the type `RevenuePoolClient<'_>`
+   --> contracts\revenue_pool\src\lib.rs:47:1
+    |
+ 47 | #[contract]
+    | ^^^^^^^^^^^
+    = note: required for `&RevenuePoolClient<'_>` to implement `UnwindSafe`
+note: required because it's used within this closure
+   --> contracts\revenue_pool\src\test.rs:161:47
+    |
+161 |         let result = std::panic::catch_unwind(|| client.distribute(&admin, &developer, &100));
+    |                                               ^^
+note: required by a bound in `test::std::panic::catch_unwind`
+   --> C:\Users\victo\.rustup\toolchains\stable-x86_64-pc-windows-msvc\lib/rustlib/src/rust\library\std\src\panic.rs:358:40
+    |
+358 | pub fn catch_unwind<F: FnOnce() -> R + UnwindSafe, R>(f: F) -> Result<R> {
+    |                                        ^^^^^^^^^^ required by this bound in `catch_unwind`
+    = note: the full name for the type has been written to 'C:\Users\victo\Desktop\Test\Callora-Contracts\target\debug\deps\callora_revenue_pool-a15dc7498c584ddd.long-type-187282151182238681.txt'
+    = note: consider using `--verbose` to print the full type name to the console
+    = note: this error originates in the attribute macro `contract` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the type `UnsafeCell<Option<Rc<dyn Fn(&Host, ContractInvocationEvent)>>>` may contain interior mutability and a reference may not be safely transferable across a catch_unwind boundary
+   --> contracts\revenue_pool\src\test.rs:161:47
+    |
+161 |         let result = std::panic::catch_unwind(|| client.distribute(&admin, &developer, &100));
+    |                      ------------------------ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `UnsafeCell<Option<Rc<dyn Fn(&Host, ContractInvocationEvent)>>>` may contain interior mutability and a reference may not be safely transferable across a catch_unwind boundary
+    |                      |
+    |                      required by a bound introduced by this call
+    |
+    = help: within `soroban_env_host::host::HostImpl`, the trait `RefUnwindSafe` is not implemented for `UnsafeCell<Option<Rc<dyn Fn(&Host, ContractInvocationEvent)>>>`
+note: required because it appears within the type `RefCell<Option<Rc<dyn Fn(&Host, ContractInvocationEvent)>>>`
+   --> C:\Users\victo\.rustup\toolchains\stable-x86_64-pc-windows-msvc\lib/rustlib/src/rust\library\core\src\cell.rs:849:12
+    |
+849 | pub struct RefCell<T: ?Sized> {
+    |            ^^^^^^^
+note: required because it appears within the type `soroban_env_host::host::HostImpl`
+   --> C:\Users\victo\.cargo\registry\src\index.crates.io-1949cf8c6b5b557f\soroban-env-host-22.1.3\src\host.rs:93:8
+    |
+ 93 | struct HostImpl {
+    |        ^^^^^^^^
+    = note: required for `Rc<soroban_env_host::host::HostImpl>` to implement `RefUnwindSafe`
+note: required because it appears within the type `soroban_env_host::host::Host`
+   --> C:\Users\victo\.cargo\registry\src\index.crates.io-1949cf8c6b5b557f\soroban-env-host-22.1.3\src\host.rs:181:12
+    |
+181 | pub struct Host(Rc<HostImpl>);
+    |            ^^^^
+note: required because it appears within the type `Env`
+   --> C:\Users\victo\.cargo\registry\src\index.crates.io-1949cf8c6b5b557f\soroban-sdk-22.0.11\src\env.rs:222:12
+    |
+222 | pub struct Env {
+    |            ^^^
+note: required because it appears within the type `RevenuePoolClient<'_>`
+   --> contracts\revenue_pool\src\lib.rs:47:1
+    |
+ 47 | #[contract]
+    | ^^^^^^^^^^^
+    = note: required for `&RevenuePoolClient<'_>` to implement `UnwindSafe`
+note: required because it's used within this closure
+   --> contracts\revenue_pool\src\test.rs:161:47
+    |
+161 |         let result = std::panic::catch_unwind(|| client.distribute(&admin, &developer, &100));
+    |                                               ^^
+note: required by a bound in `test::std::panic::catch_unwind`
+   --> C:\Users\victo\.rustup\toolchains\stable-x86_64-pc-windows-msvc\lib/rustlib/src/rust\library\std\src\panic.rs:358:40
+    |
+358 | pub fn catch_unwind<F: FnOnce() -> R + UnwindSafe, R>(f: F) -> Result<R> {
+    |                                        ^^^^^^^^^^ required by this bound in `catch_unwind`
+    = note: the full name for the type has been written to 'C:\Users\victo\Desktop\Test\Callora-Contracts\target\debug\deps\callora_revenue_pool-a15dc7498c584ddd.long-type-217220758218506435.txt'
+    = note: consider using `--verbose` to print the full type name to the console
+    = note: this error originates in the attribute macro `contract` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the type `UnsafeCell<soroban_env_host::host::CoverageScoreboard>` may contain interior mutability and a reference may not be safely transferable across a catch_unwind boundary
+   --> contracts\revenue_pool\src\test.rs:161:47
+    |
+161 |         let result = std::panic::catch_unwind(|| client.distribute(&admin, &developer, &100));
+    |                      ------------------------ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `UnsafeCell<soroban_env_host::host::CoverageScoreboard>` may contain interior mutability and a reference may not be safely transferable across a catch_unwind boundary
+    |                      |
+    |                      required by a bound introduced by this call
+    |
+    = help: within `soroban_env_host::host::HostImpl`, the trait `RefUnwindSafe` is not implemented for `UnsafeCell<soroban_env_host::host::CoverageScoreboard>`
+note: required because it appears within the type `RefCell<soroban_env_host::host::CoverageScoreboard>`
+   --> C:\Users\victo\.rustup\toolchains\stable-x86_64-pc-windows-msvc\lib/rustlib/src/rust\library\core\src\cell.rs:849:12
+    |
+849 | pub struct RefCell<T: ?Sized> {
+    |            ^^^^^^^
+note: required because it appears within the type `soroban_env_host::host::HostImpl`
+   --> C:\Users\victo\.cargo\registry\src\index.crates.io-1949cf8c6b5b557f\soroban-env-host-22.1.3\src\host.rs:93:8
+    |
+ 93 | struct HostImpl {
+    |        ^^^^^^^^
+    = note: required for `Rc<soroban_env_host::host::HostImpl>` to implement `RefUnwindSafe`
+note: required because it appears within the type `soroban_env_host::host::Host`
+   --> C:\Users\victo\.cargo\registry\src\index.crates.io-1949cf8c6b5b557f\soroban-env-host-22.1.3\src\host.rs:181:12
+    |
+181 | pub struct Host(Rc<HostImpl>);
+    |            ^^^^
+note: required because it appears within the type `Env`
+   --> C:\Users\victo\.cargo\registry\src\index.crates.io-1949cf8c6b5b557f\soroban-sdk-22.0.11\src\env.rs:222:12
+    |
+222 | pub struct Env {
+    |            ^^^
+note: required because it appears within the type `RevenuePoolClient<'_>`
+   --> contracts\revenue_pool\src\lib.rs:47:1
+    |
+ 47 | #[contract]
+    | ^^^^^^^^^^^
+    = note: required for `&RevenuePoolClient<'_>` to implement `UnwindSafe`
+note: required because it's used within this closure
+   --> contracts\revenue_pool\src\test.rs:161:47
+    |
+161 |         let result = std::panic::catch_unwind(|| client.distribute(&admin, &developer, &100));
+    |                                               ^^
+note: required by a bound in `test::std::panic::catch_unwind`
+   --> C:\Users\victo\.rustup\toolchains\stable-x86_64-pc-windows-msvc\lib/rustlib/src/rust\library\std\src\panic.rs:358:40
+    |
+358 | pub fn catch_unwind<F: FnOnce() -> R + UnwindSafe, R>(f: F) -> Result<R> {
+    |                                        ^^^^^^^^^^ required by this bound in `catch_unwind`
+    = note: this error originates in the attribute macro `contract` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the type `UnsafeCell<bool>` may contain interior mutability and a reference may not be safely transferable across a catch_unwind boundary
+   --> contracts\revenue_pool\src\test.rs:161:47
+    |
+161 |         let result = std::panic::catch_unwind(|| client.distribute(&admin, &developer, &100));
+    |                      ------------------------ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `UnsafeCell<bool>` may contain interior mutability and a reference may not be safely transferable across a catch_unwind boundary
+    |                      |
+    |                      required by a bound introduced by this call
+    |
+    = help: within `soroban_env_host::host::HostImpl`, the trait `RefUnwindSafe` is not implemented for `UnsafeCell<bool>`
+note: required because it appears within the type `RefCell<bool>`
+   --> C:\Users\victo\.rustup\toolchains\stable-x86_64-pc-windows-msvc\lib/rustlib/src/rust\library\core\src\cell.rs:849:12
+    |
+849 | pub struct RefCell<T: ?Sized> {
+    |            ^^^^^^^
+note: required because it appears within the type `soroban_env_host::host::HostImpl`
+   --> C:\Users\victo\.cargo\registry\src\index.crates.io-1949cf8c6b5b557f\soroban-env-host-22.1.3\src\host.rs:93:8
+    |
+ 93 | struct HostImpl {
+    |        ^^^^^^^^
+    = note: required for `Rc<soroban_env_host::host::HostImpl>` to implement `RefUnwindSafe`
+note: required because it appears within the type `soroban_env_host::host::Host`
+   --> C:\Users\victo\.cargo\registry\src\index.crates.io-1949cf8c6b5b557f\soroban-env-host-22.1.3\src\host.rs:181:12
+    |
+181 | pub struct Host(Rc<HostImpl>);
+    |            ^^^^
+note: required because it appears within the type `Env`
+   --> C:\Users\victo\.cargo\registry\src\index.crates.io-1949cf8c6b5b557f\soroban-sdk-22.0.11\src\env.rs:222:12
+    |
+222 | pub struct Env {
+    |            ^^^
+note: required because it appears within the type `RevenuePoolClient<'_>`
+   --> contracts\revenue_pool\src\lib.rs:47:1
+    |
+ 47 | #[contract]
+    | ^^^^^^^^^^^
+    = note: required for `&RevenuePoolClient<'_>` to implement `UnwindSafe`
+note: required because it's used within this closure
+   --> contracts\revenue_pool\src\test.rs:161:47
+    |
+161 |         let result = std::panic::catch_unwind(|| client.distribute(&admin, &developer, &100));
+    |                                               ^^
+note: required by a bound in `test::std::panic::catch_unwind`
+   --> C:\Users\victo\.rustup\toolchains\stable-x86_64-pc-windows-msvc\lib/rustlib/src/rust\library\std\src\panic.rs:358:40
+    |
+358 | pub fn catch_unwind<F: FnOnce() -> R + UnwindSafe, R>(f: F) -> Result<R> {
+    |                                        ^^^^^^^^^^ required by this bound in `catch_unwind`
+    = note: this error originates in the attribute macro `contract` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the type `UnsafeCell<soroban_env_host::host::invocation_metering::InvocationMeter>` may contain interior mutability and a reference may not be safely transferable across a catch_unwind boundary
+   --> contracts\revenue_pool\src\test.rs:161:47
+    |
+161 |         let result = std::panic::catch_unwind(|| client.distribute(&admin, &developer, &100));
+    |                      ------------------------ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `UnsafeCell<soroban_env_host::host::invocation_metering::InvocationMeter>` may contain interior mutability and a reference may not be safely transferable across a catch_unwind boundary
+    |                      |
+    |                      required by a bound introduced by this call
+    |
+    = help: within `soroban_env_host::host::HostImpl`, the trait `RefUnwindSafe` is not implemented for `UnsafeCell<soroban_env_host::host::invocation_metering::InvocationMeter>`
+note: required because it appears within the type `RefCell<soroban_env_host::host::invocation_metering::InvocationMeter>`
+   --> C:\Users\victo\.rustup\toolchains\stable-x86_64-pc-windows-msvc\lib/rustlib/src/rust\library\core\src\cell.rs:849:12
+    |
+849 | pub struct RefCell<T: ?Sized> {
+    |            ^^^^^^^
+note: required because it appears within the type `soroban_env_host::host::HostImpl`
+   --> C:\Users\victo\.cargo\registry\src\index.crates.io-1949cf8c6b5b557f\soroban-env-host-22.1.3\src\host.rs:93:8
+    |
+ 93 | struct HostImpl {
+    |        ^^^^^^^^
+    = note: required for `Rc<soroban_env_host::host::HostImpl>` to implement `RefUnwindSafe`
+note: required because it appears within the type `soroban_env_host::host::Host`
+   --> C:\Users\victo\.cargo\registry\src\index.crates.io-1949cf8c6b5b557f\soroban-env-host-22.1.3\src\host.rs:181:12
+    |
+181 | pub struct Host(Rc<HostImpl>);
+    |            ^^^^
+note: required because it appears within the type `Env`
+   --> C:\Users\victo\.cargo\registry\src\index.crates.io-1949cf8c6b5b557f\soroban-sdk-22.0.11\src\env.rs:222:12
+    |
+222 | pub struct Env {
+    |            ^^^
+note: required because it appears within the type `RevenuePoolClient<'_>`
+   --> contracts\revenue_pool\src\lib.rs:47:1
+    |
+ 47 | #[contract]
+    | ^^^^^^^^^^^
+    = note: required for `&RevenuePoolClient<'_>` to implement `UnwindSafe`
+note: required because it's used within this closure
+   --> contracts\revenue_pool\src\test.rs:161:47
+    |
+161 |         let result = std::panic::catch_unwind(|| client.distribute(&admin, &developer, &100));
+    |                                               ^^
+note: required by a bound in `test::std::panic::catch_unwind`
+   --> C:\Users\victo\.rustup\toolchains\stable-x86_64-pc-windows-msvc\lib/rustlib/src/rust\library\std\src\panic.rs:358:40
+    |
+358 | pub fn catch_unwind<F: FnOnce() -> R + UnwindSafe, R>(f: F) -> Result<R> {
+    |                                        ^^^^^^^^^^ required by this bound in `catch_unwind`
+    = note: this error originates in the attribute macro `contract` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the type `UnsafeCell<isize>` may contain interior mutability and a reference may not be safely transferable across a catch_unwind boundary
+   --> contracts\revenue_pool\src\test.rs:161:47
+    |
+161 |         let result = std::panic::catch_unwind(|| client.distribute(&admin, &developer, &100));
+    |                      ------------------------ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `UnsafeCell<isize>` may contain interior mutability and a reference may not be safely transferable across a catch_unwind boundary
+    |                      |
+    |                      required by a bound introduced by this call
+    |
+    = help: within `RefCell<Generators>`, the trait `RefUnwindSafe` is not implemented for `UnsafeCell<isize>`
+note: required because it appears within the type `Cell<isize>`
+   --> C:\Users\victo\.rustup\toolchains\stable-x86_64-pc-windows-msvc\lib/rustlib/src/rust\library\core\src\cell.rs:312:12
+    |
+312 | pub struct Cell<T: ?Sized> {
+    |            ^^^^
+note: required because it appears within the type `RefCell<Generators>`
+   --> C:\Users\victo\.rustup\toolchains\stable-x86_64-pc-windows-msvc\lib/rustlib/src/rust\library\core\src\cell.rs:849:12
+    |
+849 | pub struct RefCell<T: ?Sized> {
+    |            ^^^^^^^
+    = note: required for `Rc<RefCell<Generators>>` to implement `RefUnwindSafe`
+note: required because it appears within the type `soroban_sdk::env::EnvTestState`
+   --> C:\Users\victo\.cargo\registry\src\index.crates.io-1949cf8c6b5b557f\soroban-sdk-22.0.11\src\env.rs:244:8
+    |
+244 | struct EnvTestState {
+    |        ^^^^^^^^^^^^
+note: required because it appears within the type `Env`
+   --> C:\Users\victo\.cargo\registry\src\index.crates.io-1949cf8c6b5b557f\soroban-sdk-22.0.11\src\env.rs:222:12
+    |
+222 | pub struct Env {
+    |            ^^^
+note: required because it appears within the type `RevenuePoolClient<'_>`
+   --> contracts\revenue_pool\src\lib.rs:47:1
+    |
+ 47 | #[contract]
+    | ^^^^^^^^^^^
+    = note: required for `&RevenuePoolClient<'_>` to implement `UnwindSafe`
+note: required because it's used within this closure
+   --> contracts\revenue_pool\src\test.rs:161:47
+    |
+161 |         let result = std::panic::catch_unwind(|| client.distribute(&admin, &developer, &100));
+    |                                               ^^
+note: required by a bound in `test::std::panic::catch_unwind`
+   --> C:\Users\victo\.rustup\toolchains\stable-x86_64-pc-windows-msvc\lib/rustlib/src/rust\library\std\src\panic.rs:358:40
+    |
+358 | pub fn catch_unwind<F: FnOnce() -> R + UnwindSafe, R>(f: F) -> Result<R> {
+    |                                        ^^^^^^^^^^ required by this bound in `catch_unwind`
+    = note: this error originates in the attribute macro `contract` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the type `UnsafeCell<soroban_env_host::budget::BudgetImpl>` may contain interior mutability and a reference may not be safely transferable across a catch_unwind boundary
+    --> contracts\revenue_pool\src\test.rs:161:47
+     |
+ 161 |         let result = std::panic::catch_unwind(|| client.distribute(&admin, &developer, &100));
+     |                      ------------------------ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `UnsafeCell<soroban_env_host::budget::BudgetImpl>` may contain interior mutability and a reference may not be safely transferable across a catch_unwind boundary
+     |                      |
+     |                      required by a bound introduced by this call
+     |
+     = help: within `RefCell<soroban_env_host::budget::BudgetImpl>`, the trait `RefUnwindSafe` is not implemented for `UnsafeCell<soroban_env_host::budget::BudgetImpl>`
+note: required because it appears within the type `RefCell<soroban_env_host::budget::BudgetImpl>`
+    --> C:\Users\victo\.rustup\toolchains\stable-x86_64-pc-windows-msvc\lib/rustlib/src/rust\library\core\src\cell.rs:849:12
+     |
+ 849 | pub struct RefCell<T: ?Sized> {
+     |            ^^^^^^^
+     = note: required for `Rc<RefCell<soroban_env_host::budget::BudgetImpl>>` to implement `RefUnwindSafe`
+note: required because it appears within the type `soroban_env_host::budget::Budget`
+    --> C:\Users\victo\.cargo\registry\src\index.crates.io-1949cf8c6b5b557f\soroban-env-host-22.1.3\src\budget.rs:1057:12
+     |
+1057 | pub struct Budget(pub(crate) Rc<RefCell<BudgetImpl>>);
+     |            ^^^^^^
+note: required because it appears within the type `soroban_env_host::host::HostImpl`
+    --> C:\Users\victo\.cargo\registry\src\index.crates.io-1949cf8c6b5b557f\soroban-env-host-22.1.3\src\host.rs:93:8
+     |
+  93 | struct HostImpl {
+     |        ^^^^^^^^
+     = note: required for `Rc<soroban_env_host::host::HostImpl>` to implement `RefUnwindSafe`
+note: required because it appears within the type `soroban_env_host::host::Host`
+    --> C:\Users\victo\.cargo\registry\src\index.crates.io-1949cf8c6b5b557f\soroban-env-host-22.1.3\src\host.rs:181:12
+     |
+ 181 | pub struct Host(Rc<HostImpl>);
+     |            ^^^^
+note: required because it appears within the type `Env`
+    --> C:\Users\victo\.cargo\registry\src\index.crates.io-1949cf8c6b5b557f\soroban-sdk-22.0.11\src\env.rs:222:12
+     |
+ 222 | pub struct Env {
+     |            ^^^
+note: required because it appears within the type `RevenuePoolClient<'_>`
+    --> contracts\revenue_pool\src\lib.rs:47:1
+     |
+  47 | #[contract]
+     | ^^^^^^^^^^^
+     = note: required for `&RevenuePoolClient<'_>` to implement `UnwindSafe`
+note: required because it's used within this closure
+    --> contracts\revenue_pool\src\test.rs:161:47
+     |
+ 161 |         let result = std::panic::catch_unwind(|| client.distribute(&admin, &developer, &100));
+     |                                               ^^
+note: required by a bound in `test::std::panic::catch_unwind`
+    --> C:\Users\victo\.rustup\toolchains\stable-x86_64-pc-windows-msvc\lib/rustlib/src/rust\library\std\src\panic.rs:358:40
+     |
+ 358 | pub fn catch_unwind<F: FnOnce() -> R + UnwindSafe, R>(f: F) -> Result<R> {
+     |                                        ^^^^^^^^^^ required by this bound in `catch_unwind`
+     = note: this error originates in the attribute macro `contract` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0308]: mismatched types
+   --> contracts\vault\src\lib.rs:421:22
+    |
+421 |             if id != offering_id {
+    |                --    ^^^^^^^^^^^ expected `String`, found `&String`
+    |                |
+    |                expected because this is `soroban_sdk::String`
+    |
+help: consider dereferencing the borrow
+    |
+421 |             if id != *offering_id {
+    |                      +
+
+error: cannot find macro `format` in this scope
+   --> contracts\vault\src\test_views.rs:363:51
+    |
+363 |         let offering_id = String::from_str(&env, &format!("offer-{}", i));
+    |                                                   ^^^^^^
+
+warning: duplicated attribute
+    --> contracts\vault\src\test.rs:3238:1
+     |
+3238 | #[test]
+     | ^^^^^^^
+     |
+     = note: `#[warn(duplicate_macro_attributes)]` on by default
+
+warning: unused import: `TryFromVal`
+ --> contracts\vault\src\test.rs:4:65
+  |
+4 | use soroban_sdk::{token, Address, Env, IntoVal, String, Symbol, TryFromVal};
+  |                                                                 ^^^^^^^^^^
+  |
+  = note: `#[warn(unused_imports)]` (part of `#[warn(unused)]`) on by default
+
+warning: unused variable: `pool_addr`
+    --> contracts\revenue_pool\src\test.rs:1899:10
+     |
+1899 |     let (pool_addr, client) = create_pool(&env);
+     |          ^^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_pool_addr`
+     |
+     = note: `#[warn(unused_variables)]` (part of `#[warn(unused)]`) on by default
+
+warning: unused variable: `pool_addr`
+    --> contracts\revenue_pool\src\test.rs:1916:10
+     |
+1916 |     let (pool_addr, client) = create_pool(&env);
+     |          ^^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_pool_addr`
+
+For more information about this error, try `rustc --explain E0277`.
+warning: `callora-revenue-pool` (lib test) generated 54 warnings
+error: could not compile `callora-revenue-pool` (lib test) due to 23 previous errors; 54 warnings emitted
+warning: build failed, waiting for other jobs to finish...
+For more information about this error, try `rustc --explain E0308`.
+error: could not compile `callora-vault` (lib) due to 1 previous error
+error[E0599]: no method named `unwrap` found for unit type `()` in the current scope
+   --> contracts\vault\src\test_views.rs:376:41
+    |
+376 |     client.remove_price(&owner, &offer).unwrap();
+    |                                         ^^^^^^ method not found in `()`
+
+warning: unused variable: `non_owner`
+    --> contracts\vault\src\test.rs:2911:9
+     |
+2911 |     let non_owner = Address::generate(&env);
+     |         ^^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_non_owner`
+     |
+     = note: `#[warn(unused_variables)]` (part of `#[warn(unused)]`) on by default
+
+Some errors have detailed explanations: E0308, E0599.
+For more information about an error, try `rustc --explain E0308`.
+warning: `callora-vault` (lib test) generated 3 warnings
+error: could not compile `callora-vault` (lib test) due to 3 previous errors; 3 warnings emitted

--- a/scripts/e2e_setup.rs
+++ b/scripts/e2e_setup.rs
@@ -1,0 +1,164 @@
+//! Shared setup boilerplate for the end-to-end full-cycle test
+//! (`tests/e2e_full_cycle.rs`).
+//!
+//! This module deploys all four contracts the platform needs for a single
+//! production cycle — a mock USDC token, `callora-vault`, `callora-settlement`,
+//! and `callora-revenue-pool` — wires them together exactly as an operator
+//! would in production (per `docs/CONTRACT_ADDRESS_CONFIGURATION.md`), and
+//! returns a [`Harness`] bundling every client and identity the test needs.
+//!
+//! Keeping this in `scripts/` (rather than inlining it in the test file)
+//! means future E2E or integration tests can reuse the same wiring instead of
+//! re-deriving it, and a reviewer only has to read the wiring logic once.
+//!
+//! NOTE: `tests/` binaries cannot `mod`-include arbitrary paths outside the
+//! crate without `#[path]`. This file is wired into `tests/e2e_full_cycle.rs`
+//! via `#[path = "../scripts/e2e_setup.rs"] mod e2e_setup;` (both `tests/`
+//! and `scripts/` are siblings under the workspace root, hence one `../`) —
+//! see the test file header for details. If your project structure differs,
+//! adjust that `#[path]` attribute to point here.
+
+use callora_revenue_pool::RevenuePoolClient;
+use callora_settlement::CalloraSettlementClient;
+use callora_vault::CalloraVaultClient;
+use soroban_sdk::testutils::Address as _;
+use soroban_sdk::token::{StellarAssetClient, TokenClient};
+use soroban_sdk::{Address, Env};
+
+/// Every contract client, token client, and test identity the E2E suite needs.
+///
+/// Bundling these in one struct (rather than returning a long tuple) keeps
+/// `tests/e2e_full_cycle.rs` readable — each stage of the cycle reaches for
+/// `h.vault`, `h.settlement`, `h.revenue_pool`, etc. by name.
+pub struct Harness<'a> {
+    pub env: Env,
+
+    // Token (mock USDC) — `StellarAssetClient` mints, `TokenClient` reads
+    // balances / does ordinary transfers exactly like real USDC would.
+    pub usdc_admin_client: StellarAssetClient<'a>,
+    pub usdc: TokenClient<'a>,
+    pub usdc_id: Address,
+
+    // Contract clients.
+    pub vault: CalloraVaultClient<'a>,
+    pub settlement: CalloraSettlementClient<'a>,
+    pub revenue_pool: RevenuePoolClient<'a>,
+
+    // Contract addresses (handy for cross-contract wiring / assertions
+    // without re-deriving them from the clients each time).
+    pub vault_id: Address,
+    pub settlement_id: Address,
+    pub revenue_pool_id: Address,
+
+    // Identities.
+    /// Vault owner; also used as the shared admin for settlement and
+    /// revenue_pool to keep the harness simple — production deployments
+    /// may use distinct admins per contract.
+    pub owner: Address,
+    /// Backend address authorized to call `deduct` / `batch_deduct` on the
+    /// vault (set via `set_authorized_caller`).
+    pub backend: Address,
+    /// Two developer wallets used to exercise both fund-destination paths:
+    /// `dev_a` receives funds via the settlement contract's per-developer
+    /// ledger and withdraws them directly; `dev_b` receives funds via the
+    /// revenue_pool's `distribute` / `batch_distribute`.
+    pub dev_a: Address,
+    pub dev_b: Address,
+}
+
+/// Total USDC (in stroops) minted to `owner` and deposited into the vault
+/// at setup time. Chosen large enough to comfortably cover every deduct,
+/// credit, and distribution exercised in the full-cycle scenario.
+pub const INITIAL_MINT: i128 = 1_000_000_000;
+
+/// Deploys the mock USDC token plus all three Callora contracts, wires them
+/// together (vault → settlement, vault → revenue_pool, settlement → vault,
+/// revenue_pool → usdc), mints `INITIAL_MINT` USDC to `owner`, and returns a
+/// ready-to-use [`Harness`].
+///
+/// # Wiring performed
+/// 1. Deploy mock USDC (Stellar Asset Contract test token).
+/// 2. Deploy `vault`, `settlement`, `revenue_pool`.
+/// 3. `vault.init(...)` with `owner`, the mock USDC address, and `revenue_pool`
+///    recorded as the (informational) revenue pool address.
+/// 4. `vault.set_authorized_caller(backend)` so the backend identity can call
+///    `deduct` / `batch_deduct` in the test without using the owner key.
+/// 5. `vault.set_settlement(settlement_id)` — required before any deduct call
+///    will succeed (`VaultError::SettlementNotSet` otherwise).
+/// 6. `settlement.init(owner, vault_id)` — registers the vault as the only
+///    non-admin caller permitted to call `receive_payment`.
+/// 7. `revenue_pool.init(owner, usdc_id)`.
+/// 8. Mint `INITIAL_MINT` USDC to `owner` on-ledger (vault `deposit` requires
+///    the caller to already hold the USDC being deposited).
+///
+/// All calls use `env.mock_all_auths()`, so every `require_auth()` in the
+/// contracts is satisfied without constructing real signatures — standard
+/// practice for native Soroban SDK tests.
+pub fn setup<'a>(env: &Env) -> Harness<'a> {
+    env.mock_all_auths();
+
+    let owner = Address::generate(env);
+    let backend = Address::generate(env);
+    let dev_a = Address::generate(env);
+    let dev_b = Address::generate(env);
+
+    // ---- Mock USDC -------------------------------------------------------
+    let usdc_id = env.register_stellar_asset_contract_v2(owner.clone()).address();
+    let usdc_admin_client = StellarAssetClient::new(env, &usdc_id);
+    let usdc = TokenClient::new(env, &usdc_id);
+
+    // ---- Contracts -----------------------------------------------------
+    // `register` takes a contract type implementing `Default`/unit-struct
+    // construction (all three `#[contract]` structs here are field-less)
+    // plus a constructor-args tuple; these contracts have no `__constructor`,
+    // so the second argument is `()`.
+    let vault_id = env.register(callora_vault::CalloraVault, ());
+    let vault = CalloraVaultClient::new(env, &vault_id);
+
+    let settlement_id = env.register(callora_settlement::CalloraSettlement, ());
+    let settlement = CalloraSettlementClient::new(env, &settlement_id);
+
+    let revenue_pool_id = env.register(callora_revenue_pool::RevenuePool, ());
+    let revenue_pool = RevenuePoolClient::new(env, &revenue_pool_id);
+
+    // ---- Mint working capital before vault init (init can verify on-ledger
+    // balance when initial_balance > 0; we pass None and deposit explicitly
+    // in the test instead, so minting can happen in either order). ----------
+    usdc_admin_client.mint(&owner, &INITIAL_MINT);
+
+    // ---- Initialize vault --------------------------------------------------
+    vault
+        .init(
+            &owner,
+            &usdc_id,
+            &None,                       // initial_balance: deposit explicitly in the test
+            &Some(backend.clone()),       // authorized_caller
+            &None,                        // min_deposit: default (1)
+            &Some(revenue_pool_id.clone()), // revenue_pool: informational on vault
+            &None,                        // max_deduct: default (i128::MAX)
+        );
+    vault.set_settlement(&owner, &settlement_id);
+
+    // ---- Initialize settlement ---------------------------------------------
+    settlement.init(&owner, &vault_id);
+
+    // ---- Initialize revenue pool --------------------------------------------
+    revenue_pool.init(&owner, &usdc_id);
+
+    Harness {
+        env: env.clone(),
+        usdc_admin_client,
+        usdc,
+        usdc_id,
+        vault,
+        settlement,
+        revenue_pool,
+        vault_id,
+        settlement_id,
+        revenue_pool_id,
+        owner,
+        backend,
+        dev_a,
+        dev_b,
+    }
+}

--- a/tests/e2e_full_cycle.rs
+++ b/tests/e2e_full_cycle.rs
@@ -1,0 +1,377 @@
+//! # End-to-end full-cycle smoke test
+//!
+//! Wires `callora-vault`, `callora-settlement`, and `callora-revenue-pool`
+//! together in a single [`soroban_sdk::Env`] and walks the complete
+//! production fund-cycle, asserting balances at every stage.
+//!
+//! ## Why this test exists
+//!
+//! Unit tests cover each contract in isolation, and an existing
+//! vault↔settlement integration test covers that one pairing. Neither catches
+//! a refactor that silently breaks the *full* pipeline an operator actually
+//! runs in production. This test is intended to be the project's smoke test:
+//! if it's red, the platform is broken end-to-end, full stop.
+//!
+//! ## The real fund topology (read this before extending the test)
+//!
+//! The issue that prompted this test described the pipeline as a single
+//! chain: `vault → settlement → developer withdraw → revenue_pool sweep →
+//! admin batch_distribute`. Having read the actual contract sources, **that
+//! chain does not exist on-chain.** `callora-settlement` and
+//! `callora-revenue-pool` are independent contracts with no call path
+//! between them — there is no "sweep" function anywhere in this workspace.
+//! The real topology is two **parallel** destinations for vault-deducted
+//! funds:
+//!
+//! ```text
+//!                    ┌──────────────────────────────────────────┐
+//!                    │                  vault                   │
+//!                    │  deposit · deduct/batch_deduct · withdraw │
+//!                    │  · distribute (admin sweep of surplus)    │
+//!                    └───────────────┬────────────────┬──────────┘
+//!                                    │                │
+//!                  to_pool=true      │                │ distribute(to=revenue_pool)
+//!            (all vault deducts)     │                │ (admin-initiated, separate path)
+//!                                    ▼                ▼
+//!                       ┌─────────────────────┐  ┌───────────────────────┐
+//!                       │  callora-settlement  │  │ callora-revenue-pool  │
+//!                       │  global_pool /       │  │ funded by ANY USDC    │
+//!                       │  developer_balances   │  │ transfer in; admin    │
+//!                       │                      │  │ calls distribute /    │
+//!                       │  developer calls     │  │ batch_distribute      │
+//!                       │  withdraw_developer_  │  │ to pay developers     │
+//!                       │  balance() directly   │  └───────────────────────┘
+//!                       └─────────────────────┘
+//! ```
+//!
+//! This test therefore exercises **both** paths in one scenario so the
+//! conservation assertion is meaningful across all three contracts:
+//!
+//! 1. Vault deposit.
+//! 2. Many deducts (single `deduct` + `batch_deduct`), always routed to
+//!    settlement's global pool (vault hard-codes `to_pool=true`).
+//! 3. Settlement admin credits a developer's per-developer balance directly
+//!    (`receive_payment(to_pool=false)`) — modeling an off-chain-priced
+//!    credit distinct from the vault's pooled deducts — then that developer
+//!    calls `withdraw_developer_balance` to pull USDC out of settlement.
+//! 4. Vault admin sweeps on-ledger surplus into the revenue pool via
+//!    `vault.distribute`, then the revenue pool admin pays a second
+//!    developer via `batch_distribute`.
+//! 5. Pause-stage edge cases on both vault and revenue_pool.
+//! 6. A deliberately-oversized `batch_distribute` to confirm atomic,
+//!    all-or-nothing failure with zero partial transfers.
+//! 7. A final conservation assertion across every wallet and contract this
+//!    test touched.
+//!
+//! ## Conservation invariant
+//!
+//! At every checkpoint:
+//!
+//! ```text
+//! vault.balance()
+//!   + settlement.global_pool.total_balance
+//!   + sum(settlement developer balances for all devs touched)
+//!   + revenue_pool.balance()
+//!   + sum(on-ledger USDC balances of every wallet that started with 0)
+//!   == INITIAL_MINT
+//! ```
+//!
+//! `owner`'s on-ledger wallet balance is included on the right-hand side
+//! implicitly by tracking deltas from `INITIAL_MINT`, since `owner` is the
+//! address that received the initial mint and pays for deposits.
+//!
+//! Run with:
+//! ```text
+//! cargo test --workspace e2e_full_cycle
+//! ```
+
+// Pull in the shared setup helper from `scripts/`. Soroban integration tests
+// under `tests/` are each compiled as an independent crate, so a plain `mod`
+// statement can't reach outside `tests/`; `#[path]` makes the helper file a
+// module of *this* binary without needing it published from any contract
+// crate's `lib.rs`.
+#[path = "../scripts/e2e_setup.rs"]
+mod e2e_setup;
+
+use e2e_setup::{setup, Harness, INITIAL_MINT};
+use soroban_sdk::{vec, Env, Symbol};
+
+/// Sum of a [`Harness`]'s settlement-side holdings: the global pool plus
+/// every developer balance tracked in settlement. Pulled into a helper so
+/// every checkpoint computes the conservation invariant identically.
+fn settlement_total(h: &Harness, devs: &[soroban_sdk::Address]) -> i128 {
+    let pool = h.settlement.get_global_pool().total_balance;
+    let dev_sum: i128 = devs.iter().map(|d| h.settlement.get_developer_balance(d)).sum();
+    pool + dev_sum
+}
+
+/// Asserts the platform-wide conservation invariant documented in this
+/// file's module doc: every stroop minted at setup is accounted for across
+/// the vault, settlement, revenue_pool, and every wallet this test touched.
+///
+/// `extra_wallets` should list every address (besides `owner`) that might
+/// hold USDC at the time of the check — e.g. developer wallets after a
+/// withdraw or distribute.
+fn assert_conserved(h: &Harness, devs: &[soroban_sdk::Address], extra_wallets: &[soroban_sdk::Address]) {
+    let vault_bal = h.vault.balance();
+    let settlement_bal = settlement_total(h, devs);
+    let revenue_pool_bal = h.revenue_pool.balance();
+    let owner_wallet = h.usdc.balance(&h.owner);
+    let wallets_sum: i128 = extra_wallets.iter().map(|w| h.usdc.balance(w)).sum();
+
+    let total = vault_bal + settlement_bal + revenue_pool_bal + owner_wallet + wallets_sum;
+    assert_eq!(
+        total, INITIAL_MINT,
+        "conservation violated: vault={vault_bal} settlement={settlement_bal} \
+         revenue_pool={revenue_pool_bal} owner_wallet={owner_wallet} \
+         other_wallets={wallets_sum} (expected total {INITIAL_MINT})"
+    );
+}
+
+/// Full production-cycle smoke test: deposit → many deducts → settlement
+/// crediting (pool + per-developer) → developer withdraw → revenue_pool
+/// funding → admin batch_distribute, with a conservation check at every
+/// stage. See the module-level doc comment for the fund-topology diagram
+/// this test is built around.
+#[test]
+fn e2e_full_cycle() {
+    let env = Env::default();
+    let h: Harness = setup(&env);
+    let devs = [h.dev_a.clone(), h.dev_b.clone()];
+
+    // Sanity: everything starts at zero except owner's wallet.
+    assert_conserved(&h, &devs, &[h.dev_a.clone(), h.dev_b.clone()]);
+    assert_eq!(h.usdc.balance(&h.owner), INITIAL_MINT);
+
+    // ------------------------------------------------------------------
+    // Stage 1 — Deposit
+    // ------------------------------------------------------------------
+    let deposit_amount: i128 = 600_000_000;
+    h.vault.deposit(&h.owner, &deposit_amount);
+
+    assert_eq!(h.vault.balance(), deposit_amount);
+    assert_eq!(h.usdc.balance(&h.owner), INITIAL_MINT - deposit_amount);
+    assert_conserved(&h, &devs, &[h.dev_a.clone(), h.dev_b.clone()]);
+
+    // ------------------------------------------------------------------
+    // Stage 2 — Many deducts (single + batch), all routed to settlement's
+    // global pool, since the vault hard-codes `to_pool=true` for every
+    // deduct it initiates.
+    // ------------------------------------------------------------------
+    let single_deduct_amount: i128 = 10_000_000;
+    h.vault.deduct(
+        &h.backend,
+        &single_deduct_amount,
+        &Some(Symbol::new(&env, "req_single_1")),
+    );
+
+    let batch_items = vec![
+        &env,
+        callora_vault::DeductItem {
+            amount: 5_000_000,
+            request_id: Some(Symbol::new(&env, "req_batch_1")),
+        },
+        callora_vault::DeductItem {
+            amount: 7_500_000,
+            request_id: Some(Symbol::new(&env, "req_batch_2")),
+        },
+        callora_vault::DeductItem {
+            amount: 2_500_000,
+            request_id: None, // no idempotency tracking for this leg
+        },
+    ];
+    let batch_total: i128 = batch_items.iter().map(|i| i.amount).sum();
+    h.vault.batch_deduct(&h.backend, &batch_items);
+
+    let total_deducted = single_deduct_amount + batch_total;
+    assert_eq!(h.vault.balance(), deposit_amount - total_deducted);
+    assert_eq!(
+        h.settlement.get_global_pool().total_balance,
+        total_deducted,
+        "every vault-initiated deduct must land in settlement's global pool"
+    );
+    assert_eq!(
+        h.usdc.balance(&h.settlement_id),
+        total_deducted,
+        "settlement must hold the on-ledger USDC the vault transferred"
+    );
+    assert_conserved(&h, &devs, &[h.dev_a.clone(), h.dev_b.clone()]);
+
+    // Re-using a request_id must be rejected (idempotency), and must not
+    // move any funds — re-assert conservation after the rejected attempt.
+    let dup_result = h.vault.try_deduct(
+        &h.backend,
+        &1,
+        &Some(Symbol::new(&env, "req_single_1")),
+    );
+    assert!(dup_result.is_err(), "duplicate request_id must be rejected");
+    assert_eq!(h.vault.balance(), deposit_amount - total_deducted);
+    assert_conserved(&h, &devs, &[h.dev_a.clone(), h.dev_b.clone()]);
+
+    // ------------------------------------------------------------------
+    // Stage 3 — Settlement → developer path.
+    //
+    // The vault only ever credits the global pool, so to exercise the
+    // per-developer ledger + direct-withdraw path we model an
+    // admin-initiated credit, exactly as `receive_payment`'s interface
+    // permits (caller may be "the registered vault OR admin").
+    // ------------------------------------------------------------------
+    let dev_a_credit: i128 = 4_000_000;
+    h.settlement
+        .receive_payment(&h.owner, &dev_a_credit, &false, &Some(h.dev_a.clone()));
+
+    assert_eq!(h.settlement.get_developer_balance(&h.dev_a), dev_a_credit);
+    assert_eq!(
+        h.settlement.get_global_pool().total_balance,
+        total_deducted,
+        "crediting a developer must not touch the global pool"
+    );
+    assert_conserved(&h, &devs, &[h.dev_a.clone(), h.dev_b.clone()]);
+
+    // Developer withdraws their settlement balance directly. This requires
+    // settlement to hold configured USDC token + actual on-ledger funds —
+    // both are satisfied here since the vault already transferred USDC to
+    // settlement in stage 2, and `set_usdc_token` is required first.
+    h.settlement.set_usdc_token(&h.owner, &h.usdc_id);
+    let dev_a_withdraw: i128 = 1_500_000;
+    h.settlement
+        .withdraw_developer_balance(&h.dev_a, &dev_a_withdraw);
+
+    assert_eq!(
+        h.settlement.get_developer_balance(&h.dev_a),
+        dev_a_credit - dev_a_withdraw
+    );
+    assert_eq!(h.usdc.balance(&h.dev_a), dev_a_withdraw);
+    assert_conserved(&h, &devs, &[h.dev_a.clone(), h.dev_b.clone()]);
+
+    // ------------------------------------------------------------------
+    // Stage 4 — Vault → revenue_pool sweep, then admin batch_distribute.
+    //
+    // `vault.distribute` moves *untracked on-ledger surplus* (it checks the
+    // real token balance, not `meta.balance`), so top up the vault's
+    // on-ledger USDC directly to give the admin something real to sweep,
+    // mirroring how surplus might accumulate from rounding or direct
+    // transfers in production.
+    // ------------------------------------------------------------------
+    let surplus: i128 = 3_000_000;
+    h.usdc.transfer(&h.owner, &h.vault_id, &surplus);
+
+    let sweep_amount: i128 = 3_000_000;
+    h.vault.distribute(&h.owner, &h.revenue_pool_id, &sweep_amount);
+
+    assert_eq!(h.revenue_pool.balance(), sweep_amount);
+    assert_conserved(&h, &devs, &[h.dev_a.clone(), h.dev_b.clone()]);
+
+    // Admin pays dev_b out of the revenue pool via batch_distribute.
+    let dev_b_payment: i128 = 2_000_000;
+    h.revenue_pool.batch_distribute(
+        &h.owner,
+        &vec![&env, (h.dev_b.clone(), dev_b_payment)],
+    );
+
+    assert_eq!(h.usdc.balance(&h.dev_b), dev_b_payment);
+    assert_eq!(h.revenue_pool.balance(), sweep_amount - dev_b_payment);
+    assert_conserved(&h, &devs, &[h.dev_a.clone(), h.dev_b.clone()]);
+
+    // ------------------------------------------------------------------
+    // Stage 5 — Pause edge cases.
+    // ------------------------------------------------------------------
+
+    // 5a. Paused vault blocks deposit and deduct, but still allows owner
+    //     withdraw and admin distribute (per the vault's documented pause
+    //     policy — see `CalloraVault`'s module doc).
+    h.vault.pause(&h.owner);
+    assert!(h.vault.is_paused());
+
+    let blocked_deposit = h.vault.try_deposit(&h.owner, &1_000);
+    assert!(blocked_deposit.is_err(), "deposit must be blocked while paused");
+
+    let blocked_deduct = h.vault.try_deduct(&h.backend, &1_000, &None);
+    assert!(blocked_deduct.is_err(), "deduct must be blocked while paused");
+
+    // Owner withdraw is explicitly allowed while paused (emergency recovery).
+    let pre_pause_vault_balance = h.vault.balance();
+    let withdraw_amount: i128 = 1_000_000;
+    h.vault.withdraw(&withdraw_amount);
+    assert_eq!(h.vault.balance(), pre_pause_vault_balance - withdraw_amount);
+
+    h.vault.unpause(&h.owner);
+    assert!(!h.vault.is_paused());
+    assert_conserved(&h, &devs, &[h.dev_a.clone(), h.dev_b.clone()]);
+
+    // 5b. Paused revenue_pool blocks distribute / batch_distribute.
+    h.revenue_pool.pause(&h.owner);
+    assert!(h.revenue_pool.is_paused());
+
+    let blocked_distribute = h.revenue_pool.try_distribute(&h.owner, &h.dev_b, &1);
+    assert!(
+        blocked_distribute.is_err(),
+        "distribute must be blocked while revenue_pool is paused"
+    );
+    let blocked_batch = h
+        .revenue_pool
+        .try_batch_distribute(&h.owner, &vec![&env, (h.dev_b.clone(), 1)]);
+    assert!(
+        blocked_batch.is_err(),
+        "batch_distribute must be blocked while revenue_pool is paused"
+    );
+
+    h.revenue_pool.unpause(&h.owner);
+    assert!(!h.revenue_pool.is_paused());
+    assert_conserved(&h, &devs, &[h.dev_a.clone(), h.dev_b.clone()]);
+
+    // ------------------------------------------------------------------
+    // Stage 6 — Partial batch_distribute failure must be all-or-nothing.
+    //
+    // Request far more than the revenue pool currently holds; the call
+    // must revert with NO transfers applied (not even the legs that would
+    // individually have succeeded).
+    // ------------------------------------------------------------------
+    let pre_failure_pool_balance = h.revenue_pool.balance();
+    let pre_failure_dev_a_wallet = h.usdc.balance(&h.dev_a);
+    let pre_failure_dev_b_wallet = h.usdc.balance(&h.dev_b);
+
+    let oversized_batch = vec![
+        &env,
+        (h.dev_a.clone(), pre_failure_pool_balance), // alone would succeed
+        (h.dev_b.clone(), pre_failure_pool_balance), // pushes total over balance
+    ];
+    let failure = h.revenue_pool.try_batch_distribute(&h.owner, &oversized_batch);
+    assert!(
+        failure.is_err(),
+        "batch_distribute must reject a batch whose total exceeds the pool's balance"
+    );
+
+    // Confirm zero partial effect: neither leg moved, pool balance unchanged.
+    assert_eq!(h.revenue_pool.balance(), pre_failure_pool_balance);
+    assert_eq!(h.usdc.balance(&h.dev_a), pre_failure_dev_a_wallet);
+    assert_eq!(h.usdc.balance(&h.dev_b), pre_failure_dev_b_wallet);
+    assert_conserved(&h, &devs, &[h.dev_a.clone(), h.dev_b.clone()]);
+
+    // ------------------------------------------------------------------
+    // Stage 7 — Final conservation assertion.
+    //
+    // Restated explicitly (rather than only via the helper) so a reviewer
+    // can see the literal invariant from the issue's acceptance criteria
+    // without having to trace into `assert_conserved`.
+    // ------------------------------------------------------------------
+    let final_vault = h.vault.balance();
+    let final_settlement = settlement_total(&h, &devs);
+    let final_revenue_pool = h.revenue_pool.balance();
+    let final_owner_wallet = h.usdc.balance(&h.owner);
+    let final_dev_a_wallet = h.usdc.balance(&h.dev_a);
+    let final_dev_b_wallet = h.usdc.balance(&h.dev_b);
+
+    assert_eq!(
+        final_vault
+            + final_settlement
+            + final_revenue_pool
+            + final_owner_wallet
+            + final_dev_a_wallet
+            + final_dev_b_wallet,
+        INITIAL_MINT,
+        "final conservation check failed: vault tracked balance + settlement \
+         pool/developer balances + revenue_pool balance + every wallet balance \
+         must equal total USDC minted at setup"
+    );
+}


### PR DESCRIPTION
# Description

## Summary

Adds `tests/e2e_full_cycle.rs`, a workspace-level smoke test that deploys
`callora-vault`, `callora-settlement`, and `callora-revenue-pool` together in
one `Env` and walks a full production-style fund cycle, asserting balances
at every stage. Shared setup boilerplate lives in `scripts/e2e_setup.rs`.

## Topology note

The issue described one chain: `vault -> settlement -> developer withdraw ->
revenue_pool sweep -> admin batch_distribute`. That chain doesn't actually
exist on-chain — there's no `sweep` function, and settlement/revenue_pool
have no call path between them. They're two **independent** destinations
for vault-deducted funds:

- **Settlement path**: vault deducts credit settlement's global pool
  (`to_pool=true`); a developer can also be credited directly and call
  `withdraw_developer_balance` to pull USDC out.
- **Revenue pool path**: funded separately via `vault.distribute`, then paid
  out via `distribute` / `batch_distribute`.

This test exercises both real paths so the conservation check is meaningful
across all three contracts. Full diagram and rationale are in the test
file's module doc comment.

## What's covered

Deposit → single + batch deduct (with idempotency rejection) → settlement
pool/developer crediting → developer withdraw → vault surplus swept into
revenue_pool → `batch_distribute` → paused-vault edge cases (deposit/deduct
blocked, owner withdraw still allowed) → paused-revenue_pool edge cases →
oversized `batch_distribute` proven atomic (zero partial transfers) → final
cross-contract conservation assertion.

**Invariant**, checked at every stage:
```
vault.balance() + settlement.global_pool + sum(developer balances)
  + revenue_pool.balance() + sum(wallet balances) == total USDC minted
```

## Files changed

- `tests/e2e_full_cycle.rs` — the test
- `scripts/e2e_setup.rs` — shared deploy/wiring helper
- `Cargo.toml` — added `[package]` + `[dev-dependencies]` (was a virtual
  workspace; root needs a real package for a top-level `tests/` binary to
  compile against the three contract crates)
- `src/lib.rs` — empty; required for the new root package to be valid

## ⚠️ Blocked on a pre-existing, unrelated compile error

`cargo build -p callora-vault` fails on a clean `main` checkout (no PR
changes applied), in the existing `remove_offering_index` helper:

```
error[E0308]: mismatched types
   --> contracts\vault\src\lib.rs:421:22
421 |             if id != offering_id {
    |                --    ^^^^^^^^^^^ expected `String`, found `&String`
```

This blocks the project's own existing test suite too, not just this PR.
As a result **I haven't been able to confirm this test compiles or passes**
locally. The code has been carefully reviewed against the real contract
source (signatures, error enums, event payloads) but is unverified pending
a fix to that line. Suggest fixing separately before merging/reviewing this.

## Checklist

- [x] All three contracts deployed in one `Env`
- [x] Conservation assertion at every stage
- [x] Edge cases: paused vault, paused revenue_pool, partial batch failure
- [x] Doc comments throughout
- [ ] `cargo test --workspace e2e_full_cycle` passes — **blocked, see above**
- [ ] `cargo fmt` / `cargo clippy` / `./scripts/check-wasm-size.sh`

Closes #425 