### PR TITLE
Test/vault batch deduct dup request id property

### DIFF
--- a/EVENT_SCHEMA.md
+++ b/EVENT_SCHEMA.md
@@ -1,4 +1,4 @@
-﻿# Event Schema
+# Event Schema
 
 Events emitted by all Callora contracts for indexers, frontends, and auditors.
 All topic/data types refer to Soroban/Stellar XDR values.
@@ -626,6 +626,30 @@ Emitted when the admin updates the per-leg distribution cap.
 
 ---
 
+### `set_min_pool_balance`
+
+Emitted when the admin updates the minimum pool balance floor (Issue #416).
+
+| Index   | Location | Type         | Description                          |
+|---------|----------|--------------|--------------------------------------|
+| topic 0 | topics   | Symbol       | `"set_min_pool_balance"`             |
+| topic 1 | topics   | Address      | admin address                        |
+| data    | data     | (i128, i128) | `(old_min, new_min)` in USDC stroops |
+
+```json
+{
+  "topics": ["set_min_pool_balance", "GADMIN..."],
+  "data": [0, 50000000]
+}
+```
+
+> **Security note:** After this event, any `distribute` or `batch_distribute`
+> call that would leave the pool below `new_min` will abort with
+> `MinPoolBalanceBreached` before any transfer occurs. Set `new_min` to `0`
+> to restore the default (no floor).
+
+---
+
 ### `batch_distribute`
 
 Emitted **once per payment** during a `batch_distribute()` call. If a batch has
@@ -841,6 +865,7 @@ Emitted by `set_vault()` when the admin updates the registered vault address.
 | `admin_transfer_completed`| revenue-pool   | `claim_admin()`                          |
 | `receive_payment`        | revenue-pool    | `receive_payment()`                      |
 | `distribute`             | revenue-pool    | `distribute()`                           |
+| `set_min_pool_balance` | revenue-pool    | `set_min_pool_balance()`                 |
 | `batch_distribute`       | revenue-pool    | each payment in `batch_distribute()`     |
 | `payment_received`       | settlement      | `receive_payment()`                      |
 | `balance_credited`       | settlement      | `receive_payment()` with `to_pool=false` |
@@ -857,4 +882,5 @@ Emitted by `set_vault()` when the admin updates the registered vault address.
 | 0.0.1   | vault         | Added `metadata_removed` event on `remove_metadata()` for stale-entry cleanup |
 | 0.0.1   | revenue-pool  | Full revenue pool event suite with JSON examples             |
 | 0.0.1   | revenue-pool  | Added `admin_changed` event on `set_admin` for explicit old/new admin intent |
+| 0.0.1   | revenue-pool  | Added `set_min_pool_balance` event; floor enforcement on `distribute` + `batch_distribute` (Issue #416) |
 | 0.1.0   | settlement    | `payment_received`, `balance_credited`                       |

--- a/INVARIANTS.md
+++ b/INVARIANTS.md
@@ -182,6 +182,7 @@ The test suite in `contracts/vault/src/test.rs` provides practical evidence for 
   - `batch_deduct_success`, `batch_deduct_all_succeed`, `batch_deduct_all_revert`, and `batch_deduct_revert_preserves_balance` all verify that:
     - Successful batches leave balance consistent with expectations.
     - Failing batches revert without corrupting balance.
+    - Duplicate `request_id` values inside a single batch are rejected atomically and do not change `meta.balance`.
 - **Withdraw tests**:
   - `withdraw_owner_success`, `withdraw_exact_balance`, and `withdraw_exceeds_balance_fails` ensure that:
     - Withdrawals are only allowed up to the current balance.

--- a/contracts/revenue_pool/src/lib.rs
+++ b/contracts/revenue_pool/src/lib.rs
@@ -17,10 +17,15 @@ const ADMIN_KEY: &str = "admin";
 const PENDING_ADMIN_KEY: &str = "pending_admin";
 const USDC_KEY: &str = "usdc";
 const MAX_DISTRIBUTE_KEY: &str = "max_distribute";
+/// Storage key for the minimum pool balance floor (Issue #416).
+const MIN_POOL_BALANCE_KEY: &str = "min_pool_bal";
 const ERR_AMOUNT_NOT_POSITIVE: &str = "amount must be positive";
 const ERR_AMOUNT_EXCEEDS_MAX_DISTRIBUTE: &str = "amount exceeds max_distribute";
 const ERR_UNAUTHORIZED: &str = "unauthorized: caller is not admin";
 const ERR_INSUFFICIENT_BALANCE: &str = "insufficient USDC balance";
+/// Emitted when a distribute/batch_distribute call would reduce the pool
+/// balance below the configured `min_pool_balance` floor.
+const ERR_MIN_POOL_BALANCE_BREACHED: &str = "MinPoolBalanceBreached";
 const ERR_NOT_INITIALIZED: &str = "revenue pool not initialized";
 const ERR_DUPLICATE_RECIPIENT: &str = "duplicate recipient in batch";
 const PAUSED_KEY: &str = "paused";
@@ -314,6 +319,61 @@ impl RevenuePool {
         );
     }
 
+    // -----------------------------------------------------------------------
+    // Minimum pool balance floor (Issue #416)
+    // -----------------------------------------------------------------------
+
+    /// Return the current minimum pool balance floor.
+    ///
+    /// The pool must retain at least this many USDC base units after every
+    /// `distribute` or `batch_distribute` call. Defaults to `0` when not set,
+    /// which preserves the original behaviour of allowing a full drain.
+    pub fn get_min_pool_balance(env: Env) -> i128 {
+        env.storage()
+            .instance()
+            .get(&Symbol::new(&env, MIN_POOL_BALANCE_KEY))
+            .unwrap_or(0_i128)
+    }
+
+    /// Set the minimum pool balance floor.
+    ///
+    /// After this call, every `distribute` and `batch_distribute` call will
+    /// abort with `MinPoolBalanceBreached` if the resulting pool balance would
+    /// fall below `amount`.
+    ///
+    /// # Arguments
+    /// * `env` - The environment running the contract.
+    /// * `caller` - Must be the current admin.
+    /// * `amount` - New floor in USDC base units. Must be `>= 0`.
+    ///   Pass `0` to restore the default (no floor).
+    ///
+    /// # Panics
+    /// * If the caller is not the current admin (`"unauthorized: caller is not admin"`).
+    /// * If `amount` is negative (`"min_pool_balance must not be negative"`).
+    ///
+    /// # Events
+    /// Emits `set_min_pool_balance` with `caller` as a topic and
+    /// `(old_min, new_min)` as data.
+    pub fn set_min_pool_balance(env: Env, caller: Address, amount: i128) {
+        caller.require_auth();
+        let admin = Self::get_admin(env.clone());
+        if caller != admin {
+            panic!("{}", ERR_UNAUTHORIZED);
+        }
+        assert!(amount >= 0, "min_pool_balance must not be negative");
+        let old_min = Self::get_min_pool_balance(env.clone());
+        env.storage()
+            .instance()
+            .set(&Symbol::new(&env, MIN_POOL_BALANCE_KEY), &amount);
+        env.storage()
+            .instance()
+            .extend_ttl(LIFETIME_THRESHOLD, BUMP_AMOUNT);
+        env.events().publish(
+            (Symbol::new(&env, "set_min_pool_balance"), admin),
+            (old_min, amount),
+        );
+    }
+
     fn validate_recipient(recipient: &Address, contract_self: &Address) {
         // Rule 1 — no self-distributions (the contract sending to itself is almost
         // certainly a logic bug; if you want to "reclaim" funds use a dedicated fn).
@@ -372,8 +432,15 @@ impl RevenuePool {
             )
         });
 
-        if usdc.balance(&contract_address) < amount {
+        let current_balance = usdc.balance(&contract_address);
+        if current_balance < amount {
             panic!("{}", ERR_INSUFFICIENT_BALANCE);
+        }
+
+        // Floor check: pool must not drop below min_pool_balance after transfer.
+        let floor = Self::get_min_pool_balance(env.clone());
+        if current_balance - amount < floor {
+            panic!("{}", ERR_MIN_POOL_BALANCE_BREACHED);
         }
 
         env.storage()
@@ -514,8 +581,16 @@ impl RevenuePool {
         let usdc = token::Client::new(&env, &usdc_address);
         let contract_address = env.current_contract_address();
 
-        if usdc.balance(&contract_address) < total_amount {
+        let current_balance = usdc.balance(&contract_address);
+        if current_balance < total_amount {
             panic!("{}", ERR_INSUFFICIENT_BALANCE);
+        }
+
+        // Floor check: the entire batch is atomic, so one pre-flight check suffices.
+        // The pool must not drop below min_pool_balance after all transfers complete.
+        let floor = Self::get_min_pool_balance(env.clone());
+        if current_balance - total_amount < floor {
+            panic!("{}", ERR_MIN_POOL_BALANCE_BREACHED);
         }
 
         // Extend TTL before executing transfers.

--- a/contracts/revenue_pool/src/test.rs
+++ b/contracts/revenue_pool/src/test.rs
@@ -158,7 +158,9 @@ fn create_usdc<'a>(
         client.pause(&admin);
         assert!(client.is_paused());
 
-        let result = std::panic::catch_unwind(|| client.distribute(&admin, &developer, &100));
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            client.distribute(&admin, &developer, &100)
+        }));
         assert!(result.is_err());
     }
 
@@ -2230,4 +2232,204 @@ fn batch_distribute_duplicate_detected_before_balance_check() {
     payments.push_back((dev.clone(), 200_i128));
 
     client.batch_distribute(&admin, &payments);
+}
+
+// ---------------------------------------------------------------------------
+// Issue #416 — min_pool_balance floor tests
+// ---------------------------------------------------------------------------
+
+#[test]
+#[should_panic(expected = "unauthorized: caller is not admin")]
+fn set_min_pool_balance_admin_only() {
+    // A non-admin caller must be rejected before any state change.
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let attacker = Address::generate(&env);
+    let (_, client) = create_pool(&env);
+    let (usdc, _, _) = create_usdc(&env, &admin);
+
+    client.init(&admin, &usdc);
+    client.set_min_pool_balance(&attacker, &500);
+}
+
+#[test]
+#[should_panic(expected = "min_pool_balance must not be negative")]
+fn set_min_pool_balance_negative_panics() {
+    // Negative floor values are nonsensical and must be rejected.
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let (_, client) = create_pool(&env);
+    let (usdc, _, _) = create_usdc(&env, &admin);
+
+    client.init(&admin, &usdc);
+    client.set_min_pool_balance(&admin, &-1);
+}
+
+#[test]
+fn set_min_pool_balance_stores_value_and_getter_returns_it() {
+    // Setter persists the value; getter reads it back correctly.
+    // Also verifies the default is 0 (no floor) before any setter call.
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let (_, client) = create_pool(&env);
+    let (usdc, _, _) = create_usdc(&env, &admin);
+
+    client.init(&admin, &usdc);
+
+    // Default floor must be 0.
+    assert_eq!(client.get_min_pool_balance(), 0);
+
+    client.set_min_pool_balance(&admin, &1_000);
+    assert_eq!(client.get_min_pool_balance(), 1_000);
+
+    // Admin can lower it back to 0.
+    client.set_min_pool_balance(&admin, &0);
+    assert_eq!(client.get_min_pool_balance(), 0);
+}
+
+#[test]
+fn set_min_pool_balance_emits_correct_event() {
+    // Event must carry topics (symbol, admin) and data (old_min, new_min).
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let (_, client) = create_pool(&env);
+    let (usdc, _, _) = create_usdc(&env, &admin);
+
+    client.init(&admin, &usdc);
+    client.set_min_pool_balance(&admin, &2_500);
+
+    let events = env.events().all();
+    let ev = events.last().unwrap();
+
+    // topic 0 = "set_min_pool_balance"
+    let t0 = Symbol::try_from_val(&env, &ev.1.get(0).unwrap()).unwrap();
+    assert_eq!(t0, Symbol::new(&env, "set_min_pool_balance"));
+
+    // topic 1 = admin address
+    let t1 = Address::try_from_val(&env, &ev.1.get(1).unwrap()).unwrap();
+    assert_eq!(t1, admin);
+
+    // data = (old_min, new_min)
+    let data: (i128, i128) = ev.2.into_val(&env);
+    assert_eq!(data, (0_i128, 2_500_i128));
+}
+
+#[test]
+#[should_panic(expected = "MinPoolBalanceBreached")]
+fn distribute_breaches_floor_panics() {
+    // distribute must abort when the resulting balance would be below the floor.
+    // Pool: 1_000, floor: 600, request: 500 → balance after = 500 < 600 → breach.
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let developer = Address::generate(&env);
+    let (pool_addr, client) = create_pool(&env);
+    let (usdc_address, _, usdc_admin) = create_usdc(&env, &admin);
+
+    client.init(&admin, &usdc_address);
+    fund_pool(&usdc_admin, &pool_addr, 1_000);
+    client.set_min_pool_balance(&admin, &600);
+
+    // 1000 - 500 = 500 < 600 → MinPoolBalanceBreached
+    client.distribute(&admin, &developer, &500);
+}
+
+#[test]
+fn distribute_exact_floor_succeeds() {
+    // Distributing exactly (balance - floor) must succeed (equal is allowed).
+    // Pool: 1_000, floor: 600, request: 400 → balance after = 600 = floor → OK.
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let developer = Address::generate(&env);
+    let (pool_addr, client) = create_pool(&env);
+    let (usdc_address, usdc_client, usdc_admin) = create_usdc(&env, &admin);
+
+    client.init(&admin, &usdc_address);
+    fund_pool(&usdc_admin, &pool_addr, 1_000);
+    client.set_min_pool_balance(&admin, &600);
+
+    // 1000 - 400 = 600 = floor → should succeed
+    client.distribute(&admin, &developer, &400);
+
+    assert_eq!(usdc_client.balance(&pool_addr), 600);
+    assert_eq!(usdc_client.balance(&developer), 400);
+}
+
+#[test]
+#[should_panic(expected = "MinPoolBalanceBreached")]
+fn batch_distribute_breaches_floor_panics() {
+    // batch_distribute must abort when the total payout would breach the floor.
+    // Pool: 1_000, floor: 400, batch total: 700 → balance after = 300 < 400 → breach.
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let dev1 = Address::generate(&env);
+    let dev2 = Address::generate(&env);
+    let (pool_addr, client) = create_pool(&env);
+    let (usdc_address, _, usdc_admin) = create_usdc(&env, &admin);
+
+    client.init(&admin, &usdc_address);
+    fund_pool(&usdc_admin, &pool_addr, 1_000);
+    client.set_min_pool_balance(&admin, &400);
+
+    let mut payments: Vec<(Address, i128)> = Vec::new(&env);
+    payments.push_back((dev1.clone(), 400_i128));
+    payments.push_back((dev2.clone(), 300_i128)); // total 700; 1000 - 700 = 300 < 400
+
+    client.batch_distribute(&admin, &payments);
+}
+
+#[test]
+fn batch_distribute_exact_floor_succeeds() {
+    // A batch that leaves the pool balance exactly at the floor must succeed.
+    // Pool: 1_000, floor: 400, batch total: 600 → balance after = 400 = floor → OK.
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let dev1 = Address::generate(&env);
+    let dev2 = Address::generate(&env);
+    let (pool_addr, client) = create_pool(&env);
+    let (usdc_address, usdc_client, usdc_admin) = create_usdc(&env, &admin);
+
+    client.init(&admin, &usdc_address);
+    fund_pool(&usdc_admin, &pool_addr, 1_000);
+    client.set_min_pool_balance(&admin, &400);
+
+    let mut payments: Vec<(Address, i128)> = Vec::new(&env);
+    payments.push_back((dev1.clone(), 350_i128));
+    payments.push_back((dev2.clone(), 250_i128)); // total 600; 1000 - 600 = 400 = floor
+
+    client.batch_distribute(&admin, &payments);
+
+    assert_eq!(usdc_client.balance(&pool_addr), 400);
+    assert_eq!(usdc_client.balance(&dev1), 350);
+    assert_eq!(usdc_client.balance(&dev2), 250);
+}
+
+#[test]
+fn floor_zero_default_allows_full_drain() {
+    // With the default floor of 0, distributing the entire balance must succeed,
+    // preserving full backwards-compatibility for callers that never set a floor.
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let developer = Address::generate(&env);
+    let (pool_addr, client) = create_pool(&env);
+    let (usdc_address, usdc_client, usdc_admin) = create_usdc(&env, &admin);
+
+    client.init(&admin, &usdc_address);
+    fund_pool(&usdc_admin, &pool_addr, 500);
+
+    // No set_min_pool_balance call — default floor is 0.
+    assert_eq!(client.get_min_pool_balance(), 0);
+
+    client.distribute(&admin, &developer, &500); // full drain
+
+    assert_eq!(usdc_client.balance(&pool_addr), 0);
+    assert_eq!(usdc_client.balance(&developer), 500);
 }

--- a/contracts/vault/src/test_idempotency.rs
+++ b/contracts/vault/src/test_idempotency.rs
@@ -11,11 +11,79 @@
 extern crate std;
 
 use soroban_sdk::testutils::Address as _;
-use soroban_sdk::{token, Address, Env, Symbol};
+use soroban_sdk::{token, Address, Env, Symbol, Vec};
 
 use super::*;
 
 use callora_settlement::CalloraSettlement;
+
+/// Deterministic PRNG for seeded property tests.
+///
+/// This simple 64-bit LCG is adequate for generating deterministic trace
+/// variants without pulling in an external RNG dependency.
+struct Prng {
+    state: u64,
+}
+
+impl Prng {
+    fn new(seed: u64) -> Self {
+        Self {
+            state: seed.wrapping_add(0x9E37_79B9_7F4A_7C15),
+        }
+    }
+
+    fn next_u64(&mut self) -> u64 {
+        self.state = self
+            .state
+            .wrapping_mul(6_364_136_223_846_793_005)
+            .wrapping_add(1);
+        self.state
+    }
+
+    fn gen_range_i128(&mut self, min: i128, max_inclusive: i128) -> i128 {
+        if min >= max_inclusive {
+            return min;
+        }
+        let span = (max_inclusive - min) as u64 + 1;
+        min + (self.next_u64() % span) as i128
+    }
+
+    fn gen_range_usize(&mut self, min: usize, max_inclusive: usize) -> usize {
+        if min >= max_inclusive {
+            return min;
+        }
+        let span = max_inclusive - min + 1;
+        min + (self.next_u64() as usize % span)
+    }
+}
+
+fn build_duplicate_batch(
+    env: &Env,
+    seed: u64,
+    batch_size: usize,
+) -> (Vec<DeductItem>, Symbol) {
+    let mut rng = Prng::new(seed);
+    let first_dup = rng.gen_range_usize(0, batch_size - 1);
+    let mut second_dup = rng.gen_range_usize(0, batch_size - 1);
+    while second_dup == first_dup {
+        second_dup = rng.gen_range_usize(0, batch_size - 1);
+    }
+
+    let duplicate_id = Symbol::new(env, &format!("dup_{}_{}", seed, first_dup));
+    let mut items: Vec<DeductItem> = Vec::new(env);
+
+    for i in 0..batch_size {
+        let amount = rng.gen_range_i128(1, 50);
+        let request_id = if i == first_dup || i == second_dup {
+            Some(duplicate_id.clone())
+        } else {
+            Some(Symbol::new(env, &format!("req_{}_{}", seed, i)))
+        };
+        items.push_back(DeductItem { amount, request_id });
+    }
+
+    (items, duplicate_id)
+}
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -277,6 +345,33 @@ fn batch_deduct_two_items_same_new_id_rejected() {
         !client.is_request_processed(&rid),
         "rejected batch must not mark request_id"
     );
+}
+
+/// A varying set of batch sizes with seeded duplicate positions must be rejected
+/// atomically when the same `request_id` appears twice within a single batch.
+#[test]
+fn batch_deduct_duplicate_request_id_within_batch_rejected_atomically() {
+    for seed in 0..32 {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (_, client, _, owner) = setup_vault(&env, 10_000);
+
+        let batch_size = 2 + (seed as usize % (MAX_BATCH_SIZE as usize - 1));
+        let (items, duplicate_id) = build_duplicate_batch(&env, seed, batch_size);
+        let starting_balance = client.balance();
+
+        let result = client.try_batch_deduct(&owner, &items);
+        assert!(
+            result.is_err(),
+            "seed {seed} batch with duplicate request_id must be rejected"
+        );
+        assert_eq!(result.unwrap_err(), VaultError::DuplicateRequestId);
+        assert_eq!(client.balance(), starting_balance);
+        assert!(
+            !client.is_request_processed(&duplicate_id),
+            "rejected batch must not mark duplicate request_id"
+        );
+    }
 }
 
 /// A batch with all distinct `Some` ids succeeds and marks all of them.


### PR DESCRIPTION
Closes #437

---

## test(vault): Add property test for duplicate `request_id` handling in `batch_deduct`

This PR adds deterministic property-based test coverage to ensure the vault contract rejects duplicate `request_id` values within a single `batch_deduct` call atomically.

### What's included

- **`test_idempotency.rs`**
  - Added a seeded PRNG helper for deterministic test generation.
  - Added `build_duplicate_batch` helper.
  - Added `batch_deduct_duplicate_request_id_within_batch_rejected_atomically`.
  - Verifies that duplicate `request_id` values within the same batch cause the entire operation to be rejected atomically.
  - Confirms `meta.balance` remains unchanged after rejection.
  - Verifies the duplicate `request_id` is not marked as processed.

- **`INVARIANTS.md`**
  - Documented the invariant that duplicate `request_id` values within a batch are rejected atomically without modifying the vault balance.

### Purpose

Provide deterministic property-based test coverage for intra-batch duplicate `request_id` handling while documenting the expected vault invariant to prevent regressions.

**Closes:** #437