### PR TITLE
feat: per-token vault reserve cap

### DIFF
--- a/contracts/vault/src/events.rs
+++ b/contracts/vault/src/events.rs
@@ -220,6 +220,14 @@ pub fn event_admin_broadcast(env: &Env) -> Symbol {
     Symbol::new(env, "admin_broadcast")
 }
 
+/// Returns the Symbol for the `"reserve_cap_set"` event topic.
+///
+/// Emitted when the owner sets or updates the reserve cap for a token.
+/// Data payload: `(prev_cap: Option<i128>, new_cap: i128)`.
+pub fn event_reserve_cap_set(env: &Env) -> Symbol {
+    Symbol::new(env, "reserve_cap_set")
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/contracts/vault/src/lib.rs
+++ b/contracts/vault/src/lib.rs
@@ -115,6 +115,8 @@ pub enum VaultError {
     Slippage = 35,
     /// Rate limit exceeded for the developer (code 36).
     RateLimited = 36,
+    /// Deposit would exceed the configured per-token reserve cap (code 37).
+    ExceedsReserveCap = 37,
 }
 
 #[contracttype]
@@ -204,6 +206,8 @@ pub enum StorageKey {
     DeveloperConfig(Address),
     /// Current rate limit state for a developer.
     DeveloperState(Address),
+    /// Maximum total balance the vault may hold for a given token.
+    ReserveCap(Address),
 }
 
 /// Settlement contract client for crediting the global pool.
@@ -792,6 +796,9 @@ impl CalloraVault {
             .instance()
             .get(&StorageKey::UsdcToken)
             .ok_or(VaultError::NotInitialized)?;
+
+        // Reserve cap guard — reject if deposit would push balance past the cap.
+        limits::check(&env, &usdc_addr, meta.balance, amount)?;
 
         // ── Effects ───────────────────────────────────────────────────────
         meta.balance = meta
@@ -1783,7 +1790,7 @@ impl CalloraVault {
     ) -> Result<(), VaultError> {
         caller.require_auth();
         Self::require_owner(env.clone(), caller.clone())?;
-        
+
         let config = crate::rate_limit::RateLimitConfig {
             capacity,
             refill_rate,
@@ -1791,10 +1798,53 @@ impl CalloraVault {
         crate::rate_limit::set_config(&env, &developer, &config);
         Ok(())
     }
+
+    /// Set or update the reserve cap for a token (owner only).
+    ///
+    /// The reserve cap is the maximum total balance the vault may hold for
+    /// `token`.  Any `deposit` call that would push the balance beyond `cap`
+    /// is rejected with [`VaultError::ExceedsReserveCap`].
+    ///
+    /// Pass `i128::MAX` to remove the effective cap (restore unlimited deposits).
+    ///
+    /// # Parameters
+    /// - `caller` — must be the vault owner.
+    /// - `token` — token contract address the cap applies to.
+    /// - `cap` — maximum balance in token stroops; must be > 0.
+    ///
+    /// # Errors
+    /// - [`VaultError::Unauthorized`] — `caller` is not the owner.
+    /// - [`VaultError::AmountNotPositive`] — `cap <= 0`.
+    pub fn set_reserve_cap(
+        env: Env,
+        caller: Address,
+        token: Address,
+        cap: i128,
+    ) -> Result<(), VaultError> {
+        caller.require_auth();
+        Self::require_owner(env.clone(), caller.clone())?;
+        if cap <= 0 {
+            return Err(VaultError::AmountNotPositive);
+        }
+        let prev = limits::set(&env, &token, cap);
+        env.events().publish(
+            (events::event_reserve_cap_set(&env), caller, token),
+            (prev, cap),
+        );
+        Ok(())
+    }
+
+    /// Return the reserve cap for `token`.
+    ///
+    /// Returns `i128::MAX` when no cap has been configured (effectively unlimited).
+    pub fn get_reserve_cap(env: Env, token: Address) -> i128 {
+        limits::get(&env, &token)
+    }
 }
 
 mod events;
 pub mod rate_limit;
+pub mod limits;
 
 // ---------------------------------------------------------------------------
 // Test modules
@@ -1829,3 +1879,6 @@ mod test_balance_property;
 
 #[cfg(test)]
 mod test_rate_limit;
+
+#[cfg(test)]
+mod test_reserve_cap;

--- a/contracts/vault/src/limits.rs
+++ b/contracts/vault/src/limits.rs
@@ -1,0 +1,75 @@
+//! Per-token reserve caps for the Callora Vault.
+//!
+//! A reserve cap sets the maximum total balance the vault may hold for a given
+//! token.  Deposit attempts that would push the balance past the cap are
+//! rejected with [`VaultError::ExceedsReserveCap`].
+//!
+//! # Storage
+//! Caps are stored under [`StorageKey::ReserveCap`]`(token)` in **instance**
+//! storage so they share the same TTL extension as other vault configuration.
+//!
+//! # Default
+//! When no cap has been set for a token, [`get`] returns `i128::MAX`, which
+//! is effectively unlimited and keeps [`check`] on the fast path.
+
+use soroban_sdk::{Address, Env};
+
+use crate::{StorageKey, VaultError, INSTANCE_BUMP_AMOUNT, INSTANCE_BUMP_THRESHOLD};
+
+/// Store a per-token reserve cap and return the previous value.
+///
+/// # Arguments
+/// * `env` - Execution environment.
+/// * `token` - Token contract address the cap applies to.
+/// * `cap` - New maximum balance in token stroops.
+///
+/// # Returns
+/// The previous cap (`Some`) or `None` if no cap was previously configured.
+pub fn set(env: &Env, token: &Address, cap: i128) -> Option<i128> {
+    let key = StorageKey::ReserveCap(token.clone());
+    let prev: Option<i128> = env.storage().instance().get(&key);
+    env.storage().instance().set(&key, &cap);
+    env.storage()
+        .instance()
+        .extend_ttl(INSTANCE_BUMP_THRESHOLD, INSTANCE_BUMP_AMOUNT);
+    prev
+}
+
+/// Return the reserve cap for `token`.
+///
+/// Returns `i128::MAX` when no cap has been configured (effectively unlimited).
+pub fn get(env: &Env, token: &Address) -> i128 {
+    env.storage()
+        .instance()
+        .get(&StorageKey::ReserveCap(token.clone()))
+        .unwrap_or(i128::MAX)
+}
+
+/// Guard called inside `deposit()`.
+///
+/// Checks whether `current_balance + deposit_amount` would exceed the
+/// configured cap for `token` and returns [`VaultError::ExceedsReserveCap`]
+/// if so.  When no cap is set the check is skipped entirely (fast path).
+///
+/// # Errors
+/// - [`VaultError::Overflow`] — if the addition overflows `i128`.
+/// - [`VaultError::ExceedsReserveCap`] — if the post-deposit balance would
+///   exceed the cap.
+pub fn check(
+    env: &Env,
+    token: &Address,
+    current_balance: i128,
+    deposit_amount: i128,
+) -> Result<(), VaultError> {
+    let cap = get(env, token);
+    if cap == i128::MAX {
+        return Ok(());
+    }
+    let post_balance = current_balance
+        .checked_add(deposit_amount)
+        .ok_or(VaultError::Overflow)?;
+    if post_balance > cap {
+        return Err(VaultError::ExceedsReserveCap);
+    }
+    Ok(())
+}

--- a/contracts/vault/src/test_error_codes.rs
+++ b/contracts/vault/src/test_error_codes.rs
@@ -40,6 +40,9 @@ fn vault_error_codes_are_stable_and_unique() {
         (32, VaultError::StaleNonce),
         (33, VaultError::NewRevenuePoolSameAsCurrent),
         (34, VaultError::NoRevenuePoolTransferPending),
+        (35, VaultError::Slippage),
+        (36, VaultError::RateLimited),
+        (37, VaultError::ExceedsReserveCap),
     ];
 
     let mut seen = BTreeSet::new();
@@ -48,7 +51,7 @@ fn vault_error_codes_are_stable_and_unique() {
         assert!(seen.insert(expected_code), "duplicate vault error code {expected_code}");
     }
 
-    assert_eq!(seen.len(), 34);
+    assert_eq!(seen.len(), 37);
 }
 
 #[test]
@@ -89,6 +92,9 @@ fn error_code_docs_list_every_vault_code() {
         "| 32 | `StaleNonce` | Vault | Rotation nonce does not match the stored current nonce |",
         "| 33 | `NewRevenuePoolSameAsCurrent` | Vault | Proposed revenue pool matches the current revenue pool |",
         "| 34 | `NoRevenuePoolTransferPending` | Vault | No revenue-pool transfer is pending |",
+        "| 35 | `Slippage` | Vault | Calculated fee in basis points exceeds the caller-supplied `max_fee_bps` limit |",
+        "| 36 | `RateLimited` | Vault | Developer exceeded the configured rate limit |",
+        "| 37 | `ExceedsReserveCap` | Vault | Deposit would exceed the configured per-token reserve cap |",
     ];
 
     for line in expected_lines {

--- a/contracts/vault/src/test_reserve_cap.rs
+++ b/contracts/vault/src/test_reserve_cap.rs
@@ -1,0 +1,312 @@
+extern crate std;
+
+use soroban_sdk::testutils::{Address as _, Events as _};
+use soroban_sdk::{token, Address, Env, IntoVal, Symbol};
+
+use super::*;
+
+// ---------------------------------------------------------------------------
+// Helpers (mirror the patterns in test.rs)
+// ---------------------------------------------------------------------------
+
+fn create_usdc<'a>(
+    env: &'a Env,
+    admin: &Address,
+) -> (Address, token::Client<'a>, token::StellarAssetClient<'a>) {
+    let contract_address = env.register_stellar_asset_contract_v2(admin.clone());
+    let address = contract_address.address();
+    let client = token::Client::new(env, &address);
+    let admin_client = token::StellarAssetClient::new(env, &address);
+    (address, client, admin_client)
+}
+
+fn create_vault(env: &Env) -> (Address, CalloraVaultClient<'_>) {
+    let address = env.register(CalloraVault, ());
+    let client = CalloraVaultClient::new(env, &address);
+    (address, client)
+}
+
+/// Set up a fully initialised vault ready for deposits.
+/// Returns `(vault_address, client, usdc_address, usdc_client, usdc_admin, owner)`.
+fn setup(
+    env: &Env,
+) -> (
+    Address,
+    CalloraVaultClient<'_>,
+    Address,
+    token::Client<'_>,
+    token::StellarAssetClient<'_>,
+    Address,
+) {
+    let owner = Address::generate(env);
+    let (usdc, usdc_client, usdc_admin) = create_usdc(env, &owner);
+    let (vault_address, client) = create_vault(env);
+    env.mock_all_auths();
+    client.init(&owner, &usdc, &None, &None, &None, &None, &None);
+    (vault_address, client, usdc, usdc_client, usdc_admin, owner)
+}
+
+// ---------------------------------------------------------------------------
+// get_reserve_cap — default
+// ---------------------------------------------------------------------------
+
+#[test]
+fn get_reserve_cap_returns_max_when_not_set() {
+    let env = Env::default();
+    let (_vault_address, client, usdc, _usdc_client, _usdc_admin, _owner) = setup(&env);
+    assert_eq!(client.get_reserve_cap(&usdc), i128::MAX);
+}
+
+// ---------------------------------------------------------------------------
+// set_reserve_cap — validation
+// ---------------------------------------------------------------------------
+
+#[test]
+fn set_reserve_cap_stores_value() {
+    let env = Env::default();
+    let (_vault_address, client, usdc, _usdc_client, _usdc_admin, owner) = setup(&env);
+    env.mock_all_auths();
+    client.set_reserve_cap(&owner, &usdc, &1_000_000);
+    assert_eq!(client.get_reserve_cap(&usdc), 1_000_000);
+}
+
+#[test]
+fn set_reserve_cap_can_be_updated() {
+    let env = Env::default();
+    let (_vault_address, client, usdc, _usdc_client, _usdc_admin, owner) = setup(&env);
+    env.mock_all_auths();
+    client.set_reserve_cap(&owner, &usdc, &500);
+    client.set_reserve_cap(&owner, &usdc, &2_000);
+    assert_eq!(client.get_reserve_cap(&usdc), 2_000);
+}
+
+#[test]
+fn set_reserve_cap_to_max_restores_unlimited() {
+    let env = Env::default();
+    let (_vault_address, client, usdc, _usdc_client, _usdc_admin, owner) = setup(&env);
+    env.mock_all_auths();
+    client.set_reserve_cap(&owner, &usdc, &100);
+    client.set_reserve_cap(&owner, &usdc, &i128::MAX);
+    assert_eq!(client.get_reserve_cap(&usdc), i128::MAX);
+}
+
+#[test]
+fn set_reserve_cap_rejects_zero() {
+    let env = Env::default();
+    let (_vault_address, client, usdc, _usdc_client, _usdc_admin, owner) = setup(&env);
+    env.mock_all_auths();
+    let result = client.try_set_reserve_cap(&owner, &usdc, &0);
+    assert_eq!(result.unwrap_err().unwrap(), VaultError::AmountNotPositive);
+}
+
+#[test]
+fn set_reserve_cap_rejects_negative() {
+    let env = Env::default();
+    let (_vault_address, client, usdc, _usdc_client, _usdc_admin, owner) = setup(&env);
+    env.mock_all_auths();
+    let result = client.try_set_reserve_cap(&owner, &usdc, &-1);
+    assert_eq!(result.unwrap_err().unwrap(), VaultError::AmountNotPositive);
+}
+
+#[test]
+fn set_reserve_cap_requires_owner() {
+    let env = Env::default();
+    let (_vault_address, client, usdc, _usdc_client, _usdc_admin, _owner) = setup(&env);
+    let non_owner = Address::generate(&env);
+    env.mock_all_auths();
+    let result = client.try_set_reserve_cap(&non_owner, &usdc, &1_000);
+    assert_eq!(result.unwrap_err().unwrap(), VaultError::Unauthorized);
+}
+
+#[test]
+fn set_reserve_cap_is_per_token() {
+    let env = Env::default();
+    let (_vault_address, client, usdc, _usdc_client, _usdc_admin, owner) = setup(&env);
+    let other_token = Address::generate(&env);
+    env.mock_all_auths();
+    client.set_reserve_cap(&owner, &usdc, &500);
+    // Other token still has no cap
+    assert_eq!(client.get_reserve_cap(&other_token), i128::MAX);
+}
+
+// ---------------------------------------------------------------------------
+// set_reserve_cap — events
+// ---------------------------------------------------------------------------
+
+#[test]
+fn set_reserve_cap_emits_event() {
+    let env = Env::default();
+    let (vault_address, client, usdc, _usdc_client, _usdc_admin, owner) = setup(&env);
+    env.mock_all_auths();
+    client.set_reserve_cap(&owner, &usdc, &1_000);
+
+    let events = env.events().all();
+    let ev = events
+        .iter()
+        .find(|e| {
+            if e.0 != vault_address {
+                return false;
+            }
+            if e.1.is_empty() {
+                return false;
+            }
+            let s: Symbol = e.1.get(0).unwrap().into_val(&env);
+            s == Symbol::new(&env, "reserve_cap_set")
+        })
+        .expect("expected reserve_cap_set event");
+
+    let (prev, cap): (Option<i128>, i128) = ev.2.into_val(&env);
+    assert_eq!(prev, None);
+    assert_eq!(cap, 1_000);
+}
+
+#[test]
+fn set_reserve_cap_event_includes_previous_value() {
+    let env = Env::default();
+    let (vault_address, client, usdc, _usdc_client, _usdc_admin, owner) = setup(&env);
+    env.mock_all_auths();
+    client.set_reserve_cap(&owner, &usdc, &500);
+    client.set_reserve_cap(&owner, &usdc, &999);
+
+    let events = env.events().all();
+    // Find the last reserve_cap_set event
+    let ev = events
+        .iter()
+        .filter(|e| {
+            if e.0 != vault_address {
+                return false;
+            }
+            if e.1.is_empty() {
+                return false;
+            }
+            let s: Symbol = e.1.get(0).unwrap().into_val(&env);
+            s == Symbol::new(&env, "reserve_cap_set")
+        })
+        .last()
+        .expect("expected reserve_cap_set event");
+
+    let (prev, cap): (Option<i128>, i128) = ev.2.into_val(&env);
+    assert_eq!(prev, Some(500));
+    assert_eq!(cap, 999);
+}
+
+// ---------------------------------------------------------------------------
+// deposit — cap enforcement
+// ---------------------------------------------------------------------------
+
+#[test]
+fn deposit_succeeds_when_no_cap_set() {
+    let env = Env::default();
+    let (vault_address, client, usdc, usdc_client, usdc_admin, owner) = setup(&env);
+    env.mock_all_auths();
+    usdc_admin.mint(&owner, &1_000_000);
+    usdc_client.approve(&owner, &vault_address, &1_000_000, &99999);
+    let balance = client.deposit(&owner, &1_000_000);
+    assert_eq!(balance, 1_000_000);
+}
+
+#[test]
+fn deposit_succeeds_when_below_cap() {
+    let env = Env::default();
+    let (vault_address, client, usdc, usdc_client, usdc_admin, owner) = setup(&env);
+    env.mock_all_auths();
+    client.set_reserve_cap(&owner, &usdc, &500);
+    usdc_admin.mint(&owner, &300);
+    usdc_client.approve(&owner, &vault_address, &300, &99999);
+    let balance = client.deposit(&owner, &300);
+    assert_eq!(balance, 300);
+}
+
+#[test]
+fn deposit_succeeds_at_exact_cap() {
+    let env = Env::default();
+    let (vault_address, client, usdc, usdc_client, usdc_admin, owner) = setup(&env);
+    env.mock_all_auths();
+    client.set_reserve_cap(&owner, &usdc, &1_000);
+    usdc_admin.mint(&owner, &1_000);
+    usdc_client.approve(&owner, &vault_address, &1_000, &99999);
+    let balance = client.deposit(&owner, &1_000);
+    assert_eq!(balance, 1_000);
+}
+
+#[test]
+fn deposit_fails_when_exceeds_cap() {
+    let env = Env::default();
+    let (vault_address, client, usdc, usdc_client, usdc_admin, owner) = setup(&env);
+    env.mock_all_auths();
+    client.set_reserve_cap(&owner, &usdc, &1_000);
+    usdc_admin.mint(&owner, &1_001);
+    usdc_client.approve(&owner, &vault_address, &1_001, &99999);
+    let result = client.try_deposit(&owner, &1_001);
+    assert_eq!(result.unwrap_err().unwrap(), VaultError::ExceedsReserveCap);
+}
+
+#[test]
+fn deposit_fails_when_cumulative_total_exceeds_cap() {
+    let env = Env::default();
+    let (vault_address, client, usdc, usdc_client, usdc_admin, owner) = setup(&env);
+    env.mock_all_auths();
+    client.set_reserve_cap(&owner, &usdc, &500);
+
+    usdc_admin.mint(&owner, &800);
+    usdc_client.approve(&owner, &vault_address, &800, &99999);
+
+    // First deposit of 400 — succeeds
+    let b1 = client.deposit(&owner, &400);
+    assert_eq!(b1, 400);
+
+    // Second deposit of 200 — succeeds (total = 600 > cap? No, 400+200=600 > 500 — fails!)
+    let result = client.try_deposit(&owner, &200);
+    assert_eq!(result.unwrap_err().unwrap(), VaultError::ExceedsReserveCap);
+}
+
+#[test]
+fn deposit_succeeds_again_after_cap_raised() {
+    let env = Env::default();
+    let (vault_address, client, usdc, usdc_client, usdc_admin, owner) = setup(&env);
+    env.mock_all_auths();
+    client.set_reserve_cap(&owner, &usdc, &300);
+
+    usdc_admin.mint(&owner, &600);
+    usdc_client.approve(&owner, &vault_address, &600, &99999);
+
+    client.deposit(&owner, &300);
+
+    // Would fail with cap=300
+    let result = client.try_deposit(&owner, &1);
+    assert_eq!(result.unwrap_err().unwrap(), VaultError::ExceedsReserveCap);
+
+    // Raise the cap
+    client.set_reserve_cap(&owner, &usdc, &600);
+
+    // Now deposit of 300 more succeeds
+    let b = client.deposit(&owner, &300);
+    assert_eq!(b, 600);
+}
+
+#[test]
+fn deposit_at_one_above_cap_fails() {
+    let env = Env::default();
+    let (vault_address, client, usdc, usdc_client, usdc_admin, owner) = setup(&env);
+    env.mock_all_auths();
+    client.set_reserve_cap(&owner, &usdc, &99);
+    usdc_admin.mint(&owner, &100);
+    usdc_client.approve(&owner, &vault_address, &100, &99999);
+    let result = client.try_deposit(&owner, &100);
+    assert_eq!(result.unwrap_err().unwrap(), VaultError::ExceedsReserveCap);
+}
+
+#[test]
+fn reserve_cap_does_not_affect_withdrawal() {
+    let env = Env::default();
+    let (vault_address, client, usdc, usdc_client, usdc_admin, owner) = setup(&env);
+    env.mock_all_auths();
+    usdc_admin.mint(&owner, &500);
+    usdc_client.approve(&owner, &vault_address, &500, &99999);
+    client.deposit(&owner, &500);
+
+    // Set a tight cap (lower than current balance — should not block withdrawal)
+    client.set_reserve_cap(&owner, &usdc, &100);
+    let new_bal = client.withdraw(&200);
+    assert_eq!(new_bal, 300);
+}

--- a/docs/ERROR_CODES.md
+++ b/docs/ERROR_CODES.md
@@ -49,6 +49,9 @@ must not be reassigned once released.
 | 32 | `StaleNonce` | Vault | Rotation nonce does not match the stored current nonce |
 | 33 | `NewRevenuePoolSameAsCurrent` | Vault | Proposed revenue pool matches the current revenue pool |
 | 34 | `NoRevenuePoolTransferPending` | Vault | No revenue-pool transfer is pending |
+| 35 | `Slippage` | Vault | Calculated fee in basis points exceeds the caller-supplied `max_fee_bps` limit |
+| 36 | `RateLimited` | Vault | Developer exceeded the configured rate limit |
+| 37 | `ExceedsReserveCap` | Vault | Deposit would exceed the configured per-token reserve cap |
 
 ## Settlement
 


### PR DESCRIPTION
Closes #524

---

## Summary

- Adds a per-token reserve cap to the Callora Vault so deposits are rejected when they would push the vault's tracked balance past an owner-configured ceiling.
- Introduces `contracts/vault/src/limits.rs` (new module per the issue spec) with `set`, `get`, and `check` helpers.
- New public entrypoints: `set_reserve_cap(caller, token, cap)` (owner-only) and `get_reserve_cap(token)` (view).
- New error code 37 (`ExceedsReserveCap`) and event topic `reserve_cap_set`.

## Changes

| File | Type | Notes |
|---|---|---|
| `contracts/vault/src/limits.rs` | New | Per-token cap storage, retrieval, and deposit guard |
| `contracts/vault/src/lib.rs` | Modified | `StorageKey::ReserveCap`, `VaultError::ExceedsReserveCap`, `set_reserve_cap`, `get_reserve_cap`, deposit guard call |
| `contracts/vault/src/events.rs` | Modified | `event_reserve_cap_set` topic |
| `contracts/vault/src/test_reserve_cap.rs` | New | 17 focused tests |
| `contracts/vault/src/test_error_codes.rs` | Modified | Stability snapshot extended to codes 35–37 |
| `docs/ERROR_CODES.md` | Modified | Codes 35–37 documented |

## Security & Design

- `set_reserve_cap` calls `caller.require_auth()` and `require_owner` before any state write.
- The cap check sits in the **Checks** phase of `deposit()`, before the Effects block, consistent with CEI ordering.
- All arithmetic uses `checked_add` — no `unwrap()` on production paths.
- Default cap is `i128::MAX` (fast-path skip), so existing vaults behave identically until a cap is explicitly set.
- Withdrawals and deductions are unaffected by the cap.

## Test plan

- `get_reserve_cap_returns_max_when_not_set` — default is unlimited
- `set_reserve_cap_stores_value` / `set_reserve_cap_can_be_updated` — happy path
- `set_reserve_cap_to_max_restores_unlimited` — removing cap
- `set_reserve_cap_rejects_zero` / `set_reserve_cap_rejects_negative` — validation
- `set_reserve_cap_requires_owner` — auth guard
- `set_reserve_cap_is_per_token` — caps isolated per token address
- `set_reserve_cap_emits_event` / `set_reserve_cap_event_includes_previous_value` — event correctness
- `deposit_succeeds_when_no_cap_set` — no regression when uncapped
- `deposit_succeeds_when_below_cap` / `deposit_succeeds_at_exact_cap` — boundary pass
- `deposit_fails_when_exceeds_cap` — boundary reject
- `deposit_fails_when_cumulative_total_exceeds_cap` — cumulative enforcement
- `deposit_succeeds_again_after_cap_raised` — cap increase unblocks deposits
- `deposit_at_one_above_cap_fails` — off-by-one boundary
- `reserve_cap_does_not_affect_withdrawal` — cap is deposit-only