### PR TITLE
Standardize two-step admin rotation API across all contracts (#420)

### DIFF
--- a/contracts/revenue_pool/src/events.rs
+++ b/contracts/revenue_pool/src/events.rs
@@ -37,6 +37,13 @@ pub fn event_admin_transfer_completed(env: &Env) -> Symbol {
     Symbol::new(env, "admin_transfer_completed")
 }
 
+/// Returns the Symbol for the `"admin_cancelled"` event topic.
+///
+/// Emitted when the current admin cancels a pending admin transfer.
+pub fn event_admin_cancelled(env: &Env) -> Symbol {
+    Symbol::new(env, "admin_cancelled")
+}
+
 /// Returns the Symbol for the `"pause_set"` event topic.
 ///
 /// Emitted by both `pause` (with data `true`) and `unpause` (with data `false`)
@@ -118,6 +125,16 @@ mod tests {
         assert_eq!(
             event_admin_transfer_completed(&env),
             Symbol::new(&env, "admin_transfer_completed")
+        );
+    }
+
+    /// Snapshot: proves event_admin_cancelled still maps to exactly the bytes for "admin_cancelled".
+    #[test]
+    fn test_event_admin_cancelled_bytes() {
+        let env = Env::default();
+        assert_eq!(
+            event_admin_cancelled(&env),
+            Symbol::new(&env, "admin_cancelled")
         );
     }
 

--- a/contracts/revenue_pool/src/lib.rs
+++ b/contracts/revenue_pool/src/lib.rs
@@ -179,7 +179,7 @@ impl RevenuePool {
     ///
     /// # Events
     /// Emits an `admin_transfer_completed` event with the `new_admin` as a topic.
-    pub fn claim_admin(env: Env, caller: Address) {
+    pub fn accept_admin(env: Env, caller: Address) {
         caller.require_auth();
         let inst = env.storage().instance();
         let pending: Address = inst
@@ -196,6 +196,50 @@ impl RevenuePool {
 
         env.events()
             .publish((events::event_admin_transfer_completed(&env), pending), ());
+    }
+
+    /// Complete the admin transfer. Legacy name for `accept_admin`.
+    pub fn claim_admin(env: Env, caller: Address) {
+        Self::accept_admin(env, caller);
+    }
+
+    /// Cancel a pending admin transfer. Only the current admin may call this.
+    ///
+    /// # Arguments
+    /// * `env` - The environment running the contract.
+    /// * `caller` - Must be the current admin; must authorize.
+    ///
+    /// # Panics
+    /// * If the caller is not the current admin.
+    /// * If no admin transfer is pending.
+    ///
+    /// # Events
+    /// Emits `admin_cancelled` event with `(current_admin, pending_admin)`.
+    pub fn cancel_admin_transfer(env: Env, caller: Address) {
+        caller.require_auth();
+        let current = Self::get_admin(env.clone());
+        if caller != current {
+            panic!("unauthorized: caller is not admin");
+        }
+        let inst = env.storage().instance();
+        let pending: Address = inst
+            .get(&Symbol::new(&env, PENDING_ADMIN_KEY))
+            .expect("no admin transfer pending");
+
+        inst.remove(&Symbol::new(&env, PENDING_ADMIN_KEY));
+        inst.extend_ttl(LIFETIME_THRESHOLD, BUMP_AMOUNT);
+
+        env.events().publish(
+            (events::event_admin_cancelled(&env), current, pending),
+            (),
+        );
+    }
+
+    /// Return the pending admin address, or `None` if no transfer is in progress.
+    pub fn get_pending_admin(env: Env) -> Option<Address> {
+        env.storage()
+            .instance()
+            .get(&Symbol::new(&env, PENDING_ADMIN_KEY))
     }
 
     fn require_not_paused(env: &Env) {

--- a/contracts/revenue_pool/src/test.rs
+++ b/contracts/revenue_pool/src/test.rs
@@ -336,6 +336,78 @@ fn create_usdc<'a>(
     }
 
     #[test]
+    fn set_admin_two_step_transfers_control_accept_admin() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let admin = Address::generate(&env);
+        let new_admin = Address::generate(&env);
+        let (_, client) = create_pool(&env);
+        let (usdc_address, _, _) = create_usdc(&env, &admin);
+
+        client.init(&admin, &usdc_address);
+        assert_eq!(client.get_pending_admin(), None);
+
+        client.set_admin(&admin, &new_admin);
+        assert_eq!(client.get_pending_admin(), Some(new_admin.clone()));
+        assert_eq!(client.get_admin(), admin);
+
+        client.accept_admin(&new_admin);
+        assert_eq!(client.get_admin(), new_admin);
+        assert_eq!(client.get_pending_admin(), None);
+    }
+
+    #[test]
+    fn cancel_admin_transfer_clears_pending_and_emits_event() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let admin = Address::generate(&env);
+        let new_admin = Address::generate(&env);
+        let (_, client) = create_pool(&env);
+        let (usdc_address, _, _) = create_usdc(&env, &admin);
+
+        client.init(&admin, &usdc_address);
+        client.set_admin(&admin, &new_admin);
+        assert_eq!(client.get_pending_admin(), Some(new_admin.clone()));
+
+        client.cancel_admin_transfer(&admin);
+        assert_eq!(client.get_pending_admin(), None);
+
+        let events = env.events().all();
+        let cancel_event = events.last().unwrap();
+        let event_name = Symbol::try_from_val(&env, &cancel_event.1.get(0).unwrap()).unwrap();
+        assert_eq!(event_name, Symbol::new(&env, "admin_cancelled"));
+    }
+
+    #[test]
+    #[should_panic(expected = "unauthorized: caller is not admin")]
+    fn cancel_admin_transfer_non_admin_panics() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let admin = Address::generate(&env);
+        let new_admin = Address::generate(&env);
+        let attacker = Address::generate(&env);
+        let (_, client) = create_pool(&env);
+        let (usdc_address, _, _) = create_usdc(&env, &admin);
+
+        client.init(&admin, &usdc_address);
+        client.set_admin(&admin, &new_admin);
+        client.cancel_admin_transfer(&attacker);
+    }
+
+    #[test]
+    #[should_panic(expected = "no admin transfer pending")]
+    fn cancel_admin_transfer_no_pending_panics() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let admin = Address::generate(&env);
+        let (_, client) = create_pool(&env);
+        let (usdc_address, _, _) = create_usdc(&env, &admin);
+
+        client.init(&admin, &usdc_address);
+        client.cancel_admin_transfer(&admin);
+    }
+
+    #[test]
     #[should_panic(expected = "unauthorized: caller is not admin")]
     fn set_admin_unauthorized_panics() {
         let env = Env::default();

--- a/contracts/settlement/src/events.rs
+++ b/contracts/settlement/src/events.rs
@@ -53,6 +53,13 @@ pub fn event_admin_accepted(env: &Env) -> Symbol {
     Symbol::new(env, "admin_accepted")
 }
 
+/// Returns the Symbol for the `"admin_cancelled"` event topic.
+///
+/// Emitted when the current admin cancels a pending admin transfer.
+pub fn event_admin_cancelled(env: &Env) -> Symbol {
+    Symbol::new(env, "admin_cancelled")
+}
+
 /// Returns the Symbol for the `"vault_proposed"` event topic.
 ///
 /// Emitted when the admin proposes a new vault address via `propose_vault`.
@@ -117,6 +124,13 @@ mod tests {
     fn test_event_admin_accepted_bytes() {
         let env = Env::default();
         assert_eq!(event_admin_accepted(&env), Symbol::new(&env, "admin_accepted"));
+    }
+
+    /// Snapshot: proves event_admin_cancelled still maps to exactly the bytes for "admin_cancelled".
+    #[test]
+    fn test_event_admin_cancelled_bytes() {
+        let env = Env::default();
+        assert_eq!(event_admin_cancelled(&env), Symbol::new(&env, "admin_cancelled"));
     }
 
     /// Snapshot: proves event_vault_proposed still maps to exactly the bytes for "vault_proposed".

--- a/contracts/settlement/src/lib.rs
+++ b/contracts/settlement/src/lib.rs
@@ -1020,6 +1020,33 @@ impl CalloraSettlement {
             .publish((events::event_admin_accepted(&env), current, pending), ());
     }
 
+    /// Cancel a pending admin transfer. Only the current admin may call this.
+    ///
+    /// # Arguments
+    /// * `caller` - Current admin address; must match stored admin
+    ///
+    /// # Panics
+    /// * Panics if caller is not the current admin.
+    /// * Panics if no admin transfer is pending.
+    pub fn cancel_admin_transfer(env: Env, caller: Address) {
+        caller.require_auth();
+        let current = Self::get_admin(env.clone());
+        if caller != current {
+            env.panic_with_error(SettlementError::Unauthorized);
+        }
+        let inst = env.storage().instance();
+        let pending: Address = inst
+            .get(&StorageKey::PendingAdmin)
+            .expect("no admin transfer pending");
+
+        inst.remove(&StorageKey::PendingAdmin);
+
+        env.events().publish(
+            (events::event_admin_cancelled(&env), current, pending),
+            (),
+        );
+    }
+
     /// Propose a new vault address (admin only).
     ///
     /// # Arguments

--- a/contracts/settlement/src/test.rs
+++ b/contracts/settlement/src/test.rs
@@ -3,9 +3,8 @@ mod settlement_tests {
     extern crate std;
 
     use crate::{CalloraSettlement, CalloraSettlementClient, SettlementError, StorageKey};
-    use soroban_sdk::testutils::{Address as _, Ledger as _};
-    use soroban_sdk::{token, Address, Env, Error, InvokeError};
-    use soroban_sdk::{Address, Env, InvokeError, Symbol};
+    use soroban_sdk::testutils::{Address as _, Ledger as _, Events as _};
+    use soroban_sdk::{token, Address, Env, Error, InvokeError, Symbol, BytesN, TryFromVal};
 
     fn setup_contract() -> (Env, Address, Address, Address, Address) {
         let env = Env::default();
@@ -276,7 +275,7 @@ mod settlement_tests {
         let developer = Address::generate(&env);
         let addr = env.register(CalloraSettlement, ());
         let client = CalloraSettlementClient::new(&env, &addr);
-        let (usdc_address, usdc_admin_client) = create_usdc(&env, &admin);
+        let (usdc_address, _, usdc_admin_client) = create_usdc(&env, &admin);
 
         client.init(&admin, &vault);
         client.set_usdc_token(&admin, &usdc_address);
@@ -305,7 +304,7 @@ mod settlement_tests {
         let developer = Address::generate(&env);
         let addr = env.register(CalloraSettlement, ());
         let client = CalloraSettlementClient::new(&env, &addr);
-        let (usdc_address, usdc_admin_client) = create_usdc(&env, &admin);
+        let (usdc_address, _, usdc_admin_client) = create_usdc(&env, &admin);
 
         client.init(&admin, &vault);
         client.set_usdc_token(&admin, &usdc_address);
@@ -348,7 +347,7 @@ mod settlement_tests {
         let developer = Address::generate(&env);
         let addr = env.register(CalloraSettlement, ());
         let client = CalloraSettlementClient::new(&env, &addr);
-        let (usdc_address, usdc_admin_client) = create_usdc(&env, &admin);
+        let (usdc_address, _, usdc_admin_client) = create_usdc(&env, &admin);
 
         client.init(&admin, &vault);
         client.set_usdc_token(&admin, &usdc_address);
@@ -566,6 +565,60 @@ mod settlement_tests {
 
         let result = client.try_set_admin(&vault, &new_admin);
         assert!(is_error(result, SettlementError::Unauthorized));
+    }
+
+    #[test]
+    fn test_cancel_admin_transfer_success() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let admin = Address::generate(&env);
+        let vault = Address::generate(&env);
+        let new_admin = Address::generate(&env);
+        let addr = env.register(CalloraSettlement, ());
+        let client = CalloraSettlementClient::new(&env, &addr);
+        client.init(&admin, &vault);
+
+        client.set_admin(&admin, &new_admin);
+        assert_eq!(client.get_pending_admin(), Some(new_admin.clone()));
+
+        client.cancel_admin_transfer(&admin);
+        assert_eq!(client.get_pending_admin(), None);
+
+        let events = env.events().all();
+        let last_event = events.last().unwrap();
+        let event_name = Symbol::try_from_val(&env, &last_event.1.get(0).unwrap()).unwrap();
+        assert_eq!(event_name, Symbol::new(&env, "admin_cancelled"));
+    }
+
+    #[test]
+    fn test_cancel_admin_transfer_unauthorized() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let admin = Address::generate(&env);
+        let vault = Address::generate(&env);
+        let new_admin = Address::generate(&env);
+        let addr = env.register(CalloraSettlement, ());
+        let client = CalloraSettlementClient::new(&env, &addr);
+        client.init(&admin, &vault);
+
+        client.set_admin(&admin, &new_admin);
+
+        let result = client.try_cancel_admin_transfer(&vault);
+        assert!(is_error(result, SettlementError::Unauthorized));
+    }
+
+    #[test]
+    #[should_panic(expected = "no admin transfer pending")]
+    fn test_cancel_admin_transfer_no_pending_panics() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let admin = Address::generate(&env);
+        let vault = Address::generate(&env);
+        let addr = env.register(CalloraSettlement, ());
+        let client = CalloraSettlementClient::new(&env, &addr);
+        client.init(&admin, &vault);
+
+        client.cancel_admin_transfer(&admin);
     }
 
     #[test]
@@ -1857,6 +1910,7 @@ mod settlement_tests {
             pool.total_balance + sum_dev_balances,
             "Conservation invariant violated: total credits must equal pool + developer balances"
         );
+    }
     #[test]
     fn test_upgrade_and_get_version() {
         let (env, addr, admin, _vault, _third_party) = setup_contract();

--- a/contracts/vault/src/events.rs
+++ b/contracts/vault/src/events.rs
@@ -28,6 +28,13 @@ pub fn event_admin_accepted(env: &Env) -> Symbol {
     Symbol::new(env, "admin_accepted")
 }
 
+/// Returns the Symbol for the `"admin_cancelled"` event topic.
+///
+/// Emitted when the current admin cancels a pending admin transfer.
+pub fn event_admin_cancelled(env: &Env) -> Symbol {
+    Symbol::new(env, "admin_cancelled")
+}
+
 /// Returns the Symbol for the `"set_authorized_caller"` event topic.
 ///
 /// Emitted when an owner adds a new authorized caller for `deduct` operations.
@@ -210,6 +217,13 @@ mod tests {
         let env = soroban_sdk::Env::default();
         let sym = event_admin_accepted(&env);
         assert_eq!(sym, Symbol::new(&env, "admin_accepted"));
+    }
+
+    #[test]
+    fn test_event_admin_cancelled_bytes() {
+        let env = soroban_sdk::Env::default();
+        let sym = event_admin_cancelled(&env);
+        assert_eq!(sym, Symbol::new(&env, "admin_cancelled"));
     }
 
     #[test]

--- a/contracts/vault/src/lib.rs
+++ b/contracts/vault/src/lib.rs
@@ -485,6 +485,24 @@ impl CalloraVault {
         Ok(())
     }
 
+    pub fn cancel_admin_transfer(env: Env, caller: Address) -> Result<(), VaultError> {
+        caller.require_auth();
+        let cur = Self::get_admin(env.clone())?;
+        if caller != cur {
+            return Err(VaultError::Unauthorized);
+        }
+        let pending: Address = env
+            .storage()
+            .instance()
+            .get(&StorageKey::PendingAdmin)
+            .ok_or(VaultError::NoAdminTransferPending)?;
+
+        env.storage().instance().remove(&StorageKey::PendingAdmin);
+        env.events()
+            .publish((events::event_admin_cancelled(&env), cur, pending), ());
+        Ok(())
+    }
+
     pub fn require_owner(env: Env, caller: Address) -> Result<(), VaultError> {
         let meta = Self::get_meta(env.clone())?;
         if caller != meta.owner {

--- a/contracts/vault/src/test.rs
+++ b/contracts/vault/src/test.rs
@@ -3870,6 +3870,57 @@ fn accept_admin_without_pending_fails() {
 }
 
 #[test]
+fn cancel_admin_transfer_success() {
+    let env = Env::default();
+    let owner = Address::generate(&env);
+    let new_admin = Address::generate(&env);
+    let (vault_address, client) = create_vault(&env);
+    let (usdc, _, usdc_admin) = create_usdc(&env, &owner);
+    env.mock_all_auths();
+    fund_vault(&usdc_admin, &vault_address, 100);
+    client.init(&owner, &usdc, &Some(100), &None, &None, &None, &None);
+
+    client.set_admin(&owner, &new_admin);
+    assert_eq!(client.get_pending_admin(), Some(new_admin.clone()));
+
+    client.cancel_admin_transfer(&owner);
+    assert_eq!(client.get_pending_admin(), None);
+
+    let events = env.events().all();
+    let last_event = events.last().unwrap();
+    let event_name = Symbol::try_from_val(&env, &last_event.1.get(0).unwrap()).unwrap();
+    assert_eq!(event_name, Symbol::new(&env, "admin_cancelled"));
+}
+
+#[test]
+#[should_panic(expected = "unauthorized")]
+fn cancel_admin_transfer_unauthorized() {
+    let env = Env::default();
+    let owner = Address::generate(&env);
+    let new_admin = Address::generate(&env);
+    let attacker = Address::generate(&env);
+    let (_, client) = create_vault(&env);
+    let (usdc, _, _) = create_usdc(&env, &owner);
+    env.mock_all_auths();
+    client.init(&owner, &usdc, &None, &None, &None, &None, &None);
+    client.set_admin(&owner, &new_admin);
+    client.cancel_admin_transfer(&attacker);
+}
+
+#[test]
+#[should_panic(expected = "no admin transfer pending")]
+fn cancel_admin_transfer_no_pending_fails() {
+    let env = Env::default();
+    let owner = Address::generate(&env);
+    let (_, client) = create_vault(&env);
+    let (usdc, _, _) = create_usdc(&env, &owner);
+    env.mock_all_auths();
+    client.init(&owner, &usdc, &None, &None, &None, &None, &None);
+    client.cancel_admin_transfer(&owner);
+}
+
+
+#[test]
 #[should_panic(expected = "no ownership transfer pending")]
 fn accept_ownership_without_pending_fails() {
     let env = Env::default();

--- a/docs/ACCESS_CONTROL.md
+++ b/docs/ACCESS_CONTROL.md
@@ -103,6 +103,7 @@ The Callora Settlement contract tracks individual developer balances and global 
 | `receive_payment` | ✅ | ✅ | ❌ | ❌ |
 | `set_admin` | ✅ | ❌ | ❌ | ❌ |
 | `accept_admin` | ❌ | ❌ | ✅ | ❌ |
+| `cancel_admin_transfer` | ✅ | ❌ | ❌ | ❌ |
 | `propose_vault` | ✅ | ❌ | ❌ | ❌ |
 | `accept_vault` | ✅ | ✅ | ❌ | ❌ |
 | `set_vault` (alias of `propose_vault`) | ✅ | ❌ | ❌ | ❌ |
@@ -112,6 +113,34 @@ The Callora Settlement contract tracks individual developer balances and global 
 - **Two-Step Admin Rotation**: Prevents accidental loss of control by requiring the nominee to explicitly accept the role.
 - **Two-Step Vault Rotation**: Prevents accidentally misrouting settlement credits by requiring the proposed vault to accept (or the admin to finalize).
 - **Restricted Views**: Sensitive batch queries like `get_all_developer_balances` are restricted to the admin to prevent unnecessary exposure of the full ledger via the contract interface.
+- **Cancellation Safety**: The admin can invoke `cancel_admin_transfer` to clear a mistaken nomination.
+
+---
+
+## 3. Revenue Pool Access Control
+
+### Overview
+The Callora Revenue Pool contract processes USDC distribution to developer wallets. Like Settlement and Vault, it implements standard administrative roles and rotation procedures.
+
+### Roles
+- **Admin**: Handles revenue distributions and nominates administrative successions.
+- **Pending Admin**: A nominated account that has to explicitly accept the role to become the Admin.
+
+### Authorization Matrix
+
+| Function | Admin | Pending Admin | Others |
+|----------|-------|---------------|--------|
+| `distribute` | ✅ | ❌ | ❌ |
+| `batch_distribute` | ✅ | ❌ | ❌ |
+| `set_admin` | ✅ | ❌ | ❌ |
+| `accept_admin` | ❌ | ✅ | ❌ |
+| `claim_admin` (alias of `accept_admin`) | ❌ | ✅ | ❌ |
+| `cancel_admin_transfer` | ✅ | ❌ | ❌ |
+
+### Cancellation Safety
+The current admin can call `cancel_admin_transfer` to abort a pending admin nomination.
+
+---
 
 ## Test Coverage
 The implementation includes comprehensive tests covering:
@@ -132,7 +161,7 @@ The implementation includes comprehensive tests covering:
 - ✅ Only Admin can call `get_all_developer_balances`
 - ✅ All rotation and update logic preserves state integrity
 - ✅ Only current owner can call `cancel_ownership_transfer`
-- ✅ Only current admin can call `cancel_admin_transfer`
+- ✅ Only current admin can call `cancel_admin_transfer` in Vault, Settlement, and Revenue Pool
 - ✅ Cancel functions clear pending state and emit events
 - ✅ Cancel functions fail when no transfer is pending
 - ✅ Cancel functions fail for unauthorized callers
@@ -140,6 +169,5 @@ The implementation includes comprehensive tests covering:
 
 Run tests with:
 ```bash
-cargo test -p callora-settlement
-cargo test -p callora-vault
+cargo build --workspace --release --target=wasm32-unknown-unknown
 ```


### PR DESCRIPTION
### Goal
Standardizes the two-step admin rotation API across the \evenue_pool\, \settlement\, and \ault\ contracts to create symmetric capabilities as requested in #420.

### Tasks & Fixes Made
1. **Revenue Pool Contract Refactoring**:
   - Renamed \claim_admin\ to \ccept_admin\ in [lib.rs](file:///C:/Users/HP/.gemini/antigravity-ide/scratch/Callora-Contracts/contracts/revenue_pool/src/lib.rs) to match Settlement and Vault naming.
   - Added a backwards-compatible \claim_admin\ shim function which forwards to \ccept_admin\.
   - Implemented \cancel_admin_transfer\ to let the current admin cancel a pending transfer.
   - Implemented \get_pending_admin\ helper.
   - Declared the \dmin_cancelled\ event topic in [events.rs](file:///C:/Users/HP/.gemini/antigravity-ide/scratch/Callora-Contracts/contracts/revenue_pool/src/events.rs) along with snapshot tests.
2. **Settlement Contract Refactoring**:
   - Implemented \cancel_admin_transfer\ in [lib.rs](file:///C:/Users/HP/.gemini/antigravity-ide/scratch/Callora-Contracts/contracts/settlement/src/lib.rs).
   - Declared the \dmin_cancelled\ event topic in [events.rs](file:///C:/Users/HP/.gemini/antigravity-ide/scratch/Callora-Contracts/contracts/settlement/src/events.rs) along with snapshot tests.
3. **Vault Contract Refactoring**:
   - Implemented \cancel_admin_transfer\ in [lib.rs](file:///C:/Users/HP/.gemini/antigravity-ide/scratch/Callora-Contracts/contracts/vault/src/lib.rs).
   - Declared the \dmin_cancelled\ event topic in [events.rs](file:///C:/Users/HP/.gemini/antigravity-ide/scratch/Callora-Contracts/contracts/vault/src/events.rs) along with snapshot tests.
4. **Testing**:
   - Added unit test cases covering successful rotation cancellation, authorization checks, and error path validation across all three contracts (\	est.rs\).
5. **Documentation**:
   - Documented the standardized APIs, matrices, and cancellation safety checks in [ACCESS_CONTROL.md](file:///C:/Users/HP/.gemini/antigravity-ide/scratch/Callora-Contracts/docs/ACCESS_CONTROL.md).

Resolves #420