### PR TITLE
fix: Unicode normalization on metadata

### DIFF
--- a/BENCHMARKS.md
+++ b/BENCHMARKS.md
@@ -23,6 +23,20 @@ Cost estimations are derived by running transaction simulations through `soroban
 | `batch_deduct` | Medium–High | One read, one write, N events (one per item). Bulk process. | ~ 3.5M + (100k per item) |
 | `init` | Highest | First write (create instance), one event; requires auth. | ~ 4.5M |
 
+## Metadata Validation Note
+
+`callora-vault::set_metadata` and `update_metadata` now run a bounded O(n)
+visible-ASCII validation pass before storage. The input is already capped at
+256 bytes, so the incremental cost is a single linear scan plus a fixed buffer
+copy. This keeps the impact small while rejecting zero-width, bidi-override,
+and confusable metadata strings before they reach state.
+
+Release WASM size comparison for `callora-vault` using
+`cargo build --target wasm32-unknown-unknown --release -p callora-vault`:
+baseline `upstream/main` was 69,465 bytes; this change builds to 69,505 bytes
+(+40 bytes). The branch therefore has a minor size impact, though the baseline
+artifact is already above the repository's nominal 65,536-byte size target.
+
 *\*These are purely structural estimates. Actual costs fluctuate and must be simulated per deployment.*
 
 ## Obtaining Exact Numbers

--- a/contracts/vault/src/lib.rs
+++ b/contracts/vault/src/lib.rs
@@ -1186,25 +1186,16 @@ impl CalloraVault {
         Ok(())
     }
 
-    /// Validate that a vault input string is non-empty, contains no control
-    /// characters (0x00–0x1F, 0x7F), and has no leading/trailing whitespace.
+    /// Validate that a vault input string is non-empty visible ASCII with no
+    /// leading or trailing whitespace.
+    ///
+    /// The visible-ASCII policy rejects Unicode confusables, zero-width
+    /// characters, bidi overrides, and controls. Accepted strings are already
+    /// NFC-normalized because ASCII has one canonical Unicode representation.
     fn validate_vault_input(s: &String) -> Result<(), ()> {
-        let len = s.len();
-        if len == 0 {
-            return Err(());
-        }
-        let mut buf = [0u8; 256];
-        s.copy_into_slice(&mut buf[..len as usize]);
-        let bytes = &buf[..len as usize];
-        for &b in bytes {
-            if b <= 0x1F || b == 0x7F {
-                return Err(());
-            }
-        }
-        if bytes[0] == 0x20 || bytes[len as usize - 1] == 0x20 {
-            return Err(());
-        }
-        Ok(())
+        validators::is_visible_ascii_metadata(s)
+            .then_some(())
+            .ok_or(())
     }
 
     pub fn set_metadata(
@@ -1215,17 +1206,17 @@ impl CalloraVault {
     ) -> Result<String, VaultError> {
         caller.require_auth();
         Self::require_owner(env.clone(), caller.clone())?;
-        if Self::validate_vault_input(&offering_id).is_err() {
-            return Err(VaultError::OfferingIdInvalid);
-        }
-        if Self::validate_vault_input(&metadata).is_err() {
-            return Err(VaultError::MetadataInvalid);
-        }
         if offering_id.len() > MAX_OFFERING_ID_LEN {
             return Err(VaultError::OfferingIdTooLong);
         }
         if metadata.len() > MAX_METADATA_LEN {
             return Err(VaultError::MetadataTooLong);
+        }
+        if Self::validate_vault_input(&offering_id).is_err() {
+            return Err(VaultError::OfferingIdInvalid);
+        }
+        if Self::validate_vault_input(&metadata).is_err() {
+            return Err(VaultError::MetadataInvalid);
         }
         env.storage()
             .instance()
@@ -1350,6 +1341,12 @@ impl CalloraVault {
         }
         if metadata.len() > MAX_METADATA_LEN {
             return Err(VaultError::MetadataTooLong);
+        }
+        if Self::validate_vault_input(&offering_id).is_err() {
+            return Err(VaultError::OfferingIdInvalid);
+        }
+        if Self::validate_vault_input(&metadata).is_err() {
+            return Err(VaultError::MetadataInvalid);
         }
         let old: String = env
             .storage()
@@ -1576,6 +1573,7 @@ impl CalloraVault {
 }
 
 mod events;
+mod validators;
 
 // ---------------------------------------------------------------------------
 // Test modules

--- a/contracts/vault/src/validators.rs
+++ b/contracts/vault/src/validators.rs
@@ -1,0 +1,51 @@
+//! Bounded string validators for user-supplied vault metadata.
+//!
+//! Metadata is stored as contract state and later consumed by wallets,
+//! indexers, and off-chain services. Accepting arbitrary Unicode would allow
+//! invisible controls, bidi overrides, and homoglyph confusables to make two
+//! different byte strings appear identical. The on-chain policy is therefore
+//! intentionally narrow: metadata identifiers and values must be visible ASCII.
+//! ASCII is already NFC-normalized, so stored values have one canonical byte
+//! representation without pulling large Unicode tables into the WASM.
+//!
+//! The validator is O(n) over the input length, with `n` capped at the
+//! contract's existing 256-byte metadata limit.
+
+use soroban_sdk::String;
+
+/// Maximum byte length accepted by [`normalize_visible_ascii`].
+pub const MAX_VALIDATED_STRING_LEN: u32 = 256;
+
+/// Normalize a bounded metadata string to its canonical on-chain form.
+///
+/// Accepted strings are non-empty visible ASCII with no leading or trailing
+/// spaces. This rejects C0/DEL controls, zero-width and bidi controls, and
+/// Unicode confusables by construction. Because ASCII has no decomposed forms,
+/// the returned value is NFC-normalized and byte-stable.
+pub fn normalize_visible_ascii(s: &String) -> Result<[u8; MAX_VALIDATED_STRING_LEN as usize], ()> {
+    let len = s.len();
+    if len == 0 || len > MAX_VALIDATED_STRING_LEN {
+        return Err(());
+    }
+
+    let mut buf = [0u8; MAX_VALIDATED_STRING_LEN as usize];
+    s.copy_into_slice(&mut buf[..len as usize]);
+    let bytes = &buf[..len as usize];
+
+    if bytes[0] == b' ' || bytes[len as usize - 1] == b' ' {
+        return Err(());
+    }
+
+    for &b in bytes {
+        if !(0x20..=0x7e).contains(&b) {
+            return Err(());
+        }
+    }
+
+    Ok(buf)
+}
+
+/// Return whether a bounded metadata string is accepted by the on-chain policy.
+pub fn is_visible_ascii_metadata(s: &String) -> bool {
+    normalize_visible_ascii(s).is_ok()
+}

--- a/contracts/vault/tests/metadata_unicode.rs
+++ b/contracts/vault/tests/metadata_unicode.rs
@@ -1,0 +1,72 @@
+use callora_vault::{CalloraVault, CalloraVaultClient, VaultError};
+use soroban_sdk::testutils::Address as _;
+use soroban_sdk::{Address, Env, String};
+
+fn setup(env: &Env) -> (CalloraVaultClient<'_>, Address) {
+    env.mock_all_auths();
+    let owner = Address::generate(env);
+    let vault_addr = env.register(CalloraVault, ());
+    let client = CalloraVaultClient::new(env, &vault_addr);
+    let usdc = env
+        .register_stellar_asset_contract_v2(owner.clone())
+        .address();
+    client.init(&owner, &usdc, &None, &None, &None, &None, &None);
+    (client, owner)
+}
+
+#[test]
+fn set_metadata_rejects_unicode_confusables_and_invisible_controls() {
+    let env = Env::default();
+    let (client, owner) = setup(&env);
+    let offering_id = String::from_str(&env, "off1");
+
+    for metadata in [
+        "meta\u{200b}data",
+        "meta\u{200d}data",
+        "meta\u{202e}data",
+        "раypal",
+        "cafe\u{0301}",
+    ] {
+        let result =
+            client.try_set_metadata(&owner, &offering_id, &String::from_str(&env, metadata));
+        assert_eq!(result, Err(Ok(VaultError::MetadataInvalid)));
+    }
+}
+
+#[test]
+fn update_metadata_rejects_unicode_confusables_and_invisible_controls() {
+    let env = Env::default();
+    let (client, owner) = setup(&env);
+    let offering_id = String::from_str(&env, "off1");
+    client.set_metadata(&owner, &offering_id, &String::from_str(&env, "metadata"));
+
+    let result = client.try_update_metadata(
+        &owner,
+        &offering_id,
+        &String::from_str(&env, "new\u{200d}metadata"),
+    );
+    assert_eq!(result, Err(Ok(VaultError::MetadataInvalid)));
+
+    let confusable_offering_id = String::from_str(&env, "оff1");
+    let result = client.try_update_metadata(
+        &owner,
+        &confusable_offering_id,
+        &String::from_str(&env, "metadata"),
+    );
+    assert_eq!(result, Err(Ok(VaultError::OfferingIdInvalid)));
+}
+
+#[test]
+fn visible_ascii_metadata_is_stored_as_canonical_nfc() {
+    let env = Env::default();
+    let (client, owner) = setup(&env);
+    let offering_id = String::from_str(&env, "off1");
+    let metadata = String::from_str(
+        &env,
+        "ipfs://bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi",
+    );
+
+    let result = client.set_metadata(&owner, &offering_id, &metadata);
+    assert_eq!(result, metadata);
+    assert_eq!(client.get_metadata(&offering_id), Some(metadata));
+}

--- a/docs/AUDIT_BUNDLE.md
+++ b/docs/AUDIT_BUNDLE.md
@@ -230,6 +230,9 @@ The following auth matrix covers every mutating entrypoint in the audited contra
 - Removed duplicate/uncompilable method definitions in `contracts/vault/src/lib.rs` that would have bypassed or corrupted auth handling.
 - Added a negative auth regression test for `settlement::init`.
 - Verified no audited view-only functions mutate state.
+- Added bounded metadata validation in `callora-vault` so offering metadata
+  rejects zero-width, bidi-override, and other confusable Unicode input while
+  remaining NFC-normalized by policy.
 
 ### Key Test Scenarios
 


### PR DESCRIPTION
## Summary
- Add bounded metadata validation for `callora-vault::set_metadata` and `update_metadata`.
- Reject zero-width, bidi-override/control, decomposed Unicode, and homoglyph/confusable metadata by enforcing visible ASCII.
- Keep accepted metadata NFC-normalized by construction without adding heavy Unicode tables to the contract WASM.

## Notes
- The current repository stores offering metadata in `contracts/vault`; `contracts/settlement` has no metadata string entrypoints.
- Validation is O(n) over capped input length and preserves typed too-long errors before bounded buffer copies.

## Verification
- `cargo check -p callora-vault` passed.
- `cargo test -p callora-vault --test metadata_unicode -- --nocapture` passed: 3 tests.
- Full vault tests are blocked by unrelated existing compile errors in the test suite.
- WASM size impact: baseline `upstream/main` vault WASM 69,465 bytes; this branch 69,505 bytes; +40 bytes.
- `cargo fmt --check` reports broad pre-existing formatting drift outside this change.

Closes #497
