### PR TITLE
feat: per-tx max deduct

### DIFF
--- a/contracts/vault/src/lib.rs
+++ b/contracts/vault/src/lib.rs
@@ -199,7 +199,8 @@ trait Settlement {
     );
 }
 
-pub const DEFAULT_MAX_DEDUCT: i128 = i128::MAX;
+pub mod limits;
+pub use limits::{check_max_deduct, DEFAULT_MAX_DEDUCT};
 pub const DEFAULT_MIN_DEPOSIT: i128 = 1;
 pub const MAX_BATCH_SIZE: u32 = 50;
 pub const MAX_METADATA_LEN: u32 = 256;
@@ -791,9 +792,7 @@ impl CalloraVault {
         }
         Self::require_authorized_deduct_caller(env.clone(), &caller)?;
         let max_d = Self::get_max_deduct(env.clone());
-        if amount > max_d {
-            return Err(VaultError::ExceedsMaxDeduct);
-        }
+        check_max_deduct(amount, max_d)?;
         // Idempotency check — must happen before any state mutation.
         if let Some(ref rid) = request_id {
             Self::require_not_duplicate(&env, rid)?;
@@ -904,9 +903,7 @@ impl CalloraVault {
             if item.amount <= 0 {
                 return Err(VaultError::AmountNotPositive);
             }
-            if item.amount > max_d {
-                return Err(VaultError::ExceedsMaxDeduct);
-            }
+            check_max_deduct(item.amount, max_d)?;
             if running < item.amount {
                 return Err(VaultError::InsufficientBalance);
             }
@@ -1719,3 +1716,6 @@ mod test_reentrancy;
 
 #[cfg(test)]
 mod test_balance_property;
+
+#[cfg(test)]
+mod test_limits;

--- a/contracts/vault/src/limits.rs
+++ b/contracts/vault/src/limits.rs
@@ -1,0 +1,25 @@
+/// Default maximum single-deduction amount.
+///
+/// When no explicit cap is configured via [`CalloraVault::set_max_deduct`] this
+/// value is returned by [`CalloraVault::get_max_deduct`] and used as the upper
+/// bound in all deduct/batch_deduct calls.  Setting it to `i128::MAX` is
+/// effectively uncapped.
+pub const DEFAULT_MAX_DEDUCT: i128 = i128::MAX;
+
+/// Enforce the per-transaction deduction cap.
+///
+/// Returns `Err(VaultError::ExceedsMaxDeduct)` when `amount > max_deduct`.
+///
+/// # Arguments
+/// * `amount`     – the requested deduction amount; must already be validated as positive.
+/// * `max_deduct` – the configured cap (read from storage via `get_max_deduct`).
+///
+/// # Errors
+/// - [`VaultError::ExceedsMaxDeduct`] when `amount > max_deduct`.
+#[inline]
+pub fn check_max_deduct(amount: i128, max_deduct: i128) -> Result<(), crate::VaultError> {
+    if amount > max_deduct {
+        return Err(crate::VaultError::ExceedsMaxDeduct);
+    }
+    Ok(())
+}

--- a/contracts/vault/src/test_limits.rs
+++ b/contracts/vault/src/test_limits.rs
@@ -1,0 +1,43 @@
+#[cfg(test)]
+mod tests {
+    use crate::limits::{check_max_deduct, DEFAULT_MAX_DEDUCT};
+    use crate::VaultError;
+
+    #[test]
+    fn default_max_deduct_is_i128_max() {
+        assert_eq!(DEFAULT_MAX_DEDUCT, i128::MAX);
+    }
+
+    #[test]
+    fn check_max_deduct_amount_at_cap_succeeds() {
+        assert!(check_max_deduct(500, 500).is_ok());
+    }
+
+    #[test]
+    fn check_max_deduct_amount_below_cap_succeeds() {
+        assert!(check_max_deduct(1, 1_000).is_ok());
+    }
+
+    #[test]
+    fn check_max_deduct_amount_above_cap_fails() {
+        assert_eq!(
+            check_max_deduct(501, 500),
+            Err(VaultError::ExceedsMaxDeduct)
+        );
+    }
+
+    #[test]
+    fn check_max_deduct_default_cap_never_rejects_positive_amounts() {
+        assert!(check_max_deduct(i128::MAX, DEFAULT_MAX_DEDUCT).is_ok());
+    }
+
+    #[test]
+    fn check_max_deduct_cap_of_one_accepts_one() {
+        assert!(check_max_deduct(1, 1).is_ok());
+    }
+
+    #[test]
+    fn check_max_deduct_cap_of_one_rejects_two() {
+        assert_eq!(check_max_deduct(2, 1), Err(VaultError::ExceedsMaxDeduct));
+    }
+}

--- a/docs/interfaces/vault.json
+++ b/docs/interfaces/vault.json
@@ -460,12 +460,37 @@
 
     {
       "name": "get_max_deduct",
-      "description": "Return the configured maximum single-deduction amount.",
+      "description": "Return the configured maximum single-deduction amount. Defaults to i128::MAX (effectively uncapped) when never set. Implemented via DEFAULT_MAX_DEDUCT in limits.rs.",
       "access": "any",
       "params": [],
       "returns": "i128",
       "panics": [],
       "events": []
+    },
+
+    {
+      "name": "set_max_deduct",
+      "description": "Update the per-transaction deduction cap. Only the vault owner may call this. Enforced by check_max_deduct (limits.rs) on every deduct and batch_deduct call.",
+      "access": "owner (must sign)",
+      "params": [
+        {
+          "name": "max_deduct",
+          "type": "i128",
+          "optional": false,
+          "description": "New cap in token base units (stroops). Must be > 0."
+        }
+      ],
+      "returns": "void",
+      "errors": [
+        { "code": 12, "name": "MaxDeductNotPositive", "condition": "max_deduct <= 0" }
+      ],
+      "events": [
+        {
+          "topic": "set_max_deduct",
+          "data": "(old_value: i128, new_value: i128)",
+          "description": "Emitted after the cap is updated."
+        }
+      ]
     },
 
     {


### PR DESCRIPTION
- Extract DEFAULT_MAX_DEDUCT constant and check_max_deduct() helper into contracts/vault/src/limits.rs for clear separation of cap logic
- Re-export from lib.rs (pub mod limits; pub use limits::{...})
- Replace inline if-checks in deduct() and batch_deduct() with check_max_deduct()
- Add focused unit tests in test_limits.rs (7 tests: default value, at/below/above cap, edge cases)
- Update docs/interfaces/vault.json: improve get_max_deduct description, add missing set_max_deduct entry with params, errors, and event docs

Closes #538