### PR TITLE
Add contracterror pausestate

### DIFF
--- a/contracts/vault/src/errors.rs
+++ b/contracts/vault/src/errors.rs
@@ -42,6 +42,9 @@ use soroban_sdk::contracterror;
 /// | 32   | StaleNonce                     | Rotation nonce does not match the stored current nonce   |
 /// | 33   | NewRevenuePoolSameAsCurrent    | Proposed revenue pool matches the current revenue pool   |
 /// | 34   | NoRevenuePoolTransferPending   | No revenue-pool transfer is pending                      |
+/// | 35   | Slippage                       | Fee basis points exceeds caller limit                    |
+/// | 36   | RateLimited                    | Developer rate limit has been exceeded                   |
+/// | 37   | PausedState                    | Operation is rejected because the vault is paused        |
 #[contracterror]
 #[repr(u32)]
 #[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
@@ -118,4 +121,6 @@ pub enum VaultError {
     Slippage = 35,
     /// Rate limit exceeded for the developer (code 36).
     RateLimited = 36,
+    /// Operation is rejected because the vault is paused (code 37).
+    PausedState = 37,
 }

--- a/contracts/vault/src/lib.rs
+++ b/contracts/vault/src/lib.rs
@@ -31,8 +31,8 @@
 /// persistent, they do not silently archive. To prevent state bloat, an owner
 /// can explicitly prune old markers using `prune_processed_requests`.
 use soroban_sdk::{
-    contract, contractclient, contractimpl, contracttype, token, Address, BytesN, Env, String,
-    Symbol, Vec,
+    contract, contractclient, contracterror, contractimpl, contracttype, token, Address, BytesN,
+    Env, String, Symbol, Vec,
 };
 
 /// Typed error codes for the Callora Vault contract.
@@ -115,6 +115,8 @@ pub enum VaultError {
     Slippage = 35,
     /// Rate limit exceeded for the developer (code 36).
     RateLimited = 36,
+    /// Operation is rejected because the vault is paused (code 37).
+    PausedState = 37,
 }
 
 #[contracttype]
@@ -1680,7 +1682,7 @@ impl CalloraVault {
     #[inline(never)]
     fn require_not_paused(env: Env) -> Result<(), VaultError> {
         if Self::is_paused(env) {
-            return Err(VaultError::Paused);
+            return Err(VaultError::PausedState);
         }
         Ok(())
     }

--- a/contracts/vault/src/test.rs
+++ b/contracts/vault/src/test.rs
@@ -544,9 +544,7 @@ fn deposit_paused_fails() {
     usdc_client.approve(&owner, &vault_address, &100, &1000);
 
     let result = client.try_deposit(&owner, &100);
-    assert!(result.is_err());
-    // Should contain "vault is paused" but Error doesn't easily expose the string in tests without more setup
-    // but the transaction should fail.
+    assert_eq!(result, Err(Ok(VaultError::PausedState)));
 
     client.unpause(&owner);
     assert!(!client.is_paused());
@@ -1065,7 +1063,6 @@ fn deduct_authorized_caller_succeeds() {
 }
 
 #[test]
-#[should_panic(expected = "vault is paused")]
 fn deduct_paused_fails() {
     let env = Env::default();
     let owner = Address::generate(&env);
@@ -1075,7 +1072,8 @@ fn deduct_paused_fails() {
     fund_vault(&usdc_admin, &client.address, 1000);
     client.init(&owner, &usdc, &Some(1000), &None, &None, &None, &None);
     client.pause(&owner);
-    client.deduct(&owner, &100, &None, &u16::MAX);
+    let result = client.try_deduct(&owner, &100, &None, &u16::MAX);
+    assert_eq!(result, Err(Ok(VaultError::PausedState)));
 }
 
 #[test]
@@ -1402,7 +1400,7 @@ fn get_revenue_pool_consistent_after_deduct_operations() {
     client.deduct(&caller, &200, &None, &u16::MAX);
 
     // Query revenue pool after deduct - should be unchanged
-    let after = client.get_revenue_pool(, &Address::generate(&env));
+    let after = client.get_revenue_pool();
     assert_eq!(after, Some(revenue_pool.clone()));
     assert_eq!(before, after);
 
@@ -2611,7 +2609,7 @@ fn get_revenue_pool_consistent_after_deduct_operations() {
     client.deduct(&caller, &200, &None, &u16::MAX);
 
     // Query revenue pool after deduct - should be unchanged
-    let after = client.get_revenue_pool(, &Address::generate(&env));
+    let after = client.get_revenue_pool();
     assert_eq!(after, Some(revenue_pool.clone()));
     assert_eq!(before, after);
 
@@ -2934,7 +2932,7 @@ fn get_settlement_consistent_after_deduct_operations() {
     client.deduct(&caller, &200, &None, &u16::MAX);
 
     // Query settlement after deduct - should be unchanged
-    let after = client.get_settlement(, &Address::generate(&env));
+    let after = client.get_settlement();
     assert_eq!(after, settlement);
     assert_eq!(before, after);
 
@@ -3536,7 +3534,6 @@ fn get_pending_admin_returns_some_after_transfer() {
     assert_eq!(client.get_pending_admin(), None);
 }
 #[test]
-#[should_panic(expected = "vault is paused")]
 fn deduct_while_paused_fails() {
     let env = Env::default();
     let owner = Address::generate(&env);
@@ -3548,11 +3545,11 @@ fn deduct_while_paused_fails() {
     let settlement = create_settlement(&env, &owner, &vault_address);
     client.set_settlement(&owner, &settlement);
     client.pause(&owner);
-    client.deduct(&owner, &100, &None, &u16::MAX);
+    let result = client.try_deduct(&owner, &100, &None, &u16::MAX);
+    assert_eq!(result, Err(Ok(VaultError::PausedState)));
 }
 
 #[test]
-#[should_panic(expected = "vault is paused")]
 fn batch_deduct_while_paused_fails() {
     let env = Env::default();
     let owner = Address::generate(&env, &Address::generate(&env));
@@ -3571,7 +3568,8 @@ fn batch_deduct_while_paused_fails() {
             request_id: None
         , developer: Address::generate(&env) }
     ];
-    client.batch_deduct(&owner, &items); // must panic with "vault is paused"
+    let result = client.try_batch_deduct(&owner, &items);
+    assert_eq!(result, Err(Ok(VaultError::PausedState)));
 }
 
 #[test]
@@ -3780,7 +3778,7 @@ fn deduct_without_settlement_panics() {
 }
 
 #[test]
-fn deduct_without_settlement_does_not_mutate_state(, &Address::generate(&env)) {
+fn deduct_without_settlement_does_not_mutate_state() {
     // When deduct panics due to missing settlement, vault state must be unchanged.
     let env = Env::default();
     let owner = Address::generate(&env);

--- a/contracts/vault/src/test_error_codes.rs
+++ b/contracts/vault/src/test_error_codes.rs
@@ -40,15 +40,21 @@ fn vault_error_codes_are_stable_and_unique() {
         (32, VaultError::StaleNonce),
         (33, VaultError::NewRevenuePoolSameAsCurrent),
         (34, VaultError::NoRevenuePoolTransferPending),
+        (35, VaultError::Slippage),
+        (36, VaultError::RateLimited),
+        (37, VaultError::PausedState),
     ];
 
     let mut seen = BTreeSet::new();
     for (expected_code, variant) in mappings {
         assert_eq!(variant as u32, expected_code);
-        assert!(seen.insert(expected_code), "duplicate vault error code {expected_code}");
+        assert!(
+            seen.insert(expected_code),
+            "duplicate vault error code {expected_code}"
+        );
     }
 
-    assert_eq!(seen.len(), 34);
+    assert_eq!(seen.len(), 37);
 }
 
 #[test]
@@ -89,6 +95,9 @@ fn error_code_docs_list_every_vault_code() {
         "| 32 | `StaleNonce` | Vault | Rotation nonce does not match the stored current nonce |",
         "| 33 | `NewRevenuePoolSameAsCurrent` | Vault | Proposed revenue pool matches the current revenue pool |",
         "| 34 | `NoRevenuePoolTransferPending` | Vault | No revenue-pool transfer is pending |",
+        "| 35 | `Slippage` | Vault | Fee basis points exceeds the caller-supplied maximum |",
+        "| 36 | `RateLimited` | Vault | Developer rate limit has been exceeded |",
+        "| 37 | `PausedState` | Vault | Operation is rejected because the vault is paused |",
     ];
 
     for line in expected_lines {

--- a/docs/ERROR_CODES.md
+++ b/docs/ERROR_CODES.md
@@ -49,6 +49,9 @@ must not be reassigned once released.
 | 32 | `StaleNonce` | Vault | Rotation nonce does not match the stored current nonce |
 | 33 | `NewRevenuePoolSameAsCurrent` | Vault | Proposed revenue pool matches the current revenue pool |
 | 34 | `NoRevenuePoolTransferPending` | Vault | No revenue-pool transfer is pending |
+| 35 | `Slippage` | Vault | Fee basis points exceeds the caller-supplied maximum |
+| 36 | `RateLimited` | Vault | Developer rate limit has been exceeded |
+| 37 | `PausedState` | Vault | Operation is rejected because the vault is paused |
 
 ## Settlement
 


### PR DESCRIPTION
Motivation
Make pause-related rejections explicitly machine-readable by adding a dedicated PausedState error variant so callers can deterministically handle pause vs. other pause-related conditions.
Description
Add VaultError::PausedState = 37 to the Vault error enum and update the public error-code table in docs/ERROR_CODES.md.
Change the vault pause guard to return VaultError::PausedState from require_not_paused() instead of the previous generic paused handling.
Update unit tests to assert the explicit PausedState result on pause-blocked code paths (try_deposit, try_deduct, try_batch_deduct) and update test_error_codes to include the new variant and expected mapping count.
Fix a few malformed test call sites in the vault tests that prevented parsing so the updated tests compile (call-site formatting and get_revenue_pool/get_settlement call fixes).
Testing
Ran cargo fmt locally to normalize formatting (succeeded for the touched files).
Ran the contract test build cargo test -p callora-vault test_error_codes -- --nocapture and related compile attempts; the run failed due to existing unrelated workspace compile errors and duplicate/undefined symbols in other contracts (these failures are not caused by the error-variant change itself).
Updated unit tests in contracts/vault/src/test.rs and contracts/vault/src/test_error_codes.rs to assert Err(Ok(VaultError::PausedState)) for paused deposits/deducts/batch-deducts (these focused assertions are included in the PR but the full workspace test run did not complete due to unrelated compilation issues).
Closes https://github.com/CalloraOrg/Callora-Contracts/issues/556