### PR TITLE
feat(settlement): add per-developer minimum balance threshold and adm…

### DIFF
--- a/contracts/settlement/src/errors.rs
+++ b/contracts/settlement/src/errors.rs
@@ -56,4 +56,5 @@ pub enum SettlementError {
     MigrationNotFound = 20,
     TimelockNotExpired = 21,
     MigrationBalanceChanged = 22,
+    MinimumBalanceRequired = 23,
 }

--- a/contracts/settlement/src/lib.rs
+++ b/contracts/settlement/src/lib.rs
@@ -9,7 +9,9 @@ pub use errors::SettlementError;
 pub use timelock::{PendingDeveloperMigration, DEVELOPER_MIGRATION_TIMELOCK_SECONDS};
 
 mod types;
+mod limits;
 pub use types::*;
+pub use limits::*;
 
 
 #[contract]
@@ -484,7 +486,10 @@ impl CalloraSettlement {
         let new_balance = current_balance
             .checked_sub(amount)
             .ok_or(SettlementError::DeveloperBalanceUnderflow)?;
-
+        let min_balance = limits::get_developer_min_balance(env.clone(), developer.clone());
+        if new_balance < min_balance {
+            return Err(SettlementError::MinimumBalanceRequired);
+        }
         let token_client = token::Client::new(&env, &token);
 
         if token_client.balance(&contract_address) < amount {
@@ -557,6 +562,14 @@ impl CalloraSettlement {
             (events::event_daily_withdraw_cap_changed(&env), caller),
             DailyWithdrawCapChanged { developer, new_cap: cap },
         );
+    }
+
+    /// Set the minimum balance for a developer (admin only).
+    ///
+    /// This entrypoint allows the admin to enforce a per‑developer minimum balance.
+    /// It delegates to the limits module for storage and auth checks.
+    pub fn set_minimum_balance(env: Env, caller: Address, developer: Address, min_balance: i128) {
+        limits::set_developer_min_balance(env, caller, developer, min_balance);
     }
 
     /// Get the daily withdrawal cap for a developer.

--- a/contracts/settlement/src/limits.rs
+++ b/contracts/settlement/src/limits.rs
@@ -1,0 +1,36 @@
+//! Limits module for per-developer minimum balance.
+
+use soroban_sdk::{Env, Address, Symbol, contracterror, contracttype};
+use crate::errors::SettlementError;
+use crate::types::StorageKey;
+
+/// Set the minimum balance for a developer.
+///
+/// # Arguments
+/// * `env` - Execution environment.
+/// * `caller` - Must be admin.
+/// * `developer` - Target developer address.
+/// * `min_balance` - Minimum balance in token micro‑units (>= 0).
+pub fn set_developer_min_balance(env: Env, caller: Address, developer: Address, min_balance: i128) {
+    // Auth check – admin only.
+    caller.require_auth();
+    let admin = crate::lib::CalloraSettlement::get_admin(env.clone());
+    if caller != admin {
+        env.panic_with_error(SettlementError::Unauthorized);
+    }
+    if min_balance < 0 {
+        panic!("minimum balance must be non‑negative");
+    }
+    // Store the value.
+    env.storage().persistent().set(&StorageKey::DeveloperMinBalance(developer.clone()), &min_balance);
+    // Optional TTL similar to other persistent entries.
+    env.storage().persistent().extend_ttl(&StorageKey::DeveloperMinBalance(developer), 50000, 50000);
+}
+
+/// Retrieve the minimum balance for a developer. Returns `0` if not set.
+pub fn get_developer_min_balance(env: Env, developer: Address) -> i128 {
+    env.storage()
+        .persistent()
+        .get(&StorageKey::DeveloperMinBalance(developer))
+        .unwrap_or(0)
+}

--- a/contracts/settlement/src/types.rs
+++ b/contracts/settlement/src/types.rs
@@ -29,6 +29,7 @@ pub enum StorageKey {
     DeveloperBalanceV1(Address),
     /// Per-token developer balance `(developer, token)`.
     DeveloperBalance(Address, Address),
+    DeveloperMinBalance(Address),
     GlobalPool,
     Usdc,
     DailyWithdrawCap(Address),


### PR DESCRIPTION
this pr closes #527 Adds a per‑developer minimum balance threshold to the GrantFox settlement contract, allowing an admin to enforce a required balance for each developer. This ensures accounts stay funded and active throughout the campaign.