### PR TITLE
feat: per-contract version() view returning semver string

### DIFF
--- a/contracts/revenue_pool/src/lib.rs
+++ b/contracts/revenue_pool/src/lib.rs
@@ -152,6 +152,15 @@ impl RevenuePool {
             .expect("revenue pool not initialized")
     }
 
+    /// Return the contract semver string.
+    ///
+    /// Read-only view returning the Cargo package version embedded at
+    /// compile time, enabling off-chain tooling to detect capability
+    /// deltas after upgrades.
+    pub fn version(_env: Env) -> soroban_sdk::String {
+        soroban_sdk::String::from_str(&_env, env!("CARGO_PKG_VERSION"))
+    }
+
     /// Initiate replacement of the current admin. Only the existing admin may call this.
     /// The new admin must call `claim_admin` to complete the transfer.
     ///

--- a/contracts/revenue_pool/src/test.rs
+++ b/contracts/revenue_pool/src/test.rs
@@ -1569,3 +1569,20 @@ fn deposit_yield_rejects_zero_amount() {
     client.init(&admin, &usdc_address);
     client.deposit_yield(&admin, &0, &Symbol::new(&env, "fees"));
 }
+
+// ---------------------------------------------------------------------------
+// version
+// ---------------------------------------------------------------------------
+
+#[test]
+fn version_returns_semver_string() {
+    let env = Env::default();
+    let admin = Address::generate(&env);
+    let usdc = env.register_stellar_asset_contract_v2(admin.clone());
+    let contract = env.register(CalloraRevenuePool, ());
+    let client = CalloraRevenuePoolClient::new(&env, &contract);
+    env.mock_all_auths();
+    client.init(&admin, &usdc.address());
+    let v = client.version();
+    assert_eq!(v, String::from_str(&env, env!("CARGO_PKG_VERSION")));
+}

--- a/contracts/settlement/src/lib.rs
+++ b/contracts/settlement/src/lib.rs
@@ -449,6 +449,15 @@ impl CalloraSettlement {
             .unwrap_or_else(|| env.panic_with_error(SettlementError::NotInitialized))
     }
 
+    /// Return the contract semver string.
+    ///
+    /// Read-only view returning the Cargo package version embedded at
+    /// compile time, enabling off-chain tooling to detect capability
+    /// deltas after upgrades.
+    pub fn version(_env: Env) -> soroban_sdk::String {
+        soroban_sdk::String::from_str(&_env, env!("CARGO_PKG_VERSION"))
+    }
+
     /// Get registered vault address
     pub fn get_vault(env: Env) -> Address {
         env.storage()

--- a/contracts/settlement/src/test_views.rs
+++ b/contracts/settlement/src/test_views.rs
@@ -247,3 +247,20 @@ fn test_pagination_invalid_cursor() {
     assert!(next_cursor.is_none());
 }
 
+
+// ---------------------------------------------------------------------------
+// version
+// ---------------------------------------------------------------------------
+
+#[test]
+fn version_returns_semver_string() {
+    let env = Env::default();
+    let admin = Address::generate(&env);
+    let vault_addr = Address::generate(&env);
+    let contract = env.register(CalloraSettlement, ());
+    let client = CalloraSettlementClient::new(&env, &contract);
+    env.mock_all_auths();
+    client.init(&admin, &vault_addr);
+    let v = client.version();
+    assert_eq!(v, String::from_str(&env, env!("CARGO_PKG_VERSION")));
+}

--- a/contracts/vault/src/lib.rs
+++ b/contracts/vault/src/lib.rs
@@ -435,6 +435,21 @@ impl CalloraVault {
             .unwrap_or(false)
     }
 
+    /// Return the contract semver string.
+    ///
+    /// This is a read-only view that returns the Cargo package version
+    /// embedded at compile time, enabling off-chain tooling to detect
+    /// capability deltas after upgrades.
+    ///
+    /// # Example
+    ///
+    /// ```text
+    /// version() => "0.0.1"
+    /// ```
+    pub fn version(_env: Env) -> soroban_sdk::String {
+        soroban_sdk::String::from_str(&_env, env!("CARGO_PKG_VERSION"))
+    }
+
     /// Return the current authorized-caller rotation nonce.
     ///
     /// Returns `0` before the first `set_authorized_caller` call.

--- a/contracts/vault/src/test_views.rs
+++ b/contracts/vault/src/test_views.rs
@@ -377,3 +377,15 @@ fn remove_price_removes_index_entry() {
     assert_eq!(client.get_price(&offer), None);
     assert_eq!(client.list_prices(&0, &10).len(), 0);
 }
+
+// ---------------------------------------------------------------------------
+// version
+// ---------------------------------------------------------------------------
+
+#[test]
+fn version_returns_semver_string() {
+    let env = Env::default();
+    let (_owner, client, _) = setup(&env);
+    let v = client.version();
+    assert_eq!(v, String::from_str(&env, env!("CARGO_PKG_VERSION")));
+}


### PR DESCRIPTION
## Summary
Implements `version()` read-only view on all three contracts returning the Cargo semver string embedded at compile time via `env!("CARGO_PKG_VERSION")`.

## Changes
- `contracts/vault/src/lib.rs`: added `version()` → returns "0.0.1"
- `contracts/settlement/src/lib.rs`: added `version()` → returns "0.1.0"
- `contracts/revenue_pool/src/lib.rs`: added `version()` → returns "0.0.1"
- Tests added to each contract's test suite

## Testing
- `version_returns_semver_string` test in vault, settlement, revenue_pool test suites
- Compile-time version embedding ensures accuracy after upgrades

Closes #562