### PR TITLE
fix: resolve settlement crate compile errors and align V2 per-token t…

### DIFF
--- a/contracts/settlement/src/lib.rs
+++ b/contracts/settlement/src/lib.rs
@@ -1,14 +1,20 @@
 #![no_std]
 
 use soroban_sdk::{
-    contract, contracterror, contractimpl, contracttype, token, Address, BytesN, Env, Symbol, Vec,
+    contract, contracterror, contractimpl, contracttype, token, Address, BytesN, Env, String,
+    Symbol, Vec,
 };
+
+use crate::timelock::PendingDeveloperMigration;
 
 /// Maximum number of items allowed in a single `batch_receive_payment` call.
 pub const MAX_BATCH_SIZE: u32 = 50;
 
 /// Maximum number of developer balances returned per page in paginated queries.
 pub const MAX_DEVELOPER_BALANCES_PAGE_SIZE: u32 = 100;
+
+/// Maximum message length in bytes for admin broadcast messages.
+pub const MAX_MESSAGE_LEN: u32 = 256;
 
 /// Typed errors for the settlement contract.
 ///
@@ -35,6 +41,13 @@ pub const MAX_DEVELOPER_BALANCES_PAGE_SIZE: u32 = 100;
 /// | 15   | ReasonTooLong                | Reason Symbol exceeds maximum allowed length      |
 /// | 16   | InvalidClaimWindow           | Claim window end is before start                  |
 /// | 17   | ClaimWindowClosed            | Claim attempted outside developer's claim window  |
+/// | 18   | MigrationSameAddress         | Migration source == target                        |
+/// | 19   | InvalidMigrationTarget       | Destination is the contract itself                |
+/// | 20   | NoDeveloperBalance           | Source developer has no balance to migrate        |
+/// | 21   | TimelockOverflow             | Timelock addition overflows u64                   |
+/// | 22   | MigrationNotFound            | No pending migration for source address           |
+/// | 23   | TimelockNotExpired           | Timelock period has not elapsed                   |
+/// | 24   | MigrationBalanceChanged      | Source balance changed since proposal             |
 #[contracterror]
 #[derive(Clone, Copy, Debug, PartialEq)]
 #[repr(u32)]
@@ -56,6 +69,13 @@ pub enum SettlementError {
     ReasonTooLong = 15,
     InvalidClaimWindow = 16,
     ClaimWindowClosed = 17,
+    MigrationSameAddress = 18,
+    InvalidMigrationTarget = 19,
+    NoDeveloperBalance = 20,
+    TimelockOverflow = 21,
+    MigrationNotFound = 22,
+    TimelockNotExpired = 23,
+    MigrationBalanceChanged = 24,
 }
 
 /// Persistent storage keys for settlement contract
@@ -67,13 +87,21 @@ pub enum StorageKey {
     PendingAdmin,
     PendingVault,
     DeveloperIndex,
-    DeveloperBalance(Address),
+    /// Legacy single-token balance — kept for V1 → V2 migration reads only.
+    DeveloperBalanceV1(Address),
+    /// Per-token developer balance `(developer, token)`.
+    DeveloperBalance(Address, Address),
+    DeveloperMinBalance(Address),
     GlobalPool,
     Usdc,
     DailyWithdrawCap(Address),
     WithdrawalToday(Address),
     DeveloperClaimWindow(Address),
     ContractVersion,
+    /// Pending timelock'd developer balance migration record.
+    PendingDeveloperMigration(Address),
+    /// Storage-layout version marker (u32).
+    StorageVersion,
 }
 
 /// Developer balance record in settlement contract
@@ -81,6 +109,7 @@ pub enum StorageKey {
 #[derive(Clone, Debug, PartialEq)]
 pub struct DeveloperBalance {
     pub address: Address,
+    pub token: Address,
     pub balance: i128,
 }
 
@@ -130,6 +159,7 @@ pub struct PaymentReceivedEvent {
     pub amount: i128,
     pub to_pool: bool, // true if credited to global pool, false if to specific developer
     pub developer: Option<Address>, // developer address if credited to specific developer
+    pub token: Address,
 }
 
 /// Balance credited event
@@ -139,6 +169,7 @@ pub struct BalanceCreditedEvent {
     pub developer: Address,
     pub amount: i128,
     pub new_balance: i128,
+    pub token: Address,
 }
 
 /// Emitted when a new vault address is proposed via `propose_vault()`.
@@ -166,6 +197,7 @@ pub struct DeveloperWithdrawEvent {
     pub amount: i128,
     pub remaining_balance: i128,
     pub to: Address,
+    pub token: Address,
 }
 
 /// Emitted when the admin sets or changes a developer's daily withdrawal cap.
@@ -194,6 +226,46 @@ pub struct DeveloperForceCreditedEvent {
     pub amount: i128,
     pub reason: Symbol,
     pub new_balance: i128,
+    pub token: Address,
+}
+
+/// Emitted when the admin proposes or executes a timelock'd developer balance migration.
+#[contracttype]
+#[derive(Clone, Debug, PartialEq)]
+pub struct AdminMigrationEvent {
+    pub from: Address,
+    pub to: Address,
+    pub amount: i128,
+    pub executed_at: u64,
+}
+
+/// Storage TTL entry for a given storage key category.
+#[contracttype]
+#[derive(Clone, Debug, PartialEq)]
+pub struct StorageEntryTtl {
+    pub category: String,
+    pub key_desc: String,
+    pub storage_type: String,
+    pub ttl: u32,
+    pub threshold: u32,
+    pub bump_amount: u32,
+}
+
+/// Severity levels for admin broadcast messages.
+#[contracttype]
+#[derive(Clone, Debug, PartialEq)]
+pub enum Severity {
+    Info,
+    Warn,
+    Crit,
+}
+
+/// Payload for the `admin_broadcast` event.
+#[contracttype]
+#[derive(Clone, Debug, PartialEq)]
+pub struct AdminBroadcast {
+    pub severity: Severity,
+    pub message: String,
 }
 
 /// Maximum byte length for the `reason` Symbol in `force_credit_developer`.
@@ -415,11 +487,8 @@ impl CalloraSettlement {
                 .checked_add(amount)
                 .unwrap_or_else(|| env.panic_with_error(SettlementError::DeveloperOverflow));
             env.storage().persistent().set(&balance_key, &new_balance);
-            env.storage()
-                .persistent()
-                .set(&StorageKey::DeveloperBalance(dev.clone()), &new_balance);
             env.storage().persistent().extend_ttl(
-                &StorageKey::DeveloperBalance(dev.clone()),
+                &balance_key,
                 50000,
                 50000,
             );
@@ -580,6 +649,9 @@ impl CalloraSettlement {
             return Err(SettlementError::AmountNotPositive);
         }
 
+        let usdc_address = Self::get_usdc_token(env.clone())?;
+        let usdc = token::Client::new(&env, &usdc_address);
+
         let recipient = to.unwrap_or_else(|| developer.clone());
         let contract_address = env.current_contract_address();
         if recipient == contract_address {
@@ -588,10 +660,11 @@ impl CalloraSettlement {
 
         Self::require_claim_window_open(&env, &developer)?;
 
+        let balance_key = StorageKey::DeveloperBalance(developer.clone(), usdc_address.clone());
         let current_balance: i128 = env
             .storage()
             .persistent()
-            .get(&StorageKey::DeveloperBalance(developer.clone()))
+            .get(&balance_key)
             .unwrap_or(0);
         if amount > current_balance {
             return Err(SettlementError::InsufficientDeveloperBalance);
@@ -625,24 +698,14 @@ impl CalloraSettlement {
             .checked_sub(amount)
             .ok_or(SettlementError::DeveloperBalanceUnderflow)?;
 
-        let usdc_address = Self::get_usdc_token(env.clone())?;
-        let usdc = token::Client::new(&env, &usdc_address);
-
         if usdc.balance(&contract_address) < amount {
             return Err(SettlementError::InsufficientContractBalance);
         }
 
         usdc.transfer(&contract_address, &recipient, &amount);
 
-        env.storage().persistent().set(
-            &StorageKey::DeveloperBalance(developer.clone()),
-            &new_balance,
-        );
-        env.storage().persistent().extend_ttl(
-            &StorageKey::DeveloperBalance(developer.clone()),
-            50000,
-            50000,
-        );
+        env.storage().persistent().set(&balance_key, &new_balance);
+        env.storage().persistent().extend_ttl(&balance_key, 50000, 50000);
 
         let today = env.ledger().timestamp() / 86400;
         let mut daily = env
@@ -674,6 +737,7 @@ impl CalloraSettlement {
                 amount,
                 remaining_balance: new_balance,
                 to: recipient,
+                token: usdc_address,
             },
         );
 
@@ -901,15 +965,8 @@ impl CalloraSettlement {
             .checked_add(amount)
             .unwrap_or_else(|| env.panic_with_error(SettlementError::DeveloperOverflow));
 
-        env.storage().persistent().set(
-            &StorageKey::DeveloperBalance(developer.clone()),
-            &new_balance,
-        );
-        env.storage().persistent().extend_ttl(
-            &StorageKey::DeveloperBalance(developer.clone()),
-            50000,
-            50000,
-        );
+        env.storage().persistent().set(&balance_key, &new_balance);
+        env.storage().persistent().extend_ttl(&balance_key, 50000, 50000);
 
         let mut index: Vec<Address> = env
             .storage()
@@ -933,6 +990,7 @@ impl CalloraSettlement {
                 amount,
                 reason,
                 new_balance,
+                token: token.clone(),
             },
         );
     }
@@ -1124,7 +1182,7 @@ impl CalloraSettlement {
             .get(&StorageKey::DeveloperIndex)
             .unwrap_or_else(|| Vec::new(&env));
 
-        pagination::get_page(&env, &index, cursor, limit)
+        pagination::get_page(&env, &index, cursor, limit, token)
     }
 
     /// Return the remaining TTL for each storage key category.
@@ -1164,131 +1222,33 @@ impl CalloraSettlement {
                 .unwrap_or_else(|| Vec::new(&env))
         };
 
-        for dev in devs.iter() {
-            // Check DeveloperBalance (Persistent)
-            let bal_key = StorageKey::DeveloperBalance(dev.clone());
-            if env.storage().persistent().has(&bal_key) {
-                let ttl = {
-                    #[cfg(any(test, feature = "testutils"))]
-                    {
-                        env.storage().persistent().get_ttl(&bal_key)
-                    }
-                    #[cfg(not(any(test, feature = "testutils")))]
-                    {
-                        50000
-                    }
-                };
-                result.push_back(StorageEntryTtl {
-                    category: String::from_str(&env, "DeveloperBalance"),
-                    key_desc: String::from_str(&env, "DeveloperBalance"),
-                    storage_type: String::from_str(&env, "Persistent"),
-                    ttl,
-                    threshold: 50000,
-                    bump_amount: 50000,
-                });
-            }
-
-            let balance: i128 = env
-                .storage()
-                .persistent()
-                .get(&StorageKey::DeveloperBalance(
-                    address.clone(),
-                    token.clone(),
-                ))
-                .unwrap_or(0i128);
-            result.push_back(DeveloperBalance {
-                address: address.clone(),
-                token: token.clone(),
-                balance,
-            });
-            last_address = Some(address.clone());
-
-            // Check DailyWithdrawCap (Persistent)
-            let cap_key = StorageKey::DailyWithdrawCap(dev.clone());
-            if env.storage().persistent().has(&cap_key) {
-                let ttl = {
-                    #[cfg(any(test, feature = "testutils"))]
-                    {
-                        env.storage().persistent().get_ttl(&cap_key)
-                    }
-                    #[cfg(not(any(test, feature = "testutils")))]
-                    {
-                        50000
-                    }
-                };
-                result.push_back(StorageEntryTtl {
-                    category: String::from_str(&env, "DailyWithdrawCap"),
-                    key_desc: String::from_str(&env, "DailyWithdrawCap"),
-                    storage_type: String::from_str(&env, "Persistent"),
-                    ttl,
-                    threshold: 50000,
-                    bump_amount: 50000,
-                });
-            }
-        }
-
-        result
-    }
-
-    /// Return the remaining TTL for each storage key category.
-    ///
-    /// # Parameters
-    /// - `developer_addresses` — optional list of developers to check. If empty, the index is used.
-    pub fn get_storage_ttl(env: Env, developer_addresses: Vec<Address>) -> Vec<StorageEntryTtl> {
-        let mut result = Vec::new(&env);
-
-        // 1. Instance Storage
-        let instance_ttl = {
-            #[cfg(any(test, feature = "testutils"))]
-            {
-                env.storage().instance().get_ttl()
-            }
-            #[cfg(not(any(test, feature = "testutils")))]
-            {
-                17_280 * 60
-            }
-        };
-        result.push_back(StorageEntryTtl {
-            category: String::from_str(&env, "Instance"),
-            key_desc: String::from_str(&env, "Instance"),
-            storage_type: String::from_str(&env, "Instance"),
-            ttl: instance_ttl,
-            threshold: 17_280 * 30,
-            bump_amount: 17_280 * 60,
-        });
-
-        // Determine which developer addresses to inspect
-        let devs = if developer_addresses.len() > 0 {
-            developer_addresses
-        } else {
-            env.storage()
-                .instance()
-                .get(&StorageKey::DeveloperIndex)
-                .unwrap_or_else(|| Vec::new(&env))
-        };
+        // Read the USDC token address from storage for per-token balance keys.
+        let usdc_token: Option<Address> = env.storage().instance().get(&StorageKey::Usdc);
 
         for dev in devs.iter() {
-            // Check DeveloperBalance (Persistent)
-            let bal_key = StorageKey::DeveloperBalance(dev.clone());
-            if env.storage().persistent().has(&bal_key) {
-                let ttl = {
-                    #[cfg(any(test, feature = "testutils"))]
-                    {
-                        env.storage().persistent().get_ttl(&bal_key)
-                    }
-                    #[cfg(not(any(test, feature = "testutils")))]
-                    {
-                        50000
-                    }
-                };
-                result.push_back(StorageEntryTtl {
-                    category: String::from_str(&env, "DeveloperBalance"),
-                    key_desc: String::from_str(&env, "DeveloperBalance"),
-                    storage_type: String::from_str(&env, "Persistent"),
-                    ttl,
-                    threshold: 50000,
-                    bump_amount: 50000,
-                });
+            // Check DeveloperBalance (Persistent) — check per-token key if USDC is known
+            if let Some(ref usdc) = usdc_token {
+                let bal_key = StorageKey::DeveloperBalance(dev.clone(), usdc.clone());
+                if env.storage().persistent().has(&bal_key) {
+                    let ttl = {
+                        #[cfg(any(test, feature = "testutils"))]
+                        {
+                            env.storage().persistent().get_ttl(&bal_key)
+                        }
+                        #[cfg(not(any(test, feature = "testutils")))]
+                        {
+                            50000
+                        }
+                    };
+                    result.push_back(StorageEntryTtl {
+                        category: String::from_str(&env, "DeveloperBalance"),
+                        key_desc: String::from_str(&env, "DeveloperBalance"),
+                        storage_type: String::from_str(&env, "Persistent"),
+                        ttl,
+                        threshold: 50000,
+                        bump_amount: 50000,
+                    });
+                }
             }
 
             // Check WithdrawalToday (Persistent)
@@ -1705,8 +1665,12 @@ impl CalloraSettlement {
     }
 }
 
+mod admin;
 mod events;
+mod limits;
 pub mod migrate;
+mod pagination;
+mod timelock;
 
 #[cfg(test)]
 mod test;

--- a/contracts/settlement/src/limits.rs
+++ b/contracts/settlement/src/limits.rs
@@ -1,8 +1,7 @@
 //! Limits module for per-developer minimum balance.
 
 use soroban_sdk::{Env, Address, Symbol, contracterror, contracttype};
-use crate::errors::SettlementError;
-use crate::types::StorageKey;
+use crate::{SettlementError, StorageKey};
 
 /// Set the minimum balance for a developer.
 ///
@@ -14,7 +13,7 @@ use crate::types::StorageKey;
 pub fn set_developer_min_balance(env: Env, caller: Address, developer: Address, min_balance: i128) {
     // Auth check – admin only.
     caller.require_auth();
-    let admin = crate::lib::CalloraSettlement::get_admin(env.clone());
+    let admin = crate::CalloraSettlement::get_admin(env.clone());
     if caller != admin {
         env.panic_with_error(SettlementError::Unauthorized);
     }

--- a/contracts/settlement/src/pagination.rs
+++ b/contracts/settlement/src/pagination.rs
@@ -1,38 +1,12 @@
 use crate::{DeveloperBalance, StorageKey, MAX_DEVELOPER_BALANCES_PAGE_SIZE};
 use soroban_sdk::{Address, Env, Vec};
 
-/// Get a paginated page of developer balances using cursor-based pagination.
-///
-/// # Pagination Behavior
-/// Returns up to `limit` developer balance records starting **after** the supplied `cursor`
-/// address (exclusive), or from the beginning of the index when `cursor` is `None`.
-///
-/// # Cursor Semantics
-/// The returned `next_cursor` is the address of the last record returned on a full page.
-/// Subsequent calls should pass this `next_cursor` as the `cursor` argument.
-/// When the returned page has fewer elements than the requested limit (or is empty), the end
-/// of the list has been reached, and `None` is returned as the next cursor.
-///
-/// # Ordering Guarantees
-/// The index is maintained in deterministic sorted ascending order by address bytes, guaranteeing
-/// stable, deterministic pagination across repeated calls. The output is sorted, meaning pages 
-/// are stable even if interleaved credits happen for developers that sort after the cursor.
-///
-/// # Page-size Configuration
-/// The page size is capped at `MAX_DEVELOPER_BALANCES_PAGE_SIZE` (100) to limit gas usage
-/// and prevent transaction size limits from being exceeded.
-///
-/// # Intended Use
-/// This function is designed for batch reconciliation, indexing, and reporting dashboards 
-/// where developer balances must be safely and incrementally sync'd.
-///
-/// # State Mutation
-/// This function is entirely read-only and performs no write operations.
 pub fn get_page(
     env: &Env,
     index: &Vec<Address>,
     cursor: Option<Address>,
     limit: u32,
+    token: Address,
 ) -> (Vec<DeveloperBalance>, Option<Address>) {
     let effective_limit = if limit == 0 {
         return (Vec::new(env), None);
@@ -57,11 +31,12 @@ pub fn get_page(
         let balance: i128 = env
             .storage()
             .persistent()
-            .get(&StorageKey::DeveloperBalance(address.clone()))
+            .get(&StorageKey::DeveloperBalance(address.clone(), token.clone()))
             .unwrap_or(0);
 
         result.push_back(DeveloperBalance {
             address: address.clone(),
+            token: token.clone(),
             balance,
         });
         last_address = Some(address.clone());

--- a/contracts/vault/src/lib.rs
+++ b/contracts/vault/src/lib.rs
@@ -31,8 +31,8 @@
 /// persistent, they do not silently archive. To prevent state bloat, an owner
 /// can explicitly prune old markers using `prune_processed_requests`.
 use soroban_sdk::{
-    contract, contractclient, contractimpl, contracttype, token, Address, BytesN, Env, String,
-    Symbol, Vec,
+    contract, contractclient, contracterror, contractimpl, contracttype, token, Address, BytesN,
+    Env, String, Symbol, Vec,
 };
 
 /// Typed error codes for the Callora Vault contract.
@@ -326,7 +326,7 @@ impl CalloraVault {
             authorized_caller,
             min_deposit: min_d,
         };
-        inst.set(&StorageKey::Meta, &meta);
+        inst.set(&StorageKey::MetaKey, &meta);
         inst.set(&StorageKey::UsdcToken, &usdc_token);
         inst.set(&StorageKey::Admin, &owner);
         if let Some(p) = revenue_pool {
@@ -838,7 +838,7 @@ impl CalloraVault {
     /// If `calculated_fee_bps > max_fee_bps` the call reverts with
     /// `VaultError::Slippage` **before** any state is mutated.
     ///
-    /// Pass `u16::MAX` (65535) to disable the guard and preserve the existing
+    /// Pass `u32::MAX` to disable the guard and preserve the existing
     /// unrestricted behaviour — this is the default for backward compatibility.
     ///
     /// # Idempotency
@@ -858,7 +858,7 @@ impl CalloraVault {
         caller: Address,
         amount: i128,
         request_id: Option<Symbol>,
-        max_fee_bps: u16,
+        max_fee_bps: u32,
         developer: Address,
     ) -> Result<i128, VaultError> {
         Self::require_not_paused(env.clone())?;
@@ -885,8 +885,8 @@ impl CalloraVault {
         }
         // Slippage guard: reject if the deducted amount exceeds max_fee_bps of the
         // current balance. Calculated before any state mutation or external call.
-        // Uses u16::MAX as the sentinel for "no limit" (backward-compatible default).
-        if max_fee_bps < u16::MAX && meta.balance > 0 {
+        // Uses u32::MAX as the sentinel for "no limit" (backward-compatible default).
+        if max_fee_bps < u32::MAX && meta.balance > 0 {
             let calculated_fee_bps = amount
                 .checked_mul(10_000)
                 .ok_or(VaultError::Overflow)?
@@ -916,6 +916,7 @@ impl CalloraVault {
             &amount,
             &true, // to_pool = true: credit global pool
             &Some(developer.clone()), // developer is passed down
+            &ut,
         );
 
         // Now that external operations succeeded, update internal state
@@ -1027,6 +1028,7 @@ impl CalloraVault {
             &total,
             &true, // to_pool = true: credit global pool
             &None, // developers are tracked per-item, not passed for whole batch
+            &ut,
         );
 
         // Now that external operations succeeded, update internal state
@@ -1083,7 +1085,7 @@ impl CalloraVault {
         let mut meta = Self::get_meta(env.clone())?;
         let old = meta.owner.clone();
         meta.owner = pending;
-        env.storage().instance().set(&StorageKey::Meta, &meta);
+        env.storage().instance().set(&StorageKey::MetaKey, &meta);
         env.storage().instance().remove(&StorageKey::PendingOwner);
         env.events().publish(
             (events::event_ownership_accepted(&env), old, meta.owner),
@@ -1300,13 +1302,6 @@ impl CalloraVault {
             (),
         );
         Ok(())
-    }
-
-    pub fn get_max_deduct(env: Env) -> i128 {
-        env.storage()
-            .instance()
-            .get(&StorageKey::MaxDeduct)
-            .unwrap_or(DEFAULT_MAX_DEDUCT)
     }
 
     /// Store the settlement contract address (admin only).
@@ -1556,26 +1551,6 @@ impl CalloraVault {
     /// After calling `upgrade`, you may need to invoke a separate `migrate` function
     /// (if implemented in the new WASM) to update storage schema or perform data migrations.
     /// See UPGRADE.md for the complete operational flow.
-    pub fn broadcast(env: Env, caller: Address, severity: Severity, message: String) -> Result<(), VaultError> {
-        caller.require_auth();
-        let admin = Self::get_admin(env.clone())?;
-        if caller != admin {
-            return Err(VaultError::Unauthorized);
-        }
-        let len = message.len();
-        if len == 0 {
-            panic!("message cannot be empty");
-        }
-        if len > MAX_MESSAGE_LEN {
-            panic!("message length exceeds maximum of 256 characters");
-        }
-        env.events().publish(
-            (events::event_admin_broadcast(&env), caller),
-            AdminBroadcast { severity, message },
-        );
-        Ok(())
-    }
-
     pub fn upgrade(env: Env, caller: Address, new_wasm_hash: BytesN<32>) {
         caller.require_auth();
         let admin = Self::get_admin(env.clone()).expect("vault must be initialized before upgrade");
@@ -1795,6 +1770,7 @@ impl CalloraVault {
 
 mod events;
 pub mod rate_limit;
+mod validators;
 
 // ---------------------------------------------------------------------------
 // Test modules

--- a/contracts/vault/tests/event_order.rs
+++ b/contracts/vault/tests/event_order.rs
@@ -1,0 +1,333 @@
+use callora_vault::{CalloraVault, CalloraVaultClient, DeductItem};
+use soroban_sdk::testutils::{Address as _, Events as _};
+use soroban_sdk::{token, Address, Env, IntoVal, Symbol, Vec};
+use callora_settlement::CalloraSettlement;
+
+fn setup(env: &Env) -> (CalloraVaultClient<'_>, Address, Address, Address) {
+    env.mock_all_auths();
+    let owner = Address::generate(env);
+    let developer = Address::generate(env);
+    let vault_addr = env.register(CalloraVault, ());
+    let client = CalloraVaultClient::new(env, &vault_addr);
+
+    let usdc_addr = env
+        .register_stellar_asset_contract_v2(owner.clone())
+        .address();
+    let usdc_admin = token::StellarAssetClient::new(env, &usdc_addr);
+
+    usdc_admin.mint(&vault_addr, &10_000);
+    client.init(
+        &owner,
+        &usdc_addr,
+        &Some(10_000),
+        &None,
+        &None,
+        &None,
+        &None,
+    );
+
+    let settlement_addr = env.register(CalloraSettlement, ());
+    let settlement_client =
+        callora_settlement::CalloraSettlementClient::new(env, &settlement_addr);
+    settlement_client.init(&owner, &vault_addr);
+    client.set_settlement(&owner, &settlement_addr);
+
+    (client, owner, developer, vault_addr)
+}
+
+fn collect_deduct_events(
+    env: &Env,
+) -> Vec<(Address, Symbol)> {
+    let events = env.events().all();
+    let mut result: Vec<(Address, Symbol)> = Vec::new(env);
+    for ev in events.iter() {
+        if ev.1.is_empty() {
+            continue;
+        }
+        let s: Symbol = ev.1.get(0).unwrap().into_val(env);
+        if s != Symbol::new(env, "deduct") {
+            continue;
+        }
+        let caller: Address = ev.1.get(1).unwrap().into_val(env);
+        let rid: Symbol = ev.1.get(2).unwrap().into_val(env);
+        result.push_back((caller, rid));
+    }
+    result
+}
+
+#[test]
+fn batch_deduct_events_match_item_order() {
+    let env = Env::default();
+    let (client, owner, developer, _) = setup(&env);
+
+    let items = Vec::from_array(
+        &env,
+        [
+            DeductItem {
+                amount: 100,
+                request_id: Some(Symbol::new(&env, "item_a")),
+                developer: developer.clone(),
+            },
+            DeductItem {
+                amount: 200,
+                request_id: Some(Symbol::new(&env, "item_b")),
+                developer: developer.clone(),
+            },
+            DeductItem {
+                amount: 300,
+                request_id: Some(Symbol::new(&env, "item_c")),
+                developer: developer.clone(),
+            },
+        ],
+    );
+
+    client.batch_deduct(&owner, &items);
+
+    let deduct_events = collect_deduct_events(&env);
+    assert_eq!(deduct_events.len(), 3);
+
+    let (_c1, rid1) = deduct_events.get(0).unwrap();
+    assert_eq!(rid1, Symbol::new(&env, "item_a"));
+
+    let (_c2, rid2) = deduct_events.get(1).unwrap();
+    assert_eq!(rid2, Symbol::new(&env, "item_b"));
+
+    let (_c3, rid3) = deduct_events.get(2).unwrap();
+    assert_eq!(rid3, Symbol::new(&env, "item_c"));
+}
+
+#[test]
+fn batch_deduct_reverse_order_is_preserved() {
+    let env = Env::default();
+    let (client, owner, developer, _) = setup(&env);
+
+    let items = Vec::from_array(
+        &env,
+        [
+            DeductItem {
+                amount: 300,
+                request_id: Some(Symbol::new(&env, "z_last")),
+                developer: developer.clone(),
+            },
+            DeductItem {
+                amount: 200,
+                request_id: Some(Symbol::new(&env, "m_mid")),
+                developer: developer.clone(),
+            },
+            DeductItem {
+                amount: 100,
+                request_id: Some(Symbol::new(&env, "a_first")),
+                developer: developer.clone(),
+            },
+        ],
+    );
+
+    client.batch_deduct(&owner, &items);
+
+    let deduct_events = collect_deduct_events(&env);
+    assert_eq!(deduct_events.len(), 3);
+
+    let (_, rid0) = deduct_events.get(0).unwrap();
+    assert_eq!(rid0, Symbol::new(&env, "z_last"));
+    let (_, rid1) = deduct_events.get(1).unwrap();
+    assert_eq!(rid1, Symbol::new(&env, "m_mid"));
+    let (_, rid2) = deduct_events.get(2).unwrap();
+    assert_eq!(rid2, Symbol::new(&env, "a_first"));
+}
+
+#[test]
+fn sequential_deduct_events_match_call_order() {
+    let env = Env::default();
+    let (client, owner, developer, _) = setup(&env);
+
+    client.deduct(
+        &owner,
+        &100,
+        &Some(Symbol::new(&env, "first_call")),
+        &u16::MAX,
+        &developer,
+    );
+    client.deduct(
+        &owner,
+        &200,
+        &Some(Symbol::new(&env, "second_call")),
+        &u16::MAX,
+        &developer,
+    );
+    client.deduct(
+        &owner,
+        &300,
+        &Some(Symbol::new(&env, "third_call")),
+        &u16::MAX,
+        &developer,
+    );
+
+    let deduct_events = collect_deduct_events(&env);
+    assert_eq!(deduct_events.len(), 3);
+
+    let (_, rid0) = deduct_events.get(0).unwrap();
+    assert_eq!(rid0, Symbol::new(&env, "first_call"));
+    let (_, rid1) = deduct_events.get(1).unwrap();
+    assert_eq!(rid1, Symbol::new(&env, "second_call"));
+    let (_, rid2) = deduct_events.get(2).unwrap();
+    assert_eq!(rid2, Symbol::new(&env, "third_call"));
+}
+
+#[test]
+fn mixed_deposit_deduct_withdraw_event_order() {
+    let env = Env::default();
+    let (client, owner, developer, vault_addr) = setup(&env);
+
+    client.deposit(&owner, &500);
+
+    client.deduct(
+        &owner,
+        &200,
+        &Some(Symbol::new(&env, "deduct_1")),
+        &u16::MAX,
+        &developer,
+    );
+
+    client.withdraw(&100);
+
+    let events = env.events().all();
+    let mut event_types: Vec<Symbol> = Vec::new(&env);
+    for ev in events.iter() {
+        if ev.1.is_empty() {
+            continue;
+        }
+        let s: Symbol = ev.1.get(0).unwrap().into_val(&env);
+        event_types.push_back(s);
+    }
+
+    let mut idx = 0;
+    let expected_order = [
+        "init",
+        "set_settlement",
+        "deposit",
+        "deduct",
+        "withdraw",
+    ];
+    for et in event_types.iter() {
+        let s: Symbol = et;
+        let mut buf = [0u8; 32];
+        let len = s.to_str().copy_into_slice(&mut buf);
+        let name = core::str::from_utf8(&buf[..len as usize]).unwrap();
+        if idx < expected_order.len() && name == expected_order[idx] {
+            idx += 1;
+        }
+    }
+    assert!(
+        idx >= expected_order.len(),
+        "expected all event types in order, got stuck at {}",
+        expected_order.get(idx).unwrap_or(&"end")
+    );
+}
+
+#[test]
+fn batch_deduct_deterministic_across_repeated_calls() {
+    let env = Env::default();
+    let (client, owner, developer, _) = setup(&env);
+
+    let items = Vec::from_array(
+        &env,
+        [
+            DeductItem {
+                amount: 100,
+                request_id: Some(Symbol::new(&env, "id1")),
+                developer: developer.clone(),
+            },
+            DeductItem {
+                amount: 200,
+                request_id: Some(Symbol::new(&env, "id2")),
+                developer: developer.clone(),
+            },
+        ],
+    );
+
+    for _ in 0..5 {
+        let snapshot = env.events().all();
+        client.batch_deduct(&owner, &items);
+        let events = env.events().all();
+        let new_count = events.len() - snapshot.len();
+        let deduct_count = events
+            .iter()
+            .filter(|e| {
+                if e.1.is_empty() {
+                    return false;
+                }
+                let s: Symbol = e.1.get(0).unwrap().into_val(&env);
+                s == Symbol::new(&env, "deduct")
+            })
+            .count();
+        let snapshot_deduct_count = snapshot
+            .iter()
+            .filter(|e| {
+                if e.1.is_empty() {
+                    return false;
+                }
+                let s: Symbol = e.1.get(0).unwrap().into_val(&env);
+                s == Symbol::new(&env, "deduct")
+            })
+            .count();
+        assert_eq!(
+            deduct_count - snapshot_deduct_count,
+            2,
+            "each batch_deduct call should emit exactly 2 deduct events (iteration {})",
+            _
+        );
+    }
+}
+
+#[test]
+fn deposit_event_emitted_before_deduct_event() {
+    let env = Env::default();
+    let (client, owner, developer, _) = setup(&env);
+
+    client.deposit(&owner, &500);
+
+    client.deduct(
+        &owner,
+        &100,
+        &Some(Symbol::new(&env, "r1")),
+        &u16::MAX,
+        &developer,
+    );
+
+    let events = env.events().all();
+    let mut deposit_positions: Vec<u32> = Vec::new(&env);
+    let mut deduct_positions: Vec<u32> = Vec::new(&env);
+    for (i, ev) in events.iter().enumerate() {
+        if ev.1.is_empty() {
+            continue;
+        }
+        let s: Symbol = ev.1.get(0).unwrap().into_val(&env);
+        let name = s.to_str();
+        let mut buf = [0u8; 32];
+        let len = name.copy_into_slice(&mut buf);
+        let name_str = core::str::from_utf8(&buf[..len as usize]).unwrap();
+        if name_str == "deposit" {
+            deposit_positions.push_back(i as u32);
+        } else if name_str == "deduct" {
+            deduct_positions.push_back(i as u32);
+        }
+    }
+
+    assert!(
+        deposit_positions.len() >= 1,
+        "expected at least one deposit event"
+    );
+    assert!(
+        deduct_positions.len() >= 1,
+        "expected at least one deduct event"
+    );
+
+    let last_deposit = deposit_positions
+        .get(deposit_positions.len() - 1)
+        .unwrap();
+    let first_deduct = deduct_positions.get(0).unwrap();
+    assert!(
+        last_deposit < first_deduct,
+        "deposit event must appear before deduct event in the event log"
+    );
+}


### PR DESCRIPTION
## Description

Fixes 53 pre-existing compile errors in `callora-settlement` and 15 in `callora-vault` by aligning the settlement crate's types with the V2 per-token refactoring defined in `types.rs`.

## Changes

### `contracts/settlement/src/lib.rs`
- **`StorageKey` enum** — Expanded to match `types.rs`: added `DeveloperBalanceV1(Address)`, `DeveloperBalance(Address, Address)`, `DeveloperMinBalance(Address)`, `PendingDeveloperMigration(Address)`, `StorageVersion`
- **`DeveloperBalance` struct** — Added `token: Address` field (per-token accounting)
- **Event structs** — Added `token: Address` to `PaymentReceivedEvent`, `BalanceCreditedEvent`, `DeveloperWithdrawEvent`, `DeveloperForceCreditedEvent`
- **`SettlementError`** — Added 7 new variants: `MigrationSameAddress`, `InvalidMigrationTarget`, `NoDeveloperBalance`, `TimelockOverflow`, `MigrationNotFound`, `TimelockNotExpired`, `MigrationBalanceChanged`
- **New types** — `StorageEntryTtl`, `Severity`, `AdminBroadcast`, `AdminMigrationEvent`
- **`get_storage_ttl`** — Removed duplicate first implementation (contained stale injected code from pagination); kept the second complete version with USDC-aware per-token balance key lookup
- **`withdraw_developer_balance`** — Moved USDC token lookup earlier; uses two-arg `StorageKey::DeveloperBalance(developer, usdc)` for all balance storage operations
- **`batch_receive_payment`** — Removed stale single-arg `DeveloperBalance` writes; uses `balance_key` variable consistently
- **`force_credit_developer`** — Uses `balance_key` (two-arg) for all storage operations
- **Imports** — Added `String`, `PendingDeveloperMigration` (re-exported from `timelock`), added module declarations for `admin`, `limits`, `pagination`, `timelock`

### `contracts/settlement/src/limits.rs`
- Fixed path references: `crate::lib::CalloraSettlement` → `crate::CalloraSettlement`, `crate::errors::SettlementError` and `crate::types::StorageKey` → `crate::{SettlementError, StorageKey}`

### `contracts/settlement/src/pagination.rs`
- Added `token: Address` parameter to `get_page()`
- Added `token` field to `DeveloperBalance` struct construction
- Uses `StorageKey::DeveloperBalance(address, token)` for balance lookup

### `contracts/vault/src/lib.rs`
- Added `contracterror` to `soroban_sdk` imports
- Changed `StorageKey::Meta` → `StorageKey::MetaKey` (2 occurrences)
- Changed `max_fee_bps` type from `u16` to `u32` (u16 not supported as Soroban contract parameter in SDK 22)
- Changed `u16::MAX` → `u32::MAX` references
- Added missing `token` argument to two `settlement_client.receive_payment()` calls
- Removed duplicate `get_max_deduct` function
- Removed duplicate `broadcast` function (kept the `Err()` returning version over `panic!()` version)
- Added `mod validators;` declaration

### `contracts/vault/tests/event_order.rs` (new)
- Draft integration test for stable event emission ordering across runs

## Verification

| Crate | Command | Result |
|-------|---------|--------|
| `callora-settlement` | `cargo check --lib` | ✅ 0 errors |
| `callora-vault` | `cargo check --lib` | ✅ 0 errors |

> **Note:** Full test suites cannot execute in this environment — `dlltool.exe` is missing from the MinGW-w64 toolchain. Run on a system with the MinGW toolchain or use `rustup default stable-msvc` to test.

## Breaking Changes

- `max_fee_bps` in vault `deduct` / `batch_deduct` changed from `u16` to `u32`
- `StorageKey::Meta` renamed to `StorageKey::MetaKey`
- `StorageKey::DeveloperBalance(Address)` → `StorageKey::DeveloperBalance(Address, Address)` (requires token parameter)
- `DeveloperBalance` struct now requires `token: Address` field
- `PaymentReceivedEvent`, `BalanceCreditedEvent`, `DeveloperWithdrawEvent`, `DeveloperForceCreditedEvent` now include `token` field

closes #532 