### PR TITLE
Add admin nuclear pause

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ The primary storage and metering contract. Holds USDC on behalf of API consumers
 - `set_allowed_depositor(caller, depositor)` — Owner-only; delegate deposit rights.
 - `set_authorized_caller(caller)` — Owner-only; set the address permitted to trigger deductions.
 - `pause(caller)` — Admin/owner-only; activate circuit-breaker to block deposits and deductions.
+- `nuclear_pause(caller)` — Admin-only emergency pause path. If admin is a Stellar multisig account, native account thresholds and signer weights are enforced by `require_auth`.
 - `unpause(caller)` — Admin/owner-only; deactivate circuit-breaker to restore operations.
 - `is_paused()` — View; returns current pause state.
 - `get_meta()` — View; returns `VaultMeta` (owner, balance, authorized_caller, min_deposit). Panics if uninitialized.
@@ -189,4 +190,3 @@ See [SECURITY.md](SECURITY.md) for the full Vault Security Checklist and audit r
 ---
 
 Part of [Callora](https://github.com/CalloraOrg).
-

--- a/contracts/vault/ACCESS_CONTROL.md
+++ b/contracts/vault/ACCESS_CONTROL.md
@@ -29,8 +29,8 @@ The **Owner** has the highest level of privilege. They are responsible for the m
 The **Admin** role is designed for tactical system management. By default, the Admin is the Owner upon initialization.
 
 - **Management**: The current Admin can transfer the role via `set_admin`.
-- **Primary Power**: Can call `distribute` and `set_settlement`.
-- **Use Case**: Used by settlement services or automated distribution logic.
+- **Primary Power**: Can call `distribute`, `set_settlement`, and `nuclear_pause`.
+- **Use Case**: Used by settlement services, automated distribution logic, or a Stellar multisig emergency council. When Admin is a multisig account, `require_auth` enforces native threshold and signer-weight policy for `nuclear_pause`.
 
 ### 3. Authorized Caller
 

--- a/contracts/vault/src/lib.rs
+++ b/contracts/vault/src/lib.rs
@@ -748,6 +748,30 @@ impl CalloraVault {
         Ok(())
     }
 
+    /// Activate the circuit breaker through the configured admin address only.
+    ///
+    /// This is the emergency "nuclear pause" path intended for deployments where
+    /// `StorageKey::Admin` is a Stellar multisig account. Calling
+    /// `admin.require_auth()` makes the host enforce that account's multisig
+    /// thresholds and signer weights before the vault can be paused.
+    ///
+    /// Unlike `pause`, the owner fallback is intentionally not accepted here:
+    /// the nuclear-pause authority is the configured admin/multisig account.
+    pub fn nuclear_pause(env: Env, caller: Address) -> Result<(), VaultError> {
+        caller.require_auth();
+        let admin = Self::get_admin(env.clone())?;
+        if caller != admin {
+            return Err(VaultError::Unauthorized);
+        }
+        if Self::is_paused(env.clone()) {
+            return Err(VaultError::AlreadyPaused);
+        }
+        env.storage().instance().set(&StorageKey::Paused, &true);
+        env.events()
+            .publish((events::event_vault_paused(&env), caller), ());
+        Ok(())
+    }
+
     pub fn unpause(env: Env, caller: Address) -> Result<(), VaultError> {
         caller.require_auth();
         Self::require_admin_or_owner(env.clone(), &caller)?;

--- a/contracts/vault/src/test.rs
+++ b/contracts/vault/src/test.rs
@@ -874,6 +874,49 @@ fn pause_emits_event() {
     assert_eq!(admin_topic, owner);
 }
 
+#[test]
+fn nuclear_pause_requires_current_admin_and_sets_pause() {
+    let env = Env::default();
+    let owner = Address::generate(&env);
+    let admin = Address::generate(&env);
+    let intruder = Address::generate(&env);
+    let (_, client) = create_vault(&env);
+    let (usdc, _, _) = create_usdc(&env, &owner);
+
+    env.mock_all_auths();
+    client.init(&owner, &usdc, &None, &None, &None, &None, &None);
+    client.set_admin(&owner, &admin);
+    client.accept_admin();
+    assert_eq!(client.get_admin(), admin);
+
+    let intruder_res = client.try_nuclear_pause(&intruder);
+    assert!(intruder_res.is_err(), "intruder cannot nuclear-pause");
+
+    let owner_res = client.try_nuclear_pause(&owner);
+    assert!(
+        owner_res.is_err(),
+        "owner fallback is not accepted for the admin/multisig nuclear pause"
+    );
+
+    client.nuclear_pause(&admin);
+    assert!(client.is_paused());
+}
+
+#[test]
+fn nuclear_pause_rejects_already_paused() {
+    let env = Env::default();
+    let owner = Address::generate(&env);
+    let (_, client) = create_vault(&env);
+    let (usdc, _, _) = create_usdc(&env, &owner);
+
+    env.mock_all_auths();
+    client.init(&owner, &usdc, &None, &None, &None, &None, &None);
+    client.nuclear_pause(&owner);
+
+    let res = client.try_nuclear_pause(&owner);
+    assert!(res.is_err(), "nuclear_pause must be idempotency-safe");
+}
+
 // ---------------------------------------------------------------------------
 // Deduct tests
 // ---------------------------------------------------------------------------

--- a/docs/ACCESS_CONTROL.md
+++ b/docs/ACCESS_CONTROL.md
@@ -11,6 +11,7 @@ The Callora Vault implements role-based access control for deposit operations to
 - **Authorized Caller**: Optional address permitted to trigger `deduct` operations.
 - **Pending Owner**: Nominee awaiting acceptance of the owner role.
 - **Pending Admin**: Nominee awaiting acceptance of the admin role.
+- **Admin / Multisig Admin**: Current admin address. If this address is a Stellar multisig account, native thresholds and signer weights are enforced by `require_auth`.
 - **Pending Revenue Pool**: Proposed revenue pool address awaiting acceptance.
 
 ### Authorization Matrix
@@ -35,6 +36,7 @@ The Callora Vault implements role-based access control for deposit operations to
 | `accept_revenue_pool` | ❌ | ❌ | ❌ | ❌ | ✅ |
 | `cancel_revenue_pool` | ✅ | ❌ | ❌ | ❌ | ❌ |
 | `pause` | ✅ | ❌ | ❌ | ❌ | ❌ |
+| `nuclear_pause` | ❌ | ❌ | ❌ | ❌ | Admin only |
 | `unpause` | ✅ | ❌ | ❌ | ❌ | ❌ |
 
 ### Security Model
@@ -42,6 +44,7 @@ The Callora Vault implements role-based access control for deposit operations to
 - **Two-Step Admin Rotation**: Prevents accidental loss of control by requiring the nominee to explicitly accept the role.
 - **Cancellation Safety**: Provides `cancel_ownership_transfer` and `cancel_admin_transfer` functions to abort mistaken nominations before acceptance.
 - **Restricted Depositors**: Only owner and explicitly allowed depositors can increase vault balance.
+- **Multisig-Guarded Nuclear Pause**: `nuclear_pause(caller)` accepts only the current admin address and calls `caller.require_auth()`, so deployments that set admin to a Stellar multisig account get native threshold enforcement for the emergency pause.
 - **Nonce-Bound Authorized-Caller Rotation**: `set_authorized_caller` requires the caller to supply the current monotonic nonce (see below), preventing a leaked owner signature from being replayed to reinstate a stale `authorized_caller`.
 
 ### Authorized-Caller Replay Protection

--- a/docs/interfaces/vault.json
+++ b/docs/interfaces/vault.json
@@ -519,6 +519,26 @@
     },
 
     {
+      "name": "nuclear_pause",
+      "description": "Admin-only emergency circuit breaker. Intended for a configured Stellar multisig admin account; require_auth enforces that account's thresholds and signer weights. Blocks deposit, deduct, and batch_deduct.",
+      "access": "admin only (must sign; native account multisig thresholds apply)",
+      "params": [
+        {
+          "name": "caller",
+          "type": "Address",
+          "optional": false,
+          "description": "Must be the current admin address; must authorize."
+        }
+      ],
+      "returns": "void",
+      "panics": [
+        "\"unauthorized: caller is not admin\" â€” auth failure.",
+        "\"vault already paused\" â€” already in paused state."
+      ],
+      "events": [{ "topics": ["\"vault_paused\"", "caller"], "data": "void" }]
+    },
+
+    {
       "name": "set_allowed_depositor",
       "description": "Add or clear the set of allowed depositors. Pass Some(address) to add; None to revoke all.",
       "access": "owner",


### PR DESCRIPTION
Motivation
Provide an admin-only emergency "nuclear" pause that is guarded by the configured Admin address so deployments can set Admin to a Stellar multisig and rely on native multisig thresholds via require_auth.
Description
Add nuclear_pause(env: Env, caller: Address) to contracts/vault/src/lib.rs which requires the caller to be the current admin (calls caller.require_auth()), rejects non-admin callers and already-paused state, sets the Paused storage key, and publishes the existing vault_paused event.
Add focused tests in contracts/vault/src/test.rs covering: current-admin-only access after admin rotation, owner fallback rejection, successful pause, and rejecting an already-paused call.
Update operator and interface documentation: README.md, docs/interfaces/vault.json, docs/ACCESS_CONTROL.md, and contracts/vault/ACCESS_CONTROL.md to document the new nuclear_pause API and the multisig security model.
Small test/format adjustments only where necessary for the new behavior and docs; commit created with message feat: admin nuclear pause.
Testing
Ran git diff --check which passed before committing the changes.
Attempted cargo test -p callora-vault nuclear_pause -- --nocapture and cargo test -p callora-vault pause_unpause_admin_only -- --nocapture, but test runs failed to complete due to pre-existing repository compile errors (duplicate contract exports and unrelated syntax issues in vault/settlement test code), so the new tests were added but could not be validated end-to-end in this environment.
cargo fmt --all could not complete because of pre-existing syntax errors outside the scope of this PR (in contracts/vault/src/test.rs).
Closes https://github.com/CalloraOrg/Callora-Contracts/issues/561