### PR TITLE
Add revenue pool yield deposit entrypoint

### DIFF
--- a/contracts/revenue_pool/YIELD_DEPOSIT.md
+++ b/contracts/revenue_pool/YIELD_DEPOSIT.md
@@ -1,0 +1,28 @@
+# Revenue Pool Yield Deposits
+
+`deposit_yield(treasury, amount, source)` lets the current revenue-pool admin
+deposit accumulated protocol earnings into the pool through one audited
+entrypoint.
+
+## Behavior
+
+- `treasury` must be the current admin and must authorize the call.
+- `amount` must be positive and is transferred from `treasury` to the revenue
+  pool contract using the configured USDC token contract.
+- `source` is a short Soroban `Symbol` label for indexers, such as `fees` or
+  `yield`.
+- `get_cumulative_yield_deposited()` returns the total amount deposited through
+  this entrypoint.
+
+## Event
+
+Each successful deposit emits:
+
+```text
+topics: ["yield_deposited", treasury]
+data:   (amount, source, cumulative_yield_deposited)
+```
+
+The metric update, token transfer, and event emission are part of the same
+Soroban transaction. If the transfer fails, the metric and event are reverted
+with the rest of the transaction.

--- a/contracts/revenue_pool/src/events.rs
+++ b/contracts/revenue_pool/src/events.rs
@@ -60,6 +60,14 @@ pub fn event_receive_payment(env: &Env) -> Symbol {
     Symbol::new(env, "receive_payment")
 }
 
+/// Returns the Symbol for the `"yield_deposited"` event topic.
+///
+/// Emitted when the treasury deposits accumulated protocol yield into the
+/// revenue pool via `deposit_yield`.
+pub fn event_yield_deposited(env: &Env) -> Symbol {
+    Symbol::new(env, "yield_deposited")
+}
+
 /// Returns the Symbol for the `"set_max_distribute"` event topic.
 ///
 /// Emitted when the admin updates the per-leg maximum distribute cap.
@@ -105,7 +113,10 @@ mod tests {
     #[test]
     fn test_event_admin_changed_bytes() {
         let env = Env::default();
-        assert_eq!(event_admin_changed(&env), Symbol::new(&env, "admin_changed"));
+        assert_eq!(
+            event_admin_changed(&env),
+            Symbol::new(&env, "admin_changed")
+        );
     }
 
     /// Snapshot: proves event_admin_transfer_started still maps to exactly the bytes for "admin_transfer_started".
@@ -149,14 +160,30 @@ mod tests {
     #[test]
     fn test_event_receive_payment_bytes() {
         let env = Env::default();
-        assert_eq!(event_receive_payment(&env), Symbol::new(&env, "receive_payment"));
+        assert_eq!(
+            event_receive_payment(&env),
+            Symbol::new(&env, "receive_payment")
+        );
+    }
+
+    /// Snapshot: proves event_yield_deposited still maps to exactly the bytes for "yield_deposited".
+    #[test]
+    fn test_event_yield_deposited_bytes() {
+        let env = Env::default();
+        assert_eq!(
+            event_yield_deposited(&env),
+            Symbol::new(&env, "yield_deposited")
+        );
     }
 
     /// Snapshot: proves event_set_max_distribute still maps to exactly the bytes for "set_max_distribute".
     #[test]
     fn test_event_set_max_distribute_bytes() {
         let env = Env::default();
-        assert_eq!(event_set_max_distribute(&env), Symbol::new(&env, "set_max_distribute"));
+        assert_eq!(
+            event_set_max_distribute(&env),
+            Symbol::new(&env, "set_max_distribute")
+        );
     }
 
     /// Snapshot: proves event_distribute still maps to exactly the bytes for "distribute".
@@ -170,7 +197,10 @@ mod tests {
     #[test]
     fn test_event_batch_distribute_bytes() {
         let env = Env::default();
-        assert_eq!(event_batch_distribute(&env), Symbol::new(&env, "batch_distribute"));
+        assert_eq!(
+            event_batch_distribute(&env),
+            Symbol::new(&env, "batch_distribute")
+        );
     }
 
     /// Snapshot: proves event_upgraded still maps to exactly the bytes for "upgraded".

--- a/contracts/revenue_pool/src/lib.rs
+++ b/contracts/revenue_pool/src/lib.rs
@@ -19,6 +19,7 @@ const ADMIN_KEY: &str = "admin";
 const PENDING_ADMIN_KEY: &str = "pending_admin";
 const USDC_KEY: &str = "usdc";
 const MAX_DISTRIBUTE_KEY: &str = "max_distribute";
+const CUMULATIVE_YIELD_DEPOSITED_KEY: &str = "cumulative_yield_deposited";
 const ERR_AMOUNT_NOT_POSITIVE: &str = "amount must be positive";
 const ERR_AMOUNT_EXCEEDS_MAX_DISTRIBUTE: &str = "amount exceeds max_distribute";
 const ERR_UNAUTHORIZED: &str = "unauthorized: caller is not admin";
@@ -229,10 +230,8 @@ impl RevenuePool {
         inst.remove(&Symbol::new(&env, PENDING_ADMIN_KEY));
         inst.extend_ttl(LIFETIME_THRESHOLD, BUMP_AMOUNT);
 
-        env.events().publish(
-            (events::event_admin_cancelled(&env), current, pending),
-            (),
-        );
+        env.events()
+            .publish((events::event_admin_cancelled(&env), current, pending), ());
     }
 
     /// Return the pending admin address, or `None` if no transfer is in progress.
@@ -343,6 +342,76 @@ impl RevenuePool {
             (events::event_receive_payment(&env), caller),
             (amount, from_vault),
         );
+    }
+
+    /// Deposit accumulated protocol yield into the revenue pool.
+    ///
+    /// The current admin acts as the treasury authority. The treasury must
+    /// authorize the call, and USDC is transferred from that treasury address to
+    /// this revenue-pool contract. The cumulative deposited-yield metric is
+    /// updated atomically with the transfer and event emission.
+    ///
+    /// # Arguments
+    /// * `env` - The environment running the contract.
+    /// * `treasury` - Must be the current admin and must authorize the call.
+    /// * `amount` - USDC amount in base units. Must be positive.
+    /// * `source` - Short source label for indexers, e.g. `fees` or `yield`.
+    ///
+    /// # Panics
+    /// * If `treasury` is not the current admin (`"unauthorized: caller is not admin"`).
+    /// * If `amount` is zero or negative (`"amount must be positive"`).
+    /// * If the cumulative metric would overflow (`"cumulative yield overflow"`).
+    /// * If the revenue pool has not been initialized.
+    ///
+    /// # Events
+    /// Emits `yield_deposited` with `treasury` as topic and
+    /// `(amount, source, cumulative_yield_deposited)` as data.
+    pub fn deposit_yield(env: Env, treasury: Address, amount: i128, source: Symbol) {
+        treasury.require_auth();
+        let admin = Self::get_admin(env.clone());
+        if treasury != admin {
+            panic!("{}", ERR_UNAUTHORIZED);
+        }
+        if amount <= 0 {
+            panic!("{}", ERR_AMOUNT_NOT_POSITIVE);
+        }
+
+        let previous_total = Self::get_cumulative_yield_deposited(env.clone());
+        let new_total = match previous_total.checked_add(amount) {
+            Some(total) => total,
+            None => panic!("cumulative yield overflow"),
+        };
+
+        let usdc_address: Address = env
+            .storage()
+            .instance()
+            .get(&Symbol::new(&env, USDC_KEY))
+            .expect(ERR_NOT_INITIALIZED);
+        let usdc = token::Client::new(&env, &usdc_address);
+        let contract_address = env.current_contract_address();
+
+        let inst = env.storage().instance();
+        inst.set(
+            &Symbol::new(&env, CUMULATIVE_YIELD_DEPOSITED_KEY),
+            &new_total,
+        );
+        inst.extend_ttl(LIFETIME_THRESHOLD, BUMP_AMOUNT);
+
+        usdc.transfer(&treasury, &contract_address, &amount);
+        env.events().publish(
+            (events::event_yield_deposited(&env), treasury),
+            (amount, source, new_total),
+        );
+    }
+
+    /// Return the cumulative USDC yield deposited through [`Self::deposit_yield`].
+    ///
+    /// Defaults to zero before the first yield deposit.
+    pub fn get_cumulative_yield_deposited(env: Env) -> i128 {
+        env.storage()
+            .instance()
+            .get(&Symbol::new(&env, CUMULATIVE_YIELD_DEPOSITED_KEY))
+            .unwrap_or(0)
     }
 
     /// Get the current per-leg distribution cap.

--- a/contracts/revenue_pool/src/test.rs
+++ b/contracts/revenue_pool/src/test.rs
@@ -158,7 +158,9 @@ fn create_usdc<'a>(
         client.pause(&admin);
         assert!(client.is_paused());
 
-        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| client.distribute(&admin, &developer, &100)));
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            client.distribute(&admin, &developer, &100)
+        }));
         assert!(result.is_err());
     }
 
@@ -2109,7 +2111,7 @@ fn chunk_iter_preserves_order_and_amounts() {
     let env = Env::default();
     let payments = make_payments(&env, 7); // amounts 1..=7
     let chunks = crate::chunk_iter(&env, payments, 3); // [3, 3, 1]
-    // Flatten and assert amounts return in order 1,2,3,4,5,6,7.
+                                                       // Flatten and assert amounts return in order 1,2,3,4,5,6,7.
     let mut expected: i128 = 1;
     for chunk in chunks.iter() {
         for (_, amount) in chunk.iter() {
@@ -2493,4 +2495,78 @@ fn batch_distribute_duplicate_detected_before_balance_check() {
     payments.push_back((dev.clone(), 200_i128));
 
     client.batch_distribute(&admin, &payments);
+}
+
+#[test]
+fn deposit_yield_transfers_from_treasury_and_updates_metric() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let (pool_addr, client) = create_pool(&env);
+    let (usdc_address, usdc_client, usdc_admin) = create_usdc(&env, &admin);
+    let source = Symbol::new(&env, "fees");
+
+    client.init(&admin, &usdc_address);
+    usdc_admin.mint(&admin, &1_000);
+
+    client.deposit_yield(&admin, &400, &source);
+
+    assert_eq!(usdc_client.balance(&admin), 600);
+    assert_eq!(usdc_client.balance(&pool_addr), 400);
+    assert_eq!(client.get_cumulative_yield_deposited(), 400);
+
+    let events = env.events().all();
+    let deposit_event = events.last().unwrap();
+    let event_name = Symbol::try_from_val(&env, &deposit_event.1.get(0).unwrap()).unwrap();
+    assert_eq!(event_name, Symbol::new(&env, "yield_deposited"));
+
+    let data: (i128, Symbol, i128) =
+        <(i128, Symbol, i128)>::try_from_val(&env, &deposit_event.2).unwrap();
+    assert_eq!(data, (400, source, 400));
+}
+
+#[test]
+fn deposit_yield_accumulates_multiple_sources() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let (pool_addr, client) = create_pool(&env);
+    let (usdc_address, usdc_client, usdc_admin) = create_usdc(&env, &admin);
+
+    client.init(&admin, &usdc_address);
+    usdc_admin.mint(&admin, &1_000);
+
+    client.deposit_yield(&admin, &250, &Symbol::new(&env, "fees"));
+    client.deposit_yield(&admin, &150, &Symbol::new(&env, "yield"));
+
+    assert_eq!(client.get_cumulative_yield_deposited(), 400);
+    assert_eq!(usdc_client.balance(&pool_addr), 400);
+    assert_eq!(usdc_client.balance(&admin), 600);
+}
+
+#[test]
+#[should_panic(expected = "unauthorized: caller is not admin")]
+fn deposit_yield_rejects_non_treasury() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let attacker = Address::generate(&env);
+    let (_, client) = create_pool(&env);
+    let (usdc_address, _, _) = create_usdc(&env, &admin);
+
+    client.init(&admin, &usdc_address);
+    client.deposit_yield(&attacker, &100, &Symbol::new(&env, "fees"));
+}
+
+#[test]
+#[should_panic(expected = "amount must be positive")]
+fn deposit_yield_rejects_zero_amount() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let (_, client) = create_pool(&env);
+    let (usdc_address, _, _) = create_usdc(&env, &admin);
+
+    client.init(&admin, &usdc_address);
+    client.deposit_yield(&admin, &0, &Symbol::new(&env, "fees"));
 }


### PR DESCRIPTION
## Summary
- Add a `deposit_yield` revenue-pool entrypoint that lets the authorized treasury deposit protocol earnings.
- Track cumulative deposited yield and emit a `yield_deposited` event for observability.
- Cover the entrypoint with unit tests and add operator documentation.

## Verification
- `PATH="$HOME/.rustup/toolchains/1.90.0-aarch64-apple-darwin/bin:$PATH" cargo check -p callora-revenue-pool --lib`
- `cargo test -p callora-revenue-pool deposit_yield -- --nocapture` is currently blocked before running the filtered tests by an existing `test_proptest.rs` `HashSet<Address>` compile error.
- `cargo fmt --package callora-revenue-pool -- --check` is currently blocked by an existing formatting issue in `test_proptest.rs`.

## CI note
- Current red CI is caused by existing workspace formatting/proptest failures.
- The release build also hits the repo's existing 64 KiB vault WASM gate; PR #520 raises the budget to the requested 100 KB check.

Closes #484