### PR TITLE
fix: reject zero-address recipient on withdraw_to

### DIFF
--- a/contracts/vault/src/lib.rs
+++ b/contracts/vault/src/lib.rs
@@ -115,6 +115,8 @@ pub enum VaultError {
     Slippage = 35,
     /// Rate limit exceeded for the developer (code 36).
     RateLimited = 36,
+    /// Recipient address cannot be zero (code 37).
+    ZeroAddressRecipient = 37,
 }
 
 #[contracttype]
@@ -1127,9 +1129,23 @@ impl CalloraVault {
         Ok(meta.balance)
     }
 
+    /// Withdraw USDC from the vault to a specified recipient (owner only).
+    ///
+    /// # Parameters
+    /// - `to` — recipient address; must not be the zero address.
+    /// - `amount` — amount to withdraw; must be positive.
+    ///
+    /// # Errors
+    /// - `VaultError::ZeroAddressRecipient` — recipient is the zero address.
+    /// - `VaultError::AmountNotPositive` — `amount <= 0`.
+    /// - `VaultError::InsufficientBalance` — vault balance is less than `amount`.
     pub fn withdraw_to(env: Env, to: Address, amount: i128) -> Result<i128, VaultError> {
         let mut meta = Self::get_meta(env.clone())?;
         meta.owner.require_auth();
+        // Reject zero-address recipient
+        if Self::is_zero_address(&env, &to) {
+            return Err(VaultError::ZeroAddressRecipient);
+        }
         if amount <= 0 {
             return Err(VaultError::AmountNotPositive);
         }
@@ -1699,6 +1715,16 @@ impl CalloraVault {
         Ok(())
     }
 
+    /// Check if an address is the zero address (all zero bytes).
+    ///
+    /// Returns `true` if the address is a contract address with all zero bytes.
+    #[inline(never)]
+    fn is_zero_address(env: &Env, addr: &Address) -> bool {
+        let zero_bytes = BytesN::<32>::from_array(env, &[0u8; 32]);
+        let zero_addr = Address::from_contract_id(&zero_bytes);
+        *addr == zero_addr
+    }
+
     /// Broadcast an emergency message from the admin.
     ///
     /// Only the current admin may call this function.
@@ -1829,3 +1855,6 @@ mod test_balance_property;
 
 #[cfg(test)]
 mod test_rate_limit;
+
+#[cfg(test)]
+mod test_withdraw_to_zero_address;

--- a/contracts/vault/src/test_withdraw_to_zero_address.rs
+++ b/contracts/vault/src/test_withdraw_to_zero_address.rs
@@ -1,0 +1,181 @@
+//! Focused tests for withdraw_to zero-address recipient validation.
+//!
+//! Verifies that `withdraw_to` rejects zero-address recipients with
+//! `VaultError::ZeroAddressRecipient` (error code 37).
+
+extern crate std;
+
+use soroban_sdk::testutils::Address as _;
+use soroban_sdk::{token, Address, BytesN, Env};
+
+use super::*;
+
+// ---------------------------------------------------------------------------
+// Test helpers (copied from test.rs for isolation)
+// ---------------------------------------------------------------------------
+
+fn create_usdc<'a>(
+    env: &'a Env,
+    admin: &Address,
+) -> (Address, token::Client<'a>, token::StellarAssetClient<'a>) {
+    let contract_address = env.register_stellar_asset_contract_v2(admin.clone());
+    let address = contract_address.address();
+    let client = token::Client::new(env, &address);
+    let admin_client = token::StellarAssetClient::new(env, &address);
+    (address, client, admin_client)
+}
+
+fn create_vault(env: &Env) -> (Address, CalloraVaultClient<'_>) {
+    let address = env.register(CalloraVault, ());
+    let client = CalloraVaultClient::new(env, &address);
+    (address, client)
+}
+
+fn fund_vault(
+    usdc_admin_client: &token::StellarAssetClient,
+    vault_address: &Address,
+    amount: i128,
+) {
+    usdc_admin_client.mint(vault_address, &amount);
+}
+
+/// Create a zero address (contract address with all zero bytes).
+fn zero_address(env: &Env) -> Address {
+    let zero_bytes = BytesN::<32>::from_array(env, &[0u8; 32]);
+    Address::from_contract_id(&zero_bytes)
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+/// Verify that withdraw_to rejects zero-address recipient.
+#[test]
+fn withdraw_to_zero_address_fails() {
+    let env = Env::default();
+    let owner = Address::generate(&env);
+    let (vault_address, client) = create_vault(&env);
+    let (usdc, _, usdc_admin) = create_usdc(&env, &owner);
+
+    env.mock_all_auths();
+    fund_vault(&usdc_admin, &vault_address, 1000);
+    client.init(&owner, &usdc, &Some(1000), &None, &None, &None, &None);
+
+    let zero_addr = zero_address(&env);
+    let result = client.try_withdraw_to(&zero_addr, &100);
+
+    assert!(result.is_err(), "expected error for zero-address recipient");
+    // Verify the specific error code (37 = ZeroAddressRecipient)
+    let err = result.unwrap_err();
+    match err {
+        Ok(vault_err) => {
+            assert_eq!(vault_err, VaultError::ZeroAddressRecipient);
+        }
+        Err(_) => panic!("expected VaultError::ZeroAddressRecipient"),
+    }
+}
+
+/// Verify that withdraw_to succeeds with a valid non-zero recipient.
+#[test]
+fn withdraw_to_valid_address_succeeds() {
+    let env = Env::default();
+    let owner = Address::generate(&env);
+    let recipient = Address::generate(&env);
+    let (vault_address, client) = create_vault(&env);
+    let (usdc, usdc_client, usdc_admin) = create_usdc(&env, &owner);
+
+    env.mock_all_auths();
+    fund_vault(&usdc_admin, &vault_address, 1000);
+    client.init(&owner, &usdc, &Some(1000), &None, &None, &None, &None);
+
+    let remaining = client.withdraw_to(&recipient, &100);
+
+    assert_eq!(remaining, 900);
+    assert_eq!(client.balance(), 900);
+    assert_eq!(usdc_client.balance(&recipient), 100);
+}
+
+/// Verify that zero-address check happens before amount validation.
+#[test]
+fn withdraw_to_zero_address_checked_before_amount() {
+    let env = Env::default();
+    let owner = Address::generate(&env);
+    let (vault_address, client) = create_vault(&env);
+    let (usdc, _, usdc_admin) = create_usdc(&env, &owner);
+
+    env.mock_all_auths();
+    fund_vault(&usdc_admin, &vault_address, 1000);
+    client.init(&owner, &usdc, &Some(1000), &None, &None, &None, &None);
+
+    // Even with an invalid amount (0), zero-address should be rejected first
+    let zero_addr = zero_address(&env);
+    let result = client.try_withdraw_to(&zero_addr, &0);
+
+    assert!(result.is_err(), "expected error for zero-address recipient");
+    let err = result.unwrap_err();
+    match err {
+        Ok(vault_err) => {
+            // Zero-address check should happen before amount validation
+            assert_eq!(vault_err, VaultError::ZeroAddressRecipient);
+        }
+        Err(_) => panic!("expected VaultError::ZeroAddressRecipient"),
+    }
+}
+
+/// Verify that withdraw_to to zero address fails even when paused.
+/// (Since withdraw is allowed when paused for emergency recovery,
+/// zero-address validation should still apply.)
+#[test]
+fn withdraw_to_zero_address_fails_even_when_paused() {
+    let env = Env::default();
+    let owner = Address::generate(&env);
+    let (vault_address, client) = create_vault(&env);
+    let (usdc, _, usdc_admin) = create_usdc(&env, &owner);
+
+    env.mock_all_auths();
+    fund_vault(&usdc_admin, &vault_address, 1000);
+    client.init(&owner, &usdc, &Some(1000), &None, &None, &None, &None);
+
+    // Pause the vault
+    client.pause(&owner);
+    assert!(client.is_paused());
+
+    let zero_addr = zero_address(&env);
+    let result = client.try_withdraw_to(&zero_addr, &100);
+
+    assert!(result.is_err(), "expected error for zero-address recipient even when paused");
+    let err = result.unwrap_err();
+    match err {
+        Ok(vault_err) => {
+            assert_eq!(vault_err, VaultError::ZeroAddressRecipient);
+        }
+        Err(_) => panic!("expected VaultError::ZeroAddressRecipient"),
+    }
+}
+
+/// Verify that a valid recipient still works after a failed zero-address attempt.
+#[test]
+fn withdraw_to_valid_after_zero_address_rejection() {
+    let env = Env::default();
+    let owner = Address::generate(&env);
+    let recipient = Address::generate(&env);
+    let (vault_address, client) = create_vault(&env);
+    let (usdc, usdc_client, usdc_admin) = create_usdc(&env, &owner);
+
+    env.mock_all_auths();
+    fund_vault(&usdc_admin, &vault_address, 1000);
+    client.init(&owner, &usdc, &Some(1000), &None, &None, &None, &None);
+
+    // First, try zero address (should fail)
+    let zero_addr = zero_address(&env);
+    let result = client.try_withdraw_to(&zero_addr, &100);
+    assert!(result.is_err());
+
+    // Balance should be unchanged
+    assert_eq!(client.balance(), 1000);
+
+    // Now try valid recipient (should succeed)
+    let remaining = client.withdraw_to(&recipient, &100);
+    assert_eq!(remaining, 900);
+    assert_eq!(usdc_client.balance(&recipient), 100);
+}


### PR DESCRIPTION
## Summary

  Closes #572

  This PR adds validation to `vault.withdraw_to` to reject zero-address recipients, preventing funds from being sent to an invalid/burn address.

  ### Changes
  - Added `ZeroAddressRecipient` error variant (code 37) to `VaultError`
  - Added `is_zero_address` helper function that checks if an address is all zero bytes
  - Added validation in `withdraw_to` that rejects zero-address recipients before amount validation
  - Added NatSpec-style rustdoc documentation to `withdraw_to`
  - Added focused tests in `test_withdraw_to_zero_address.rs`:
    - `withdraw_to_zero_address_fails` - verifies rejection
    - `withdraw_to_valid_address_succeeds` - verifies normal operation
    - `withdraw_to_zero_address_checked_before_amount` - verifies check ordering
    - `withdraw_to_zero_address_fails_even_when_paused` - verifies behavior during pause
    - `withdraw_to_valid_after_zero_address_rejection` - verifies state unchanged after rejection

  ## Test plan
  - [ ] Run `cargo test -p callora-vault test_withdraw_to_zero_address`
  - [ ] Run full test suite `cargo test -p callora-vault`
  - [ ] Run `cargo clippy -p callora-vault`
  - [ ] Verify error code 37 is returned for zero-address recipients