### PR TITLE
feat: per-developer claim window

### DIFF
--- a/contracts/settlement/src/events.rs
+++ b/contracts/settlement/src/events.rs
@@ -37,6 +37,13 @@ pub fn event_daily_withdraw_cap_changed(env: &Env) -> Symbol {
     Symbol::new(env, "daily_withdraw_cap_changed")
 }
 
+/// Returns the Symbol for the `"claim_window_changed"` event topic.
+///
+/// Emitted when the admin sets or clears a developer's claim window.
+pub fn event_developer_claim_window_changed(env: &Env) -> Symbol {
+    Symbol::new(env, "claim_window_changed")
+}
+
 /// Returns the Symbol for the `"admin_nominated"` event topic.
 ///
 /// Emitted when the current admin nominates a new admin via `set_admin`.
@@ -85,21 +92,30 @@ mod tests {
     #[test]
     fn test_event_payment_received_bytes() {
         let env = Env::default();
-        assert_eq!(event_payment_received(&env), Symbol::new(&env, "payment_received"));
+        assert_eq!(
+            event_payment_received(&env),
+            Symbol::new(&env, "payment_received")
+        );
     }
 
     /// Snapshot: proves event_balance_credited still maps to exactly the bytes for "balance_credited".
     #[test]
     fn test_event_balance_credited_bytes() {
         let env = Env::default();
-        assert_eq!(event_balance_credited(&env), Symbol::new(&env, "balance_credited"));
+        assert_eq!(
+            event_balance_credited(&env),
+            Symbol::new(&env, "balance_credited")
+        );
     }
 
     /// Snapshot: proves event_developer_withdraw still maps to exactly the bytes for "developer_withdraw".
     #[test]
     fn test_event_developer_withdraw_bytes() {
         let env = Env::default();
-        assert_eq!(event_developer_withdraw(&env), Symbol::new(&env, "developer_withdraw"));
+        assert_eq!(
+            event_developer_withdraw(&env),
+            Symbol::new(&env, "developer_withdraw")
+        );
     }
 
     /// Snapshot: proves event_daily_withdraw_cap_changed still maps to exactly the bytes for "daily_withdraw_cap_changed".
@@ -112,38 +128,63 @@ mod tests {
         );
     }
 
+    /// Snapshot: proves event_developer_claim_window_changed still maps to exactly the bytes for "claim_window_changed".
+    #[test]
+    fn test_event_developer_claim_window_changed_bytes() {
+        let env = Env::default();
+        assert_eq!(
+            event_developer_claim_window_changed(&env),
+            Symbol::new(&env, "claim_window_changed")
+        );
+    }
+
     /// Snapshot: proves event_admin_nominated still maps to exactly the bytes for "admin_nominated".
     #[test]
     fn test_event_admin_nominated_bytes() {
         let env = Env::default();
-        assert_eq!(event_admin_nominated(&env), Symbol::new(&env, "admin_nominated"));
+        assert_eq!(
+            event_admin_nominated(&env),
+            Symbol::new(&env, "admin_nominated")
+        );
     }
 
     /// Snapshot: proves event_admin_accepted still maps to exactly the bytes for "admin_accepted".
     #[test]
     fn test_event_admin_accepted_bytes() {
         let env = Env::default();
-        assert_eq!(event_admin_accepted(&env), Symbol::new(&env, "admin_accepted"));
+        assert_eq!(
+            event_admin_accepted(&env),
+            Symbol::new(&env, "admin_accepted")
+        );
     }
 
     /// Snapshot: proves event_admin_cancelled still maps to exactly the bytes for "admin_cancelled".
     #[test]
     fn test_event_admin_cancelled_bytes() {
         let env = Env::default();
-        assert_eq!(event_admin_cancelled(&env), Symbol::new(&env, "admin_cancelled"));
+        assert_eq!(
+            event_admin_cancelled(&env),
+            Symbol::new(&env, "admin_cancelled")
+        );
     }
 
     /// Snapshot: proves event_vault_proposed still maps to exactly the bytes for "vault_proposed".
     #[test]
     fn test_event_vault_proposed_bytes() {
         let env = Env::default();
-        assert_eq!(event_vault_proposed(&env), Symbol::new(&env, "vault_proposed"));
+        assert_eq!(
+            event_vault_proposed(&env),
+            Symbol::new(&env, "vault_proposed")
+        );
     }
 
     /// Snapshot: proves event_vault_accepted still maps to exactly the bytes for "vault_accepted".
     #[test]
     fn test_event_vault_accepted_bytes() {
         let env = Env::default();
-        assert_eq!(event_vault_accepted(&env), Symbol::new(&env, "vault_accepted"));
+        assert_eq!(
+            event_vault_accepted(&env),
+            Symbol::new(&env, "vault_accepted")
+        );
     }
 }

--- a/contracts/settlement/src/lib.rs
+++ b/contracts/settlement/src/lib.rs
@@ -1,6 +1,8 @@
 #![no_std]
 
-use soroban_sdk::{contract, contracterror, contractimpl, contracttype, token, Address, BytesN, Env, Symbol, Vec};
+use soroban_sdk::{
+    contract, contracterror, contractimpl, contracttype, token, Address, BytesN, Env, Symbol, Vec,
+};
 
 /// Maximum number of items allowed in a single `batch_receive_payment` call.
 pub const MAX_BATCH_SIZE: u32 = 50;
@@ -31,6 +33,8 @@ pub const MAX_DEVELOPER_BALANCES_PAGE_SIZE: u32 = 100;
 /// | 13   | DailyWithdrawCapExceeded     | Developer's daily withdrawal cap would be exceeded|
 /// | 14   | GasExhaustionRisk            | Index too large for safe full scan; use pagination|
 /// | 15   | ReasonTooLong                | Reason Symbol exceeds maximum allowed length      |
+/// | 16   | InvalidClaimWindow           | Claim window end is before start                  |
+/// | 17   | ClaimWindowClosed            | Claim attempted outside developer's claim window  |
 #[contracterror]
 #[derive(Clone, Copy, Debug, PartialEq)]
 #[repr(u32)]
@@ -45,11 +49,13 @@ pub enum SettlementError {
     DeveloperOverflow = 8,
     UsdcTokenNotConfigured = 9,
     InsufficientDeveloperBalance = 10,
-    DeveloperBalanceUnderflow    = 11,
-    InsufficientContractBalance  = 12,
-    DailyWithdrawCapExceeded     = 13,
-    GasExhaustionRisk            = 14,
-    ReasonTooLong                = 15,
+    DeveloperBalanceUnderflow = 11,
+    InsufficientContractBalance = 12,
+    DailyWithdrawCapExceeded = 13,
+    GasExhaustionRisk = 14,
+    ReasonTooLong = 15,
+    InvalidClaimWindow = 16,
+    ClaimWindowClosed = 17,
 }
 
 /// Persistent storage keys for settlement contract
@@ -66,6 +72,7 @@ pub enum StorageKey {
     Usdc,
     DailyWithdrawCap(Address),
     WithdrawalToday(Address),
+    DeveloperClaimWindow(Address),
     ContractVersion,
 }
 
@@ -101,6 +108,18 @@ pub struct GlobalPool {
 pub struct DailyWithdrawState {
     pub day: u64,
     pub amount: i128,
+}
+
+/// Timestamp range during which a developer may claim accrued balance.
+///
+/// `start_ts` and `end_ts` are ledger timestamps in seconds. The window is
+/// inclusive on both ends: a withdrawal is allowed when
+/// `start_ts <= env.ledger().timestamp() <= end_ts`.
+#[contracttype]
+#[derive(Clone, Debug, PartialEq)]
+pub struct DeveloperClaimWindow {
+    pub start_ts: u64,
+    pub end_ts: u64,
 }
 
 /// Payment received event
@@ -157,6 +176,16 @@ pub struct DailyWithdrawCapChanged {
     pub new_cap: i128,
 }
 
+/// Emitted when the admin sets or clears a developer claim window.
+#[contracttype]
+#[derive(Clone, Debug, PartialEq)]
+pub struct DeveloperClaimWindowChanged {
+    pub developer: Address,
+    pub start_ts: u64,
+    pub end_ts: u64,
+    pub enabled: bool,
+}
+
 /// Emitted when an admin force-credits a developer balance (escape hatch).
 #[contracttype]
 #[derive(Clone, Debug, PartialEq)]
@@ -171,7 +200,6 @@ pub struct DeveloperForceCreditedEvent {
 /// The Soroban SDK enforces a 32-byte limit on Symbol values at construction;
 /// this constant is used for explicit defense-in-depth validation.
 pub const MAX_REASON_LENGTH: u32 = 32;
-
 
 #[contract]
 pub struct CalloraSettlement;
@@ -383,9 +411,11 @@ impl CalloraSettlement {
             env.storage()
                 .persistent()
                 .set(&StorageKey::DeveloperBalance(dev.clone()), &new_balance);
-            env.storage()
-                .persistent()
-                .extend_ttl(&StorageKey::DeveloperBalance(dev.clone()), 50000, 50000);
+            env.storage().persistent().extend_ttl(
+                &StorageKey::DeveloperBalance(dev.clone()),
+                50000,
+                50000,
+            );
             // Add to index in sorted order if not already present
             let mut index: Vec<Address> = inst
                 .get(&StorageKey::DeveloperIndex)
@@ -475,125 +505,241 @@ impl CalloraSettlement {
             .ok_or(SettlementError::UsdcTokenNotConfigured)
     }
 
-    /// Withdraw developer balance as USDC to a designated recipient (defaults to the developer).
-///
-/// Requires the developer to authorize the request and the requested amount
-/// to be positive and covered by the tracked developer balance.
-///
-/// # Arguments
-/// * `developer` - Address of the developer withdrawing their balance
-/// * `amount` - Amount to withdraw in USDC micro-units
-/// * `to` - Optional recipient address; if `None`, defaults to `developer`
-///
-/// # Errors
-/// - `AmountNotPositive` if amount is ≤ 0
-/// - `InsufficientDeveloperBalance` if developer balance < amount
-/// - `DailyWithdrawCapExceeded` if daily cap is exceeded
-/// - `DeveloperBalanceUnderflow` if subtraction underflows
-/// - `UsdcTokenNotConfigured` if USDC token not set
-/// - `InsufficientContractBalance` if contract has insufficient USDC
-/// - Panics if `to` is the contract's own address
-pub fn withdraw_developer_balance(
-    env: Env,
-    developer: Address,
-    amount: i128,
-    to: Option<Address>,
-) -> Result<(), SettlementError> {
-    developer.require_auth();
-    if amount <= 0 {
-        return Err(SettlementError::AmountNotPositive);
-    }
+    /// Withdraw developer balance as USDC to a designated recipient.
+    ///
+    /// Requires the developer to authorize the request, the amount to be
+    /// positive, the developer's optional claim window to be open, and the
+    /// requested amount to be covered by the tracked developer balance.
+    ///
+    /// # Arguments
+    /// * `developer` - Address of the developer withdrawing their balance.
+    /// * `amount` - Amount to withdraw in USDC micro-units.
+    /// * `to` - Optional recipient address; if `None`, defaults to `developer`.
+    ///
+    /// # Errors
+    /// - `AmountNotPositive` if amount is <= 0.
+    /// - `ClaimWindowClosed` if a developer claim window exists and the current
+    ///   ledger timestamp is outside that inclusive window.
+    /// - `InsufficientDeveloperBalance` if developer balance < amount.
+    /// - `DailyWithdrawCapExceeded` if daily cap is exceeded.
+    /// - `DeveloperBalanceUnderflow` if subtraction underflows.
+    /// - `UsdcTokenNotConfigured` if USDC token not set.
+    /// - `InsufficientContractBalance` if contract has insufficient USDC.
+    /// - Panics if `to` is the contract's own address.
+    pub fn withdraw_developer_balance(
+        env: Env,
+        developer: Address,
+        amount: i128,
+        to: Option<Address>,
+    ) -> Result<(), SettlementError> {
+        developer.require_auth();
+        if amount <= 0 {
+            return Err(SettlementError::AmountNotPositive);
+        }
 
-    let recipient = to.unwrap_or_else(|| developer.clone());
-    let contract_address = env.current_contract_address();
-    if recipient == contract_address {
-        panic!("invalid recipient: cannot withdraw to contract itself");
-    }
+        let recipient = to.unwrap_or_else(|| developer.clone());
+        let contract_address = env.current_contract_address();
+        if recipient == contract_address {
+            panic!("invalid recipient: cannot withdraw to contract itself");
+        }
 
-    let current_balance: i128 = env
-        .storage()
-        .persistent()
-        .get(&StorageKey::DeveloperBalance(developer.clone()))
-        .unwrap_or(0);
-    if amount > current_balance {
-        return Err(SettlementError::InsufficientDeveloperBalance);
-    }
+        Self::require_claim_window_open(&env, &developer)?;
 
-    let cap: i128 = env
-        .storage()
-        .persistent()
-        .get(&StorageKey::DailyWithdrawCap(developer.clone()))
-        .unwrap_or(0);
-    if cap > 0 {
+        let current_balance: i128 = env
+            .storage()
+            .persistent()
+            .get(&StorageKey::DeveloperBalance(developer.clone()))
+            .unwrap_or(0);
+        if amount > current_balance {
+            return Err(SettlementError::InsufficientDeveloperBalance);
+        }
+
+        let cap: i128 = env
+            .storage()
+            .persistent()
+            .get(&StorageKey::DailyWithdrawCap(developer.clone()))
+            .unwrap_or(0);
+        if cap > 0 {
+            let today = env.ledger().timestamp() / 86400;
+            let mut daily = env
+                .storage()
+                .persistent()
+                .get::<_, DailyWithdrawState>(&StorageKey::WithdrawalToday(developer.clone()))
+                .unwrap_or(DailyWithdrawState {
+                    day: today,
+                    amount: 0,
+                });
+            if daily.day != today {
+                daily.day = today;
+                daily.amount = 0;
+            }
+            if daily.amount.checked_add(amount).is_none_or(|sum| sum > cap) {
+                return Err(SettlementError::DailyWithdrawCapExceeded);
+            }
+        }
+
+        let new_balance = current_balance
+            .checked_sub(amount)
+            .ok_or(SettlementError::DeveloperBalanceUnderflow)?;
+
+        let usdc_address = Self::get_usdc_token(env.clone())?;
+        let usdc = token::Client::new(&env, &usdc_address);
+
+        if usdc.balance(&contract_address) < amount {
+            return Err(SettlementError::InsufficientContractBalance);
+        }
+
+        usdc.transfer(&contract_address, &recipient, &amount);
+
+        env.storage().persistent().set(
+            &StorageKey::DeveloperBalance(developer.clone()),
+            &new_balance,
+        );
+        env.storage().persistent().extend_ttl(
+            &StorageKey::DeveloperBalance(developer.clone()),
+            50000,
+            50000,
+        );
+
         let today = env.ledger().timestamp() / 86400;
         let mut daily = env
             .storage()
             .persistent()
             .get::<_, DailyWithdrawState>(&StorageKey::WithdrawalToday(developer.clone()))
-            .unwrap_or(DailyWithdrawState { day: today, amount: 0 });
+            .unwrap_or(DailyWithdrawState {
+                day: today,
+                amount: 0,
+            });
         if daily.day != today {
             daily.day = today;
             daily.amount = 0;
         }
-        if daily.amount.checked_add(amount).is_none_or(|sum| sum > cap) {
-            return Err(SettlementError::DailyWithdrawCapExceeded);
+        daily.amount = daily.amount.saturating_add(amount);
+        env.storage()
+            .persistent()
+            .set(&StorageKey::WithdrawalToday(developer.clone()), &daily);
+        env.storage().persistent().extend_ttl(
+            &StorageKey::WithdrawalToday(developer.clone()),
+            50000,
+            50000,
+        );
+
+        env.events().publish(
+            (events::event_developer_withdraw(&env), developer.clone()),
+            DeveloperWithdrawEvent {
+                developer,
+                amount,
+                remaining_balance: new_balance,
+                to: recipient,
+            },
+        );
+
+        Ok(())
+    }
+
+    /// Configure the inclusive claim window for a developer.
+    ///
+    /// A configured window restricts `withdraw_developer_balance` so the
+    /// developer can claim only when the current ledger timestamp is between
+    /// `start_ts` and `end_ts`, inclusive. Developers with no configured
+    /// window remain claimable at any time.
+    ///
+    /// # Access Control
+    /// Only the current admin can call this function.
+    ///
+    /// # Errors
+    /// - `Unauthorized` if caller is not the current admin.
+    /// - `InvalidClaimWindow` if `end_ts < start_ts`.
+    ///
+    /// # Events
+    /// Emits `developer_claim_window_changed` with `enabled = true`.
+    pub fn set_developer_claim_window(
+        env: Env,
+        caller: Address,
+        developer: Address,
+        start_ts: u64,
+        end_ts: u64,
+    ) -> Result<(), SettlementError> {
+        caller.require_auth();
+        Self::require_admin(env.clone(), caller)?;
+        if end_ts < start_ts {
+            return Err(SettlementError::InvalidClaimWindow);
         }
+
+        let window = DeveloperClaimWindow { start_ts, end_ts };
+        env.storage().persistent().set(
+            &StorageKey::DeveloperClaimWindow(developer.clone()),
+            &window,
+        );
+        env.storage().persistent().extend_ttl(
+            &StorageKey::DeveloperClaimWindow(developer.clone()),
+            50000,
+            50000,
+        );
+
+        env.events().publish(
+            (
+                events::event_developer_claim_window_changed(&env),
+                developer.clone(),
+            ),
+            DeveloperClaimWindowChanged {
+                developer,
+                start_ts,
+                end_ts,
+                enabled: true,
+            },
+        );
+
+        Ok(())
     }
 
-    let new_balance = current_balance
-        .checked_sub(amount)
-        .ok_or(SettlementError::DeveloperBalanceUnderflow)?;
+    /// Clear a developer's claim window and restore unrestricted claiming.
+    ///
+    /// # Access Control
+    /// Only the current admin can call this function.
+    ///
+    /// # Errors
+    /// - `Unauthorized` if caller is not the current admin.
+    ///
+    /// # Events
+    /// Emits `developer_claim_window_changed` with `enabled = false`.
+    pub fn clear_developer_claim_window(
+        env: Env,
+        caller: Address,
+        developer: Address,
+    ) -> Result<(), SettlementError> {
+        caller.require_auth();
+        Self::require_admin(env.clone(), caller)?;
 
-    let usdc_address = Self::get_usdc_token(env.clone())?;
-    let usdc = token::Client::new(&env, &usdc_address);
+        env.storage()
+            .persistent()
+            .remove(&StorageKey::DeveloperClaimWindow(developer.clone()));
 
-    if usdc.balance(&contract_address) < amount {
-        return Err(SettlementError::InsufficientContractBalance);
+        env.events().publish(
+            (
+                events::event_developer_claim_window_changed(&env),
+                developer.clone(),
+            ),
+            DeveloperClaimWindowChanged {
+                developer,
+                start_ts: 0,
+                end_ts: 0,
+                enabled: false,
+            },
+        );
+
+        Ok(())
     }
 
-    usdc.transfer(&contract_address, &recipient, &amount);
-
-    env.storage().persistent().set(
-        &StorageKey::DeveloperBalance(developer.clone()),
-        &new_balance,
-    );
-    env.storage().persistent().extend_ttl(
-        &StorageKey::DeveloperBalance(developer.clone()),
-        50000,
-        50000,
-    );
-
-    // Update daily withdrawal accumulator
-    let today = env.ledger().timestamp() / 86400;
-    let mut daily = env
-        .storage()
-        .persistent()
-        .get::<_, DailyWithdrawState>(&StorageKey::WithdrawalToday(developer.clone()))
-        .unwrap_or(DailyWithdrawState { day: today, amount: 0 });
-    if daily.day != today {
-        daily.day = today;
-        daily.amount = 0;
+    /// Return the configured claim window for a developer, if one exists.
+    pub fn get_developer_claim_window(
+        env: Env,
+        developer: Address,
+    ) -> Option<DeveloperClaimWindow> {
+        env.storage()
+            .persistent()
+            .get(&StorageKey::DeveloperClaimWindow(developer))
     }
-    daily.amount = daily.amount.saturating_add(amount);
-    env.storage()
-        .persistent()
-        .set(&StorageKey::WithdrawalToday(developer.clone()), &daily);
-    env.storage()
-        .persistent()
-        .extend_ttl(&StorageKey::WithdrawalToday(developer.clone()), 50000, 50000);
-
-    env.events().publish(
-        (events::event_developer_withdraw(&env), developer.clone()),
-        DeveloperWithdrawEvent {
-            developer,
-            amount,
-            remaining_balance: new_balance,
-            to: recipient,
-        },
-    );
-
-    Ok(())
-}
 
     /// Set the daily withdrawal cap for a developer (admin only).
     ///
@@ -613,13 +759,18 @@ pub fn withdraw_developer_balance(
         env.storage()
             .persistent()
             .set(&StorageKey::DailyWithdrawCap(developer.clone()), &cap);
-        env.storage()
-            .persistent()
-            .extend_ttl(&StorageKey::DailyWithdrawCap(developer.clone()), 50000, 50000);
+        env.storage().persistent().extend_ttl(
+            &StorageKey::DailyWithdrawCap(developer.clone()),
+            50000,
+            50000,
+        );
 
         env.events().publish(
             (events::event_daily_withdraw_cap_changed(&env), caller),
-            DailyWithdrawCapChanged { developer, new_cap: cap },
+            DailyWithdrawCapChanged {
+                developer,
+                new_cap: cap,
+            },
         );
     }
 
@@ -695,16 +846,15 @@ pub fn withdraw_developer_balance(
             .checked_add(amount)
             .unwrap_or_else(|| env.panic_with_error(SettlementError::DeveloperOverflow));
 
-        env.storage()
-            .persistent()
-            .set(&StorageKey::DeveloperBalance(developer.clone()), &new_balance);
-        env.storage()
-            .persistent()
-            .extend_ttl(
-                &StorageKey::DeveloperBalance(developer.clone()),
-                50000,
-                50000,
-            );
+        env.storage().persistent().set(
+            &StorageKey::DeveloperBalance(developer.clone()),
+            &new_balance,
+        );
+        env.storage().persistent().extend_ttl(
+            &StorageKey::DeveloperBalance(developer.clone()),
+            50000,
+            50000,
+        );
 
         let mut index: Vec<Address> = env
             .storage()
@@ -719,7 +869,10 @@ pub fn withdraw_developer_balance(
         }
 
         env.events().publish(
-            (Symbol::new(&env, "developer_force_credited"), developer.clone()),
+            (
+                Symbol::new(&env, "developer_force_credited"),
+                developer.clone(),
+            ),
             DeveloperForceCreditedEvent {
                 developer,
                 amount,
@@ -1063,10 +1216,8 @@ pub fn withdraw_developer_balance(
 
         inst.remove(&StorageKey::PendingAdmin);
 
-        env.events().publish(
-            (events::event_admin_cancelled(&env), current, pending),
-            (),
-        );
+        env.events()
+            .publish((events::event_admin_cancelled(&env), current, pending), ());
     }
 
     /// Propose a new vault address (admin only).
@@ -1168,6 +1319,28 @@ pub fn withdraw_developer_balance(
         }
     }
 
+    fn require_admin(env: Env, caller: Address) -> Result<(), SettlementError> {
+        let admin = Self::get_admin(env);
+        if caller != admin {
+            return Err(SettlementError::Unauthorized);
+        }
+        Ok(())
+    }
+
+    fn require_claim_window_open(env: &Env, developer: &Address) -> Result<(), SettlementError> {
+        let window: Option<DeveloperClaimWindow> = env
+            .storage()
+            .persistent()
+            .get(&StorageKey::DeveloperClaimWindow(developer.clone()));
+        if let Some(window) = window {
+            let now = env.ledger().timestamp();
+            if now < window.start_ts || now > window.end_ts {
+                return Err(SettlementError::ClaimWindowClosed);
+            }
+        }
+        Ok(())
+    }
+
     /// Admin-gated contract upgrade.
     ///
     /// Only the current admin may call. This will instruct the host to update
@@ -1181,7 +1354,8 @@ pub fn withdraw_developer_balance(
         }
 
         // Perform the on-chain upgrade via the deployer interface.
-        env.deployer().update_current_contract_wasm(new_wasm_hash.clone());
+        env.deployer()
+            .update_current_contract_wasm(new_wasm_hash.clone());
 
         // Persist the version marker for on-chain queries.
         env.storage()
@@ -1197,9 +1371,7 @@ pub fn withdraw_developer_balance(
     ///
     /// Returns `None` if no upgrade has been performed yet (initial deployment).
     pub fn get_version(env: Env) -> Option<BytesN<32>> {
-        env.storage()
-            .instance()
-            .get(&StorageKey::ContractVersion)
+        env.storage().instance().get(&StorageKey::ContractVersion)
     }
 
     /// Insert `addr` into `index` in sorted order (ascending by raw bytes).

--- a/contracts/settlement/src/test.rs
+++ b/contracts/settlement/src/test.rs
@@ -3,8 +3,8 @@ mod settlement_tests {
     extern crate std;
 
     use crate::{CalloraSettlement, CalloraSettlementClient, SettlementError, StorageKey};
-    use soroban_sdk::testutils::{Address as _, Ledger as _, Events as _};
-    use soroban_sdk::{token, Address, Env, Error, InvokeError, Symbol, BytesN, TryFromVal};
+    use soroban_sdk::testutils::{Address as _, Events as _, Ledger as _};
+    use soroban_sdk::{token, Address, BytesN, Env, Error, InvokeError, Symbol, TryFromVal};
 
     fn setup_contract() -> (Env, Address, Address, Address, Address) {
         let env = Env::default();
@@ -388,14 +388,15 @@ mod settlement_tests {
         let custodial = Address::generate(&env);
         let addr = env.register(CalloraSettlement, ());
         let client = CalloraSettlementClient::new(&env, &addr);
-        let (usdc_address, usdc_admin_client) = create_usdc(&env, &admin);
+        let (usdc_address, _, usdc_admin_client) = create_usdc(&env, &admin);
 
         client.init(&admin, &vault);
         client.set_usdc_token(&admin, &usdc_address);
         client.receive_payment(&vault, &150i128, &false, &Some(developer.clone()));
         usdc_admin_client.mint(&addr, &150i128);
 
-        let result = client.try_withdraw_developer_balance(&developer, &150i128, &Some(custodial.clone()));
+        let result =
+            client.try_withdraw_developer_balance(&developer, &150i128, &Some(custodial.clone()));
         assert!(result.is_ok());
         assert_eq!(client.get_developer_balance(&developer), 0i128);
         assert_eq!(
@@ -421,14 +422,15 @@ mod settlement_tests {
         let custodial = Address::generate(&env);
         let addr = env.register(CalloraSettlement, ());
         let client = CalloraSettlementClient::new(&env, &addr);
-        let (usdc_address, usdc_admin_client) = create_usdc(&env, &admin);
+        let (usdc_address, _, usdc_admin_client) = create_usdc(&env, &admin);
 
         client.init(&admin, &vault);
         client.set_usdc_token(&admin, &usdc_address);
         client.receive_payment(&vault, &200i128, &false, &Some(developer.clone()));
         usdc_admin_client.mint(&addr, &200i128);
 
-        let result = client.try_withdraw_developer_balance(&developer, &200i128, &Some(custodial.clone()));
+        let result =
+            client.try_withdraw_developer_balance(&developer, &200i128, &Some(custodial.clone()));
         assert!(result.is_ok());
 
         let events = env.events().all();
@@ -459,7 +461,7 @@ mod settlement_tests {
         let developer = Address::generate(&env);
         let addr = env.register(CalloraSettlement, ());
         let client = CalloraSettlementClient::new(&env, &addr);
-        let (usdc_address, usdc_admin_client) = create_usdc(&env, &admin);
+        let (usdc_address, _, usdc_admin_client) = create_usdc(&env, &admin);
 
         client.init(&admin, &vault);
         client.set_usdc_token(&admin, &usdc_address);
@@ -1796,18 +1798,8 @@ mod settlement_tests {
         let client = CalloraSettlementClient::new(&env, &addr);
         let developer = Address::generate(&env);
 
-        client.force_credit_developer(
-            &admin,
-            &developer,
-            &500i128,
-            &Symbol::new(&env, "first"),
-        );
-        client.force_credit_developer(
-            &admin,
-            &developer,
-            &300i128,
-            &Symbol::new(&env, "second"),
-        );
+        client.force_credit_developer(&admin, &developer, &500i128, &Symbol::new(&env, "first"));
+        client.force_credit_developer(&admin, &developer, &300i128, &Symbol::new(&env, "second"));
 
         assert_eq!(client.get_developer_balance(&developer), 800i128);
     }
@@ -1819,8 +1811,7 @@ mod settlement_tests {
         let developer = Address::generate(&env);
         let reason = Symbol::new(&env, "unauthorized_test");
 
-        let vault_result =
-            client.try_force_credit_developer(&vault, &developer, &100i128, &reason);
+        let vault_result = client.try_force_credit_developer(&vault, &developer, &100i128, &reason);
         assert!(is_error(vault_result, SettlementError::Unauthorized));
 
         let third_party_result =
@@ -1913,12 +1904,10 @@ mod settlement_tests {
         let developer = Address::generate(&env);
 
         env.as_contract(&addr, || {
-            env.storage()
-                .persistent()
-                .set(
-                    &crate::StorageKey::DeveloperBalance(developer.clone()),
-                    &i128::MAX,
-                );
+            env.storage().persistent().set(
+                &crate::StorageKey::DeveloperBalance(developer.clone()),
+                &i128::MAX,
+            );
         });
 
         let result = client.try_force_credit_developer(
@@ -2042,12 +2031,12 @@ mod settlement_tests {
         usdc_admin_client.mint(&addr, &1000i128);
 
         // First withdrawal of 300 should succeed (under 500 cap)
-        let result = client.try_withdraw_developer_balance(&developer, &300i128);
+        let result = client.try_withdraw_developer_balance(&developer, &300i128, &None);
         assert!(result.is_ok());
         assert_eq!(client.get_developer_balance(&developer), 700i128);
 
         // Second withdrawal of 300 would push total to 600 (over 500 cap)
-        let result = client.try_withdraw_developer_balance(&developer, &300i128);
+        let result = client.try_withdraw_developer_balance(&developer, &300i128, &None);
         assert!(is_error(result, SettlementError::DailyWithdrawCapExceeded));
         assert_eq!(client.get_developer_balance(&developer), 700i128);
     }
@@ -2070,16 +2059,22 @@ mod settlement_tests {
         usdc_admin_client.mint(&addr, &1000i128);
 
         // Withdraw 200 + 200 = 400, still under 500
-        assert!(client.try_withdraw_developer_balance(&developer, &200i128).is_ok());
-        assert!(client.try_withdraw_developer_balance(&developer, &200i128).is_ok());
+        assert!(client
+            .try_withdraw_developer_balance(&developer, &200i128, &None)
+            .is_ok());
+        assert!(client
+            .try_withdraw_developer_balance(&developer, &200i128, &None)
+            .is_ok());
         assert_eq!(client.get_developer_balance(&developer), 600i128);
 
         // Third withdrawal of 100 would push to 500 (exact cap — allowed)
-        assert!(client.try_withdraw_developer_balance(&developer, &100i128).is_ok());
+        assert!(client
+            .try_withdraw_developer_balance(&developer, &100i128, &None)
+            .is_ok());
         assert_eq!(client.get_developer_balance(&developer), 500i128);
 
         // Fourth withdrawal of 1 would exceed cap
-        let result = client.try_withdraw_developer_balance(&developer, &1i128);
+        let result = client.try_withdraw_developer_balance(&developer, &1i128, &None);
         assert!(is_error(result, SettlementError::DailyWithdrawCapExceeded));
     }
 
@@ -2101,7 +2096,9 @@ mod settlement_tests {
         client.receive_payment(&vault, &1000i128, &false, &Some(developer.clone()));
         usdc_admin_client.mint(&addr, &1000i128);
 
-        assert!(client.try_withdraw_developer_balance(&developer, &1000i128).is_ok());
+        assert!(client
+            .try_withdraw_developer_balance(&developer, &1000i128, &None)
+            .is_ok());
         assert_eq!(client.get_developer_balance(&developer), 0i128);
     }
 
@@ -2122,7 +2119,9 @@ mod settlement_tests {
         client.receive_payment(&vault, &1000i128, &false, &Some(developer.clone()));
         usdc_admin_client.mint(&addr, &1000i128);
 
-        assert!(client.try_withdraw_developer_balance(&developer, &1000i128).is_ok());
+        assert!(client
+            .try_withdraw_developer_balance(&developer, &1000i128, &None)
+            .is_ok());
         assert_eq!(client.get_developer_balance(&developer), 0i128);
     }
 
@@ -2146,11 +2145,13 @@ mod settlement_tests {
         usdc_admin_client.mint(&addr, &1000i128);
 
         // Withdraw 400 on day 0
-        assert!(client.try_withdraw_developer_balance(&developer, &400i128).is_ok());
+        assert!(client
+            .try_withdraw_developer_balance(&developer, &400i128, &None)
+            .is_ok());
         assert_eq!(client.get_developer_balance(&developer), 600i128);
 
         // Another 200 would exceed the 500 cap
-        let result = client.try_withdraw_developer_balance(&developer, &200i128);
+        let result = client.try_withdraw_developer_balance(&developer, &200i128, &None);
         assert!(is_error(result, SettlementError::DailyWithdrawCapExceeded));
 
         // Advance to day 1
@@ -2159,7 +2160,9 @@ mod settlement_tests {
         usdc_admin_client.mint(&addr, &500i128);
 
         // Withdrawal should succeed now (cap resets)
-        assert!(client.try_withdraw_developer_balance(&developer, &500i128).is_ok());
+        assert!(client
+            .try_withdraw_developer_balance(&developer, &500i128, &None)
+            .is_ok());
         assert_eq!(client.get_developer_balance(&developer), 100i128);
     }
 
@@ -2252,10 +2255,10 @@ mod settlement_tests {
 
         assert_eq!(client.get_withdrawal_today(&developer), 0i128);
 
-        client.withdraw_developer_balance(&developer, &300i128);
+        client.withdraw_developer_balance(&developer, &300i128, &None);
         assert_eq!(client.get_withdrawal_today(&developer), 300i128);
 
-        client.withdraw_developer_balance(&developer, &200i128);
+        client.withdraw_developer_balance(&developer, &200i128, &None);
         assert_eq!(client.get_withdrawal_today(&developer), 500i128);
     }
 
@@ -2281,15 +2284,251 @@ mod settlement_tests {
         usdc_admin_client.mint(&addr, &1500i128);
 
         // dev1 hits cap at 500
-        assert!(client.try_withdraw_developer_balance(&dev1, &300i128).is_ok());
+        assert!(client
+            .try_withdraw_developer_balance(&dev1, &300i128, &None)
+            .is_ok());
         // Still within cap (300 < 500)
-        assert!(client.try_withdraw_developer_balance(&dev1, &200i128).is_ok());
+        assert!(client
+            .try_withdraw_developer_balance(&dev1, &200i128, &None)
+            .is_ok());
         // Exceeds cap (300 + 200 + 1 > 500)
-        let result = client.try_withdraw_developer_balance(&dev1, &1i128);
+        let result = client.try_withdraw_developer_balance(&dev1, &1i128, &None);
         assert!(is_error(result, SettlementError::DailyWithdrawCapExceeded));
 
         // dev2 can still withdraw (no cap)
-        assert!(client.try_withdraw_developer_balance(&dev2, &500i128).is_ok());
+        assert!(client
+            .try_withdraw_developer_balance(&dev2, &500i128, &None)
+            .is_ok());
+    }
+
+    // ── developer claim window tests ────────────────────────────────────────
+
+    #[test]
+    fn test_claim_window_blocks_withdraw_before_start() {
+        let env = Env::default();
+        env.mock_all_auths();
+        env.ledger().set_timestamp(99);
+        let admin = Address::generate(&env);
+        let vault = Address::generate(&env);
+        let developer = Address::generate(&env);
+        let addr = env.register(CalloraSettlement, ());
+        let client = CalloraSettlementClient::new(&env, &addr);
+        let (usdc_address, _, usdc_admin_client) = create_usdc(&env, &admin);
+
+        client.init(&admin, &vault);
+        client.set_usdc_token(&admin, &usdc_address);
+        client
+            .try_set_developer_claim_window(&admin, &developer, &100u64, &200u64)
+            .unwrap()
+            .unwrap();
+        client.receive_payment(&vault, &100i128, &false, &Some(developer.clone()));
+        usdc_admin_client.mint(&addr, &100i128);
+
+        let result = client.try_withdraw_developer_balance(&developer, &100i128, &None);
+        assert!(is_error(result, SettlementError::ClaimWindowClosed));
+        assert_eq!(client.get_developer_balance(&developer), 100i128);
+        assert_eq!(
+            token::Client::new(&env, &usdc_address).balance(&developer),
+            0i128
+        );
+    }
+
+    #[test]
+    fn test_claim_window_allows_withdraw_at_start_and_end() {
+        let env = Env::default();
+        env.mock_all_auths();
+        env.ledger().set_timestamp(100);
+        let admin = Address::generate(&env);
+        let vault = Address::generate(&env);
+        let developer = Address::generate(&env);
+        let addr = env.register(CalloraSettlement, ());
+        let client = CalloraSettlementClient::new(&env, &addr);
+        let (usdc_address, _, usdc_admin_client) = create_usdc(&env, &admin);
+
+        client.init(&admin, &vault);
+        client.set_usdc_token(&admin, &usdc_address);
+        client
+            .try_set_developer_claim_window(&admin, &developer, &100u64, &200u64)
+            .unwrap()
+            .unwrap();
+        client.receive_payment(&vault, &200i128, &false, &Some(developer.clone()));
+        usdc_admin_client.mint(&addr, &200i128);
+
+        assert!(client
+            .try_withdraw_developer_balance(&developer, &50i128, &None)
+            .is_ok());
+        assert_eq!(client.get_developer_balance(&developer), 150i128);
+
+        env.ledger().set_timestamp(200);
+        assert!(client
+            .try_withdraw_developer_balance(&developer, &150i128, &None)
+            .is_ok());
+        assert_eq!(client.get_developer_balance(&developer), 0i128);
+        assert_eq!(
+            token::Client::new(&env, &usdc_address).balance(&developer),
+            200i128
+        );
+    }
+
+    #[test]
+    fn test_claim_window_blocks_withdraw_after_end() {
+        let env = Env::default();
+        env.mock_all_auths();
+        env.ledger().set_timestamp(201);
+        let admin = Address::generate(&env);
+        let vault = Address::generate(&env);
+        let developer = Address::generate(&env);
+        let addr = env.register(CalloraSettlement, ());
+        let client = CalloraSettlementClient::new(&env, &addr);
+        let (usdc_address, _, usdc_admin_client) = create_usdc(&env, &admin);
+
+        client.init(&admin, &vault);
+        client.set_usdc_token(&admin, &usdc_address);
+        client
+            .try_set_developer_claim_window(&admin, &developer, &100u64, &200u64)
+            .unwrap()
+            .unwrap();
+        client.receive_payment(&vault, &100i128, &false, &Some(developer.clone()));
+        usdc_admin_client.mint(&addr, &100i128);
+
+        let result = client.try_withdraw_developer_balance(&developer, &100i128, &None);
+        assert!(is_error(result, SettlementError::ClaimWindowClosed));
+        assert_eq!(client.get_developer_balance(&developer), 100i128);
+    }
+
+    #[test]
+    fn test_claim_window_clear_restores_unrestricted_withdraw() {
+        let env = Env::default();
+        env.mock_all_auths();
+        env.ledger().set_timestamp(201);
+        let admin = Address::generate(&env);
+        let vault = Address::generate(&env);
+        let developer = Address::generate(&env);
+        let addr = env.register(CalloraSettlement, ());
+        let client = CalloraSettlementClient::new(&env, &addr);
+        let (usdc_address, _, usdc_admin_client) = create_usdc(&env, &admin);
+
+        client.init(&admin, &vault);
+        client.set_usdc_token(&admin, &usdc_address);
+        client
+            .try_set_developer_claim_window(&admin, &developer, &100u64, &200u64)
+            .unwrap()
+            .unwrap();
+        assert!(client.get_developer_claim_window(&developer).is_some());
+
+        client
+            .try_clear_developer_claim_window(&admin, &developer)
+            .unwrap()
+            .unwrap();
+        assert!(client.get_developer_claim_window(&developer).is_none());
+
+        client.receive_payment(&vault, &100i128, &false, &Some(developer.clone()));
+        usdc_admin_client.mint(&addr, &100i128);
+
+        assert!(client
+            .try_withdraw_developer_balance(&developer, &100i128, &None)
+            .is_ok());
+        assert_eq!(client.get_developer_balance(&developer), 0i128);
+    }
+
+    #[test]
+    fn test_set_claim_window_rejects_invalid_range() {
+        let (env, addr, admin, _vault, _third_party) = setup_contract();
+        let client = CalloraSettlementClient::new(&env, &addr);
+        let developer = Address::generate(&env);
+
+        let result = client.try_set_developer_claim_window(&admin, &developer, &200u64, &100u64);
+
+        assert!(is_error(result, SettlementError::InvalidClaimWindow));
+        assert!(client.get_developer_claim_window(&developer).is_none());
+    }
+
+    #[test]
+    fn test_set_and_clear_claim_window_unauthorized() {
+        let (env, addr, _admin, vault, third_party) = setup_contract();
+        let client = CalloraSettlementClient::new(&env, &addr);
+        let developer = Address::generate(&env);
+
+        let result = client.try_set_developer_claim_window(&vault, &developer, &100u64, &200u64);
+        assert!(is_error(result, SettlementError::Unauthorized));
+
+        let result =
+            client.try_set_developer_claim_window(&third_party, &developer, &100u64, &200u64);
+        assert!(is_error(result, SettlementError::Unauthorized));
+
+        let result = client.try_clear_developer_claim_window(&third_party, &developer);
+        assert!(is_error(result, SettlementError::Unauthorized));
+    }
+
+    #[test]
+    fn test_claim_window_is_per_developer() {
+        let env = Env::default();
+        env.mock_all_auths();
+        env.ledger().set_timestamp(201);
+        let admin = Address::generate(&env);
+        let vault = Address::generate(&env);
+        let restricted = Address::generate(&env);
+        let unrestricted = Address::generate(&env);
+        let addr = env.register(CalloraSettlement, ());
+        let client = CalloraSettlementClient::new(&env, &addr);
+        let (usdc_address, _, usdc_admin_client) = create_usdc(&env, &admin);
+
+        client.init(&admin, &vault);
+        client.set_usdc_token(&admin, &usdc_address);
+        client
+            .try_set_developer_claim_window(&admin, &restricted, &100u64, &200u64)
+            .unwrap()
+            .unwrap();
+        client.receive_payment(&vault, &100i128, &false, &Some(restricted.clone()));
+        client.receive_payment(&vault, &100i128, &false, &Some(unrestricted.clone()));
+        usdc_admin_client.mint(&addr, &200i128);
+
+        let result = client.try_withdraw_developer_balance(&restricted, &100i128, &None);
+        assert!(is_error(result, SettlementError::ClaimWindowClosed));
+        assert!(client
+            .try_withdraw_developer_balance(&unrestricted, &100i128, &None)
+            .is_ok());
+        assert_eq!(client.get_developer_balance(&restricted), 100i128);
+        assert_eq!(client.get_developer_balance(&unrestricted), 0i128);
+    }
+
+    #[test]
+    fn test_set_claim_window_emits_event_and_getter_returns_window() {
+        use soroban_sdk::testutils::Events as _;
+        use soroban_sdk::{IntoVal, Symbol};
+
+        let (env, addr, admin, _vault, _third_party) = setup_contract();
+        let client = CalloraSettlementClient::new(&env, &addr);
+        let developer = Address::generate(&env);
+
+        client
+            .try_set_developer_claim_window(&admin, &developer, &100u64, &200u64)
+            .unwrap()
+            .unwrap();
+
+        let window = client.get_developer_claim_window(&developer).unwrap();
+        assert_eq!(window.start_ts, 100u64);
+        assert_eq!(window.end_ts, 200u64);
+
+        let events = env.events().all();
+        let ev = events
+            .iter()
+            .find(|e| {
+                !e.1.is_empty() && {
+                    let t: Symbol = e.1.get(0).unwrap().into_val(&env);
+                    t == Symbol::new(&env, "claim_window_changed")
+                }
+            })
+            .expect("expected claim_window_changed event");
+
+        let topic1: Address = ev.1.get(1).unwrap().into_val(&env);
+        assert_eq!(topic1, developer);
+
+        let data: crate::DeveloperClaimWindowChanged = ev.2.into_val(&env);
+        assert_eq!(data.developer, developer);
+        assert_eq!(data.start_ts, 100u64);
+        assert_eq!(data.end_ts, 200u64);
+        assert!(data.enabled);
     }
 
     // ── cursor-based pagination tests ────────────────────────────────────────
@@ -2316,10 +2555,17 @@ mod settlement_tests {
 
         let (page, next) = client.get_developer_balances_cursor(&admin, &None, &2u32);
 
-        assert_eq!(page.len(), 2, "first page must contain exactly limit records");
+        assert_eq!(
+            page.len(),
+            2,
+            "first page must contain exactly limit records"
+        );
         // next_cursor must point at the last record on this page so the caller
         // can continue from there.
-        assert!(next.is_some(), "next_cursor must be Some when more records exist");
+        assert!(
+            next.is_some(),
+            "next_cursor must be Some when more records exist"
+        );
         assert_eq!(
             next.as_ref().unwrap(),
             &page.get(1).unwrap().address,
@@ -2352,14 +2598,22 @@ mod settlement_tests {
 
         // Page 2 — use next_cursor from page 1
         let (page2, next2) = client.get_developer_balances_cursor(&admin, &next1, &2u32);
-        assert_eq!(page2.len(), 1, "last page must contain the remaining record");
+        assert_eq!(
+            page2.len(),
+            1,
+            "last page must contain the remaining record"
+        );
         // Reached the end of the index.
         assert!(next2.is_none(), "next_cursor must be None on the last page");
 
         // Together the two pages must cover all three developers exactly once.
         let mut all_addrs: std::vec::Vec<Address> = std::vec::Vec::new();
-        for r in page1.iter() { all_addrs.push(r.address.clone()); }
-        for r in page2.iter() { all_addrs.push(r.address.clone()); }
+        for r in page1.iter() {
+            all_addrs.push(r.address.clone());
+        }
+        for r in page2.iter() {
+            all_addrs.push(r.address.clone());
+        }
         assert_eq!(all_addrs.len(), 3);
         assert!(all_addrs.contains(&dev1));
         assert!(all_addrs.contains(&dev2));
@@ -2425,8 +2679,7 @@ mod settlement_tests {
         client.receive_payment(&vault, &999i128, &false, &Some(first_addr.clone()));
 
         // Continue pagination from the saved cursor.
-        let (page2, _) =
-            client.get_developer_balances_cursor(&admin, &cursor_after_first, &10u32);
+        let (page2, _) = client.get_developer_balances_cursor(&admin, &cursor_after_first, &10u32);
         assert_eq!(page2.len(), 2, "two records must remain after the cursor");
 
         // The first developer must not appear again in page2.
@@ -2458,8 +2711,11 @@ mod settlement_tests {
         }
 
         // Request more than the cap.
-        let (page, _) =
-            client.get_developer_balances_cursor(&admin, &None, &(MAX_DEVELOPER_BALANCES_PAGE_SIZE + 50));
+        let (page, _) = client.get_developer_balances_cursor(
+            &admin,
+            &None,
+            &(MAX_DEVELOPER_BALANCES_PAGE_SIZE + 50),
+        );
         assert_eq!(
             page.len(),
             MAX_DEVELOPER_BALANCES_PAGE_SIZE,
@@ -2547,10 +2803,16 @@ mod settlement_tests {
                 cursor_pages.push(r.address.clone());
             }
             next = nc;
-            if next.is_none() { break; }
+            if next.is_none() {
+                break;
+            }
         }
 
-        assert_eq!(cursor_pages.len(), 5, "all developers must be returned across pages");
+        assert_eq!(
+            cursor_pages.len(),
+            5,
+            "all developers must be returned across pages"
+        );
 
         // The cursor pages must be in sorted order (ascending by address).
         devs.sort();

--- a/docs/ACCESS_CONTROL.md
+++ b/docs/ACCESS_CONTROL.md
@@ -111,11 +111,14 @@ The Callora Settlement contract tracks individual developer balances and global 
 | `propose_vault` | ✅ | ❌ | ❌ | ❌ |
 | `accept_vault` | ✅ | ✅ | ❌ | ❌ |
 | `set_vault` (alias of `propose_vault`) | ✅ | ❌ | ❌ | ❌ |
+| `set_developer_claim_window` | ✅ | ❌ | ❌ | ❌ |
+| `clear_developer_claim_window` | ✅ | ❌ | ❌ | ❌ |
 | `get_all_developer_balances` | ✅ | ❌ | ❌ | ❌ |
 
 ### Security Model
 - **Two-Step Admin Rotation**: Prevents accidental loss of control by requiring the nominee to explicitly accept the role.
 - **Two-Step Vault Rotation**: Prevents accidentally misrouting settlement credits by requiring the proposed vault to accept (or the admin to finalize).
+- **Per-Developer Claim Windows**: Admins may configure inclusive ledger timestamp windows that restrict when each developer can claim accrued settlement balance. Developers without a configured window remain unrestricted.
 - **Restricted Views**: Sensitive batch queries like `get_all_developer_balances` are restricted to the admin to prevent unnecessary exposure of the full ledger via the contract interface.
 - **Cancellation Safety**: The admin can invoke `cancel_admin_transfer` to clear a mistaken nomination.
 

--- a/docs/interfaces/settlement.json
+++ b/docs/interfaces/settlement.json
@@ -20,7 +20,11 @@
       { "code": 10, "name": "InsufficientDeveloperBalance", "when": "Developer balance is less than withdrawal amount." },
       { "code": 11, "name": "DeveloperBalanceUnderflow",    "when": "Developer balance subtraction would overflow." },
       { "code": 12, "name": "InsufficientContractBalance",  "when": "Settlement contract lacks on-ledger USDC." },
-      { "code": 13, "name": "GasExhaustionRisk",            "when": "Index exceeds 100 entries; use get_developer_balances_cursor instead of get_all_developer_balances." }
+      { "code": 13, "name": "DailyWithdrawCapExceeded",     "when": "Developer's daily withdrawal cap would be exceeded." },
+      { "code": 14, "name": "GasExhaustionRisk",            "when": "Index exceeds 100 entries; use get_developer_balances_cursor instead of get_all_developer_balances." },
+      { "code": 15, "name": "ReasonTooLong",                "when": "Reason Symbol exceeds maximum allowed length." },
+      { "code": 16, "name": "InvalidClaimWindow",           "when": "Claim window end timestamp is before the start timestamp." },
+      { "code": 17, "name": "ClaimWindowClosed",            "when": "A developer attempts to claim outside their configured claim window." }
     ]
   },
 
@@ -54,6 +58,22 @@
         "developer":   { "type": "Address", "description": "Developer address that was credited." },
         "amount":      { "type": "i128",    "description": "Amount credited." },
         "new_balance": { "type": "i128",    "description": "Developer's balance after crediting." }
+      }
+    },
+    "DeveloperClaimWindow": {
+      "description": "Inclusive ledger timestamp range during which a developer may claim accrued balance.",
+      "fields": {
+        "start_ts": { "type": "u64", "description": "First ledger timestamp at which claims are allowed." },
+        "end_ts":   { "type": "u64", "description": "Last ledger timestamp at which claims are allowed." }
+      }
+    },
+    "DeveloperClaimWindowChanged": {
+      "description": "Event payload emitted when an admin sets or clears a developer claim window.",
+      "fields": {
+        "developer": { "type": "Address", "description": "Developer whose claim window changed." },
+        "start_ts":  { "type": "u64",     "description": "Configured start timestamp, or 0 when cleared." },
+        "end_ts":    { "type": "u64",     "description": "Configured end timestamp, or 0 when cleared." },
+        "enabled":   { "type": "bool",    "description": "True when a window is set; false when cleared." }
       }
     }
   },
@@ -122,6 +142,79 @@
     },
 
     {
+      "name": "withdraw_developer_balance",
+      "description": "Developer-authorized claim of accrued balance. If a claim window is configured for the developer, the current ledger timestamp must be within the inclusive [start_ts, end_ts] range.",
+      "access": "developer",
+      "params": [
+        { "name": "developer", "type": "Address",        "optional": false, "description": "Developer address; must authorize." },
+        { "name": "amount",    "type": "i128",           "optional": false, "description": "Amount to withdraw; must be > 0 and <= tracked developer balance." },
+        { "name": "to",        "type": "Address | null", "optional": true,  "description": "Recipient address. Null defaults to developer." }
+      ],
+      "returns": "Result<void, SettlementError>",
+      "errors": [
+        { "code": 4,  "name": "AmountNotPositive",            "when": "amount <= 0." },
+        { "code": 9,  "name": "UsdcTokenNotConfigured",       "when": "USDC token address is not configured." },
+        { "code": 10, "name": "InsufficientDeveloperBalance", "when": "Developer tracked balance is below amount." },
+        { "code": 11, "name": "DeveloperBalanceUnderflow",    "when": "Balance subtraction would underflow." },
+        { "code": 12, "name": "InsufficientContractBalance",  "when": "Settlement contract lacks on-ledger USDC." },
+        { "code": 13, "name": "DailyWithdrawCapExceeded",     "when": "Withdrawal would exceed the developer's daily cap." },
+        { "code": 17, "name": "ClaimWindowClosed",            "when": "Current ledger timestamp is outside the developer's configured claim window." }
+      ],
+      "events": [
+        { "topics": ["\"developer_withdraw\"", "developer"], "data": "DeveloperWithdrawEvent" }
+      ]
+    },
+
+    {
+      "name": "set_developer_claim_window",
+      "description": "Configure an inclusive claim window for a developer. Developers without a configured window remain claimable at any time.",
+      "access": "admin",
+      "params": [
+        { "name": "caller",    "type": "Address", "optional": false, "description": "Must be the current admin; must authorize." },
+        { "name": "developer", "type": "Address", "optional": false, "description": "Developer whose claim window is being configured." },
+        { "name": "start_ts",  "type": "u64",     "optional": false, "description": "First allowed ledger timestamp." },
+        { "name": "end_ts",    "type": "u64",     "optional": false, "description": "Last allowed ledger timestamp." }
+      ],
+      "returns": "Result<void, SettlementError>",
+      "errors": [
+        { "code": 3,  "name": "Unauthorized",       "when": "Caller is not the current admin." },
+        { "code": 16, "name": "InvalidClaimWindow", "when": "end_ts < start_ts." }
+      ],
+      "events": [
+        { "topics": ["\"claim_window_changed\"", "developer"], "data": "DeveloperClaimWindowChanged { enabled: true }" }
+      ]
+    },
+
+    {
+      "name": "clear_developer_claim_window",
+      "description": "Remove a developer's claim window and restore unrestricted developer claims.",
+      "access": "admin",
+      "params": [
+        { "name": "caller",    "type": "Address", "optional": false, "description": "Must be the current admin; must authorize." },
+        { "name": "developer", "type": "Address", "optional": false, "description": "Developer whose claim window is being cleared." }
+      ],
+      "returns": "Result<void, SettlementError>",
+      "errors": [
+        { "code": 3, "name": "Unauthorized", "when": "Caller is not the current admin." }
+      ],
+      "events": [
+        { "topics": ["\"claim_window_changed\"", "developer"], "data": "DeveloperClaimWindowChanged { enabled: false }" }
+      ]
+    },
+
+    {
+      "name": "get_developer_claim_window",
+      "description": "Return the configured claim window for a developer, or null when claims are unrestricted.",
+      "access": "any",
+      "params": [
+        { "name": "developer", "type": "Address", "optional": false, "description": "Developer address to query." }
+      ],
+      "returns": "DeveloperClaimWindow | null",
+      "errors": [],
+      "events": []
+    },
+
+    {
       "name": "get_all_developer_balances",
       "description": "Return a list of all developer balances. Admin only. Rejects the call with GasExhaustionRisk when the developer index exceeds 100 entries — use get_developer_balances_cursor for larger sets. The index is maintained in deterministic ascending order by address bytes.",
       "access": "admin",
@@ -132,7 +225,7 @@
       "errors": [
         { "code": 1,  "name": "NotInitialized",   "when": "Called before init." },
         { "code": 3,  "name": "Unauthorized",      "when": "Caller is not the admin." },
-        { "code": 13, "name": "GasExhaustionRisk", "when": "Developer index has more than 100 entries." }
+        { "code": 14, "name": "GasExhaustionRisk", "when": "Developer index has more than 100 entries." }
       ],
       "events": []
     },


### PR DESCRIPTION


  ## Summary
  - Add admin-configurable per-developer settlement claim windows.
  - Enforce claim windows during `withdraw_developer_balance`.
  - Add focused tests for before/start/end/after window behavior, clearing windows, unauthorized access, invalid ranges, per-developer isolation,
  and event/getter behavior.
  - Document the new API and access-control changes.

  Closes #525 