### PR TITLE
feat: revenue_pool emergency drain

### DIFF
--- a/contracts/revenue_pool/src/emergency.rs
+++ b/contracts/revenue_pool/src/emergency.rs
@@ -1,0 +1,28 @@
+//! Emergency drain types and constants for the revenue pool.
+//!
+//! The emergency drain allows the admin to propose, execute, and cancel a
+//! timelocked USDC drain to a designated address (typically the treasury).
+
+use soroban_sdk::{contracttype, Address};
+
+/// Mandatory delay between proposing and executing an emergency drain (24 hours).
+pub const EMERGENCY_DRAIN_TIMELOCK_SECONDS: u64 = 86_400;
+
+pub(crate) const EMERGENCY_DRAIN_KEY: &str = "emergency_drain";
+
+/// Immutable snapshot stored for a pending emergency drain proposal.
+///
+/// Captures the destination, amount, proposal timestamp, and the earliest
+/// ledger timestamp at which the drain may be executed.
+#[contracttype]
+#[derive(Clone, Debug, PartialEq)]
+pub struct PendingEmergencyDrain {
+    /// Address that will receive the drained USDC.
+    pub to: Address,
+    /// Amount of USDC in base units to drain.
+    pub amount: i128,
+    /// Ledger timestamp when the proposal was created.
+    pub proposed_at: u64,
+    /// Earliest ledger timestamp at which the drain may be executed.
+    pub execute_after: u64,
+}

--- a/contracts/revenue_pool/src/events.rs
+++ b/contracts/revenue_pool/src/events.rs
@@ -118,6 +118,30 @@ pub fn event_admin_broadcast(env: &Env) -> Symbol {
     Symbol::new(env, "admin_broadcast")
 }
 
+/// Returns the Symbol for the `"emergency_drain_proposed"` event topic.
+///
+/// Emitted when the admin proposes a timelocked emergency drain via
+/// [`RevenuePool::propose_emergency_drain`].
+pub fn event_emergency_drain_proposed(env: &Env) -> Symbol {
+    Symbol::new(env, "emergency_drain_proposed")
+}
+
+/// Returns the Symbol for the `"emergency_drain_executed"` event topic.
+///
+/// Emitted when the admin executes a pending emergency drain after the
+/// timelock has expired via [`RevenuePool::execute_emergency_drain`].
+pub fn event_emergency_drain_executed(env: &Env) -> Symbol {
+    Symbol::new(env, "emergency_drain_executed")
+}
+
+/// Returns the Symbol for the `"emergency_drain_cancelled"` event topic.
+///
+/// Emitted when the admin cancels a pending emergency drain via
+/// [`RevenuePool::cancel_emergency_drain`].
+pub fn event_emergency_drain_cancelled(env: &Env) -> Symbol {
+    Symbol::new(env, "emergency_drain_cancelled")
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -246,5 +270,35 @@ mod tests {
     fn test_event_admin_broadcast_bytes() {
         let env = Env::default();
         assert_eq!(event_admin_broadcast(&env), Symbol::new(&env, "admin_broadcast"));
+    }
+
+    /// Snapshot: proves event_emergency_drain_proposed still maps to exactly the bytes for "emergency_drain_proposed".
+    #[test]
+    fn test_event_emergency_drain_proposed_bytes() {
+        let env = Env::default();
+        assert_eq!(
+            event_emergency_drain_proposed(&env),
+            Symbol::new(&env, "emergency_drain_proposed")
+        );
+    }
+
+    /// Snapshot: proves event_emergency_drain_executed still maps to exactly the bytes for "emergency_drain_executed".
+    #[test]
+    fn test_event_emergency_drain_executed_bytes() {
+        let env = Env::default();
+        assert_eq!(
+            event_emergency_drain_executed(&env),
+            Symbol::new(&env, "emergency_drain_executed")
+        );
+    }
+
+    /// Snapshot: proves event_emergency_drain_cancelled still maps to exactly the bytes for "emergency_drain_cancelled".
+    #[test]
+    fn test_event_emergency_drain_cancelled_bytes() {
+        let env = Env::default();
+        assert_eq!(
+            event_emergency_drain_cancelled(&env),
+            Symbol::new(&env, "emergency_drain_cancelled")
+        );
     }
 }

--- a/contracts/revenue_pool/src/lib.rs
+++ b/contracts/revenue_pool/src/lib.rs
@@ -4,6 +4,9 @@ use soroban_sdk::{
     contract, contracterror, contractimpl, contracttype, token, Address, BytesN, Env, Map, String, Symbol, Vec,
 };
 
+#[cfg(any(test, feature = "testutils"))]
+use soroban_sdk::testutils::storage::Instance;
+
 /// Revenue settlement contract: receives USDC from vault deducts and distributes to developers.
 ///
 /// Flow: vault deduct → vault transfers USDC to this contract → admin calls distribute(to, amount).
@@ -916,10 +919,183 @@ impl RevenuePool {
 
         result
     }
+
+    /// Propose an emergency drain of USDC from the revenue pool to a designated address.
+    ///
+    /// Only the current admin may call this function. The drain is subject to a
+    /// 24-hour timelock before it can be executed via [`Self::execute_emergency_drain`].
+    /// If a previous drain proposal exists, it is replaced.
+    ///
+    /// # Arguments
+    /// * `env` - The environment running the contract.
+    /// * `caller` - Must be the current admin; must authorize.
+    /// * `to` - Address that will receive the drained USDC (typically the treasury).
+    /// * `amount` - Amount of USDC in base units to drain. Must be positive.
+    ///
+    /// # Panics
+    /// * If the caller is not the current admin.
+    /// * If `amount` is zero or negative.
+    /// * If `to` is the contract itself.
+    /// * If the revenue pool has not been initialized.
+    ///
+    /// # Events
+    /// Emits `emergency_drain_proposed` with `admin` as topic and a
+    /// [`PendingEmergencyDrain`] as data.
+    pub fn propose_emergency_drain(env: Env, caller: Address, to: Address, amount: i128) {
+        caller.require_auth();
+        let admin = Self::get_admin(env.clone());
+        if caller != admin {
+            panic!("{}", ERR_UNAUTHORIZED);
+        }
+        if amount <= 0 {
+            panic!("{}", ERR_AMOUNT_NOT_POSITIVE);
+        }
+        // Validate initialization by reading USDC address.
+        env.storage()
+            .instance()
+            .get::<_, Address>(&Symbol::new(&env, USDC_KEY))
+            .expect(ERR_NOT_INITIALIZED);
+        if to == env.current_contract_address() {
+            panic!("invalid recipient: cannot drain to the contract itself");
+        }
+
+        let proposed_at = env.ledger().timestamp();
+        let execute_after = proposed_at
+            .checked_add(emergency::EMERGENCY_DRAIN_TIMELOCK_SECONDS)
+            .expect("timelock overflow");
+
+        let drain = emergency::PendingEmergencyDrain {
+            to: to.clone(),
+            amount,
+            proposed_at,
+            execute_after,
+        };
+
+        let inst = env.storage().instance();
+        inst.set(
+            &Symbol::new(&env, emergency::EMERGENCY_DRAIN_KEY),
+            &drain,
+        );
+        inst.extend_ttl(LIFETIME_THRESHOLD, BUMP_AMOUNT);
+
+        env.events().publish(
+            (events::event_emergency_drain_proposed(&env), admin),
+            drain,
+        );
+    }
+
+    /// Execute a previously proposed emergency drain after the timelock has expired.
+    ///
+    /// Only the current admin may call this function. Transfers the proposed
+    /// USDC amount from this contract to the destination address specified in the
+    /// pending proposal. The proposal is consumed on success to prevent replay.
+    ///
+    /// # Arguments
+    /// * `env` - The environment running the contract.
+    /// * `caller` - Must be the current admin; must authorize.
+    ///
+    /// # Panics
+    /// * If the caller is not the current admin.
+    /// * If no emergency drain proposal is pending.
+    /// * If the 24-hour timelock has not yet expired.
+    /// * If the contract's USDC balance is less than the proposed amount.
+    /// * If the revenue pool has not been initialized.
+    ///
+    /// # Events
+    /// Emits `emergency_drain_executed` with `admin` as topic and
+    /// `(to, amount, proposed_at, executed_at)` as data.
+    pub fn execute_emergency_drain(env: Env, caller: Address) {
+        caller.require_auth();
+        let admin = Self::get_admin(env.clone());
+        if caller != admin {
+            panic!("{}", ERR_UNAUTHORIZED);
+        }
+
+        let inst = env.storage().instance();
+        let drain: emergency::PendingEmergencyDrain = inst
+            .get(&Symbol::new(&env, emergency::EMERGENCY_DRAIN_KEY))
+            .expect("no pending emergency drain");
+
+        let executed_at = env.ledger().timestamp();
+        if executed_at < drain.execute_after {
+            panic!("emergency drain timelock has not expired");
+        }
+
+        let usdc_address: Address = inst
+            .get(&Symbol::new(&env, USDC_KEY))
+            .expect(ERR_NOT_INITIALIZED);
+        let usdc = token::Client::new(&env, &usdc_address);
+        let contract_address = env.current_contract_address();
+
+        if usdc.balance(&contract_address) < drain.amount {
+            panic!("{}", ERR_INSUFFICIENT_BALANCE);
+        }
+
+        // Consume the proposal before transferring to prevent replay.
+        inst.remove(&Symbol::new(&env, emergency::EMERGENCY_DRAIN_KEY));
+        inst.extend_ttl(LIFETIME_THRESHOLD, BUMP_AMOUNT);
+
+        usdc.transfer(&contract_address, &drain.to, &drain.amount);
+
+        env.events().publish(
+            (events::event_emergency_drain_executed(&env), admin),
+            (drain.to, drain.amount, drain.proposed_at, executed_at),
+        );
+    }
+
+    /// Cancel a pending emergency drain proposal.
+    ///
+    /// Only the current admin may call this function.
+    ///
+    /// # Arguments
+    /// * `env` - The environment running the contract.
+    /// * `caller` - Must be the current admin; must authorize.
+    ///
+    /// # Panics
+    /// * If the caller is not the current admin.
+    /// * If no emergency drain proposal is pending.
+    ///
+    /// # Events
+    /// Emits `emergency_drain_cancelled` with `admin` as topic and the cancelled
+    /// [`PendingEmergencyDrain`] as data.
+    pub fn cancel_emergency_drain(env: Env, caller: Address) {
+        caller.require_auth();
+        let admin = Self::get_admin(env.clone());
+        if caller != admin {
+            panic!("{}", ERR_UNAUTHORIZED);
+        }
+
+        let inst = env.storage().instance();
+        let drain: emergency::PendingEmergencyDrain = inst
+            .get(&Symbol::new(&env, emergency::EMERGENCY_DRAIN_KEY))
+            .expect("no pending emergency drain");
+
+        inst.remove(&Symbol::new(&env, emergency::EMERGENCY_DRAIN_KEY));
+        inst.extend_ttl(LIFETIME_THRESHOLD, BUMP_AMOUNT);
+
+        env.events().publish(
+            (events::event_emergency_drain_cancelled(&env), admin),
+            drain,
+        );
+    }
+
+    /// Return the pending emergency drain proposal, or `None` if none is pending.
+    ///
+    /// # Arguments
+    /// * `env` - The environment running the contract.
+    ///
+    /// # Returns
+    /// `Some(PendingEmergencyDrain)` with the proposal details, or `None`.
+    pub fn get_pending_emergency_drain(env: Env) -> Option<emergency::PendingEmergencyDrain> {
+        env.storage()
+            .instance()
+            .get(&Symbol::new(&env, emergency::EMERGENCY_DRAIN_KEY))
+    }
 }
 
 
 mod events;
+mod emergency;
 /// Split `payments` into consecutive chunks of at most `chunk_size` legs each,
 /// preserving order.
 ///
@@ -985,3 +1161,6 @@ mod test_proptest;
 
 #[cfg(test)]
 mod test_error_codes;
+
+#[cfg(test)]
+mod test_emergency;

--- a/contracts/revenue_pool/src/test_emergency.rs
+++ b/contracts/revenue_pool/src/test_emergency.rs
@@ -1,0 +1,457 @@
+extern crate std;
+
+use super::*;
+use soroban_sdk::testutils::{Address as _, Events as _, Ledger as _};
+use soroban_sdk::token;
+use soroban_sdk::{Address, Env, Symbol, TryFromVal};
+
+fn create_usdc<'a>(
+    env: &'a Env,
+    admin: &Address,
+) -> (Address, token::Client<'a>, token::StellarAssetClient<'a>) {
+    let contract_address = env.register_stellar_asset_contract_v2(admin.clone());
+    let address = contract_address.address();
+    let client = token::Client::new(env, &address);
+    let admin_client = token::StellarAssetClient::new(env, &address);
+    (address, client, admin_client)
+}
+
+fn init_pool<'a>(
+    env: &'a Env,
+    admin: &Address,
+    usdc_address: &Address,
+) -> (Address, RevenuePoolClient<'a>) {
+    let pool_addr = env.register(RevenuePool, ());
+    let client = RevenuePoolClient::new(env, &pool_addr);
+    client.init(admin, usdc_address);
+    (pool_addr, client)
+}
+
+fn fund_pool(usdc_admin_client: &token::StellarAssetClient, pool_address: &Address, amount: i128) {
+    usdc_admin_client.mint(pool_address, &amount);
+}
+
+// ---------------------------------------------------------------------------
+// propose_emergency_drain
+// ---------------------------------------------------------------------------
+
+#[test]
+fn propose_success() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().set_timestamp(1_700_000_000);
+    let admin = Address::generate(&env);
+    let treasury = Address::generate(&env);
+    let (usdc_address, _, usdc_admin) = create_usdc(&env, &admin);
+    let (_pool, client) = init_pool(&env, &admin, &usdc_address);
+    fund_pool(&usdc_admin, &_pool, 10_000);
+
+    client.propose_emergency_drain(&admin, &treasury, &5_000);
+    let pending = client.get_pending_emergency_drain().unwrap();
+    assert_eq!(pending.to, treasury);
+    assert_eq!(pending.amount, 5_000);
+    assert_eq!(pending.proposed_at, 1_700_000_000);
+    assert_eq!(
+        pending.execute_after,
+        1_700_000_000 + emergency::EMERGENCY_DRAIN_TIMELOCK_SECONDS
+    );
+}
+
+#[test]
+fn propose_emits_event() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().set_timestamp(1_700_000_000);
+    let admin = Address::generate(&env);
+    let treasury = Address::generate(&env);
+    let (usdc_address, _, usdc_admin) = create_usdc(&env, &admin);
+    let (_pool, client) = init_pool(&env, &admin, &usdc_address);
+    fund_pool(&usdc_admin, &_pool, 10_000);
+
+    client.propose_emergency_drain(&admin, &treasury, &5_000);
+    let events = env.events().all();
+    let event = events.last().unwrap();
+    let topic: Symbol = Symbol::try_from_val(&env, &event.1.get(0).unwrap()).unwrap();
+    assert_eq!(topic, Symbol::new(&env, "emergency_drain_proposed"));
+    let caller: Address = Address::try_from_val(&env, &event.1.get(1).unwrap()).unwrap();
+    assert_eq!(caller, admin);
+    let data: emergency::PendingEmergencyDrain =
+        emergency::PendingEmergencyDrain::try_from_val(&env, &event.2).unwrap();
+    assert_eq!(data.to, treasury);
+    assert_eq!(data.amount, 5_000);
+}
+
+#[test]
+#[should_panic(expected = "unauthorized: caller is not admin")]
+fn propose_non_admin_panics() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let treasury = Address::generate(&env);
+    let (usdc_address, _, usdc_admin) = create_usdc(&env, &admin);
+    let (_pool, client) = init_pool(&env, &admin, &usdc_address);
+    fund_pool(&usdc_admin, &_pool, 10_000);
+    let outsider = Address::generate(&env);
+    client.propose_emergency_drain(&outsider, &treasury, &5_000);
+}
+
+#[test]
+#[should_panic(expected = "amount must be positive")]
+fn propose_zero_amount_panics() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let treasury = Address::generate(&env);
+    let (usdc_address, _, usdc_admin) = create_usdc(&env, &admin);
+    let (_pool, client) = init_pool(&env, &admin, &usdc_address);
+    fund_pool(&usdc_admin, &_pool, 10_000);
+    client.propose_emergency_drain(&admin, &treasury, &0);
+}
+
+#[test]
+#[should_panic(expected = "invalid recipient: cannot drain to the contract itself")]
+fn propose_self_drain_panics() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let (usdc_address, _, usdc_admin) = create_usdc(&env, &admin);
+    let (pool, client) = init_pool(&env, &admin, &usdc_address);
+    fund_pool(&usdc_admin, &pool, 10_000);
+    client.propose_emergency_drain(&admin, &pool, &5_000);
+}
+
+#[test]
+#[should_panic(expected = "revenue pool not initialized")]
+fn propose_not_initialized_panics() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let treasury = Address::generate(&env);
+    let pool_addr = env.register(RevenuePool, ());
+    let client = RevenuePoolClient::new(&env, &pool_addr);
+    client.propose_emergency_drain(&admin, &treasury, &1_000);
+}
+
+// ---------------------------------------------------------------------------
+// execute_emergency_drain
+// ---------------------------------------------------------------------------
+
+#[test]
+fn execute_success() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().set_timestamp(1_700_000_000);
+    let admin = Address::generate(&env);
+    let treasury = Address::generate(&env);
+    let (usdc_address, _, usdc_admin) = create_usdc(&env, &admin);
+    let (_pool, client) = init_pool(&env, &admin, &usdc_address);
+    fund_pool(&usdc_admin, &_pool, 10_000);
+
+    client.propose_emergency_drain(&admin, &treasury, &5_000);
+    env.ledger()
+        .set_timestamp(1_700_000_000 + emergency::EMERGENCY_DRAIN_TIMELOCK_SECONDS);
+    client.execute_emergency_drain(&admin);
+    assert!(client.get_pending_emergency_drain().is_none());
+}
+
+#[test]
+fn execute_transfers_usdc() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().set_timestamp(1_700_000_000);
+    let admin = Address::generate(&env);
+    let treasury = Address::generate(&env);
+    let (usdc_address, usdc_client, usdc_admin) = create_usdc(&env, &admin);
+    let (pool, client) = init_pool(&env, &admin, &usdc_address);
+    fund_pool(&usdc_admin, &pool, 10_000);
+
+    client.propose_emergency_drain(&admin, &treasury, &5_000);
+    env.ledger()
+        .set_timestamp(1_700_000_000 + emergency::EMERGENCY_DRAIN_TIMELOCK_SECONDS);
+    client.execute_emergency_drain(&admin);
+    assert_eq!(usdc_client.balance(&pool), 5_000);
+    assert_eq!(usdc_client.balance(&treasury), 5_000);
+}
+
+#[test]
+fn execute_emits_event() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().set_timestamp(1_700_000_000);
+    let admin = Address::generate(&env);
+    let treasury = Address::generate(&env);
+    let (usdc_address, _, usdc_admin) = create_usdc(&env, &admin);
+    let (_pool, client) = init_pool(&env, &admin, &usdc_address);
+    fund_pool(&usdc_admin, &_pool, 10_000);
+
+    client.propose_emergency_drain(&admin, &treasury, &5_000);
+    let executed_at = 1_700_000_000 + emergency::EMERGENCY_DRAIN_TIMELOCK_SECONDS;
+    env.ledger().set_timestamp(executed_at);
+    client.execute_emergency_drain(&admin);
+    let events = env.events().all();
+    let event = events
+        .iter()
+        .find(|ev| {
+            let topic: Symbol =
+                Symbol::try_from_val(&env, &ev.1.get(0).unwrap()).unwrap();
+            topic == Symbol::new(&env, "emergency_drain_executed")
+        })
+        .expect("emergency_drain_executed event not emitted");
+    let caller: Address = Address::try_from_val(&env, &event.1.get(1).unwrap()).unwrap();
+    assert_eq!(caller, admin);
+    let data: (Address, i128, u64, u64) =
+        <(Address, i128, u64, u64)>::try_from_val(&env, &event.2).unwrap();
+    assert_eq!(data.0, treasury);
+    assert_eq!(data.1, 5_000);
+    assert_eq!(data.2, 1_700_000_000);
+    assert_eq!(data.3, executed_at);
+}
+
+#[test]
+#[should_panic(expected = "emergency drain timelock has not expired")]
+fn execute_before_timelock_panics() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().set_timestamp(1_700_000_000);
+    let admin = Address::generate(&env);
+    let treasury = Address::generate(&env);
+    let (usdc_address, _, usdc_admin) = create_usdc(&env, &admin);
+    let (_pool, client) = init_pool(&env, &admin, &usdc_address);
+    fund_pool(&usdc_admin, &_pool, 10_000);
+
+    client.propose_emergency_drain(&admin, &treasury, &5_000);
+    client.execute_emergency_drain(&admin);
+}
+
+#[test]
+#[should_panic(expected = "no pending emergency drain")]
+fn execute_no_proposal_panics() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().set_timestamp(1_700_000_000);
+    let admin = Address::generate(&env);
+    let (usdc_address, _, usdc_admin) = create_usdc(&env, &admin);
+    let (_pool, client) = init_pool(&env, &admin, &usdc_address);
+    fund_pool(&usdc_admin, &_pool, 10_000);
+    env.ledger()
+        .set_timestamp(1_700_000_000 + emergency::EMERGENCY_DRAIN_TIMELOCK_SECONDS);
+    client.execute_emergency_drain(&admin);
+}
+
+#[test]
+#[should_panic(expected = "unauthorized: caller is not admin")]
+fn execute_non_admin_panics() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().set_timestamp(1_700_000_000);
+    let admin = Address::generate(&env);
+    let treasury = Address::generate(&env);
+    let (usdc_address, _, usdc_admin) = create_usdc(&env, &admin);
+    let (_pool, client) = init_pool(&env, &admin, &usdc_address);
+    fund_pool(&usdc_admin, &_pool, 10_000);
+    let outsider = Address::generate(&env);
+
+    client.propose_emergency_drain(&admin, &treasury, &5_000);
+    env.ledger()
+        .set_timestamp(1_700_000_000 + emergency::EMERGENCY_DRAIN_TIMELOCK_SECONDS);
+    client.execute_emergency_drain(&outsider);
+}
+
+#[test]
+#[should_panic(expected = "insufficient USDC balance")]
+fn execute_insufficient_balance_panics() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().set_timestamp(1_700_000_000);
+    let admin = Address::generate(&env);
+    let treasury = Address::generate(&env);
+    let (usdc_address, _, usdc_admin) = create_usdc(&env, &admin);
+    let (_pool, client) = init_pool(&env, &admin, &usdc_address);
+    fund_pool(&usdc_admin, &_pool, 10_000);
+
+    client.propose_emergency_drain(&admin, &treasury, &10_001);
+    env.ledger()
+        .set_timestamp(1_700_000_000 + emergency::EMERGENCY_DRAIN_TIMELOCK_SECONDS);
+    client.execute_emergency_drain(&admin);
+}
+
+#[test]
+fn execute_replay_protected() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().set_timestamp(1_700_000_000);
+    let admin = Address::generate(&env);
+    let treasury = Address::generate(&env);
+    let (usdc_address, _, usdc_admin) = create_usdc(&env, &admin);
+    let (_pool, client) = init_pool(&env, &admin, &usdc_address);
+    fund_pool(&usdc_admin, &_pool, 10_000);
+
+    client.propose_emergency_drain(&admin, &treasury, &5_000);
+    env.ledger()
+        .set_timestamp(1_700_000_000 + emergency::EMERGENCY_DRAIN_TIMELOCK_SECONDS);
+    client.execute_emergency_drain(&admin);
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        client.execute_emergency_drain(&admin);
+    }));
+    assert!(result.is_err());
+}
+
+// ---------------------------------------------------------------------------
+// cancel_emergency_drain
+// ---------------------------------------------------------------------------
+
+#[test]
+fn cancel_success() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().set_timestamp(1_700_000_000);
+    let admin = Address::generate(&env);
+    let treasury = Address::generate(&env);
+    let (usdc_address, _, usdc_admin) = create_usdc(&env, &admin);
+    let (_pool, client) = init_pool(&env, &admin, &usdc_address);
+    fund_pool(&usdc_admin, &_pool, 10_000);
+
+    client.propose_emergency_drain(&admin, &treasury, &5_000);
+    assert!(client.get_pending_emergency_drain().is_some());
+    client.cancel_emergency_drain(&admin);
+    assert!(client.get_pending_emergency_drain().is_none());
+}
+
+#[test]
+fn cancel_emits_event() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().set_timestamp(1_700_000_000);
+    let admin = Address::generate(&env);
+    let treasury = Address::generate(&env);
+    let (usdc_address, _, usdc_admin) = create_usdc(&env, &admin);
+    let (_pool, client) = init_pool(&env, &admin, &usdc_address);
+    fund_pool(&usdc_admin, &_pool, 10_000);
+
+    client.propose_emergency_drain(&admin, &treasury, &5_000);
+    client.cancel_emergency_drain(&admin);
+    let events = env.events().all();
+    let event = events
+        .iter()
+        .find(|ev| {
+            let topic: Symbol =
+                Symbol::try_from_val(&env, &ev.1.get(0).unwrap()).unwrap();
+            topic == Symbol::new(&env, "emergency_drain_cancelled")
+        })
+        .expect("emergency_drain_cancelled event not emitted");
+    let caller: Address = Address::try_from_val(&env, &event.1.get(1).unwrap()).unwrap();
+    assert_eq!(caller, admin);
+    let data: emergency::PendingEmergencyDrain =
+        emergency::PendingEmergencyDrain::try_from_val(&env, &event.2).unwrap();
+    assert_eq!(data.to, treasury);
+    assert_eq!(data.amount, 5_000);
+}
+
+#[test]
+#[should_panic(expected = "unauthorized: caller is not admin")]
+fn cancel_non_admin_panics() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().set_timestamp(1_700_000_000);
+    let admin = Address::generate(&env);
+    let treasury = Address::generate(&env);
+    let (usdc_address, _, usdc_admin) = create_usdc(&env, &admin);
+    let (_pool, client) = init_pool(&env, &admin, &usdc_address);
+    fund_pool(&usdc_admin, &_pool, 10_000);
+    let outsider = Address::generate(&env);
+
+    client.propose_emergency_drain(&admin, &treasury, &5_000);
+    client.cancel_emergency_drain(&outsider);
+}
+
+#[test]
+#[should_panic(expected = "no pending emergency drain")]
+fn cancel_no_proposal_panics() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().set_timestamp(1_700_000_000);
+    let admin = Address::generate(&env);
+    let (usdc_address, _, usdc_admin) = create_usdc(&env, &admin);
+    let (_pool, client) = init_pool(&env, &admin, &usdc_address);
+    fund_pool(&usdc_admin, &_pool, 10_000);
+
+    client.cancel_emergency_drain(&admin);
+}
+
+// ---------------------------------------------------------------------------
+// reproposal
+// ---------------------------------------------------------------------------
+
+#[test]
+fn reproposal_replaces_existing() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().set_timestamp(1_700_000_000);
+    let admin = Address::generate(&env);
+    let treasury = Address::generate(&env);
+    let other = Address::generate(&env);
+    let (usdc_address, _, usdc_admin) = create_usdc(&env, &admin);
+    let (_pool, client) = init_pool(&env, &admin, &usdc_address);
+    fund_pool(&usdc_admin, &_pool, 10_000);
+
+    client.propose_emergency_drain(&admin, &treasury, &5_000);
+    env.ledger().set_timestamp(1_700_000_100);
+    client.propose_emergency_drain(&admin, &other, &3_000);
+    let pending = client.get_pending_emergency_drain().unwrap();
+    assert_eq!(pending.to, other);
+    assert_eq!(pending.amount, 3_000);
+    assert_eq!(pending.proposed_at, 1_700_000_100);
+    assert_eq!(
+        pending.execute_after,
+        1_700_000_100 + emergency::EMERGENCY_DRAIN_TIMELOCK_SECONDS
+    );
+}
+
+// ---------------------------------------------------------------------------
+// get_pending_emergency_drain
+// ---------------------------------------------------------------------------
+
+#[test]
+fn get_pending_returns_none_when_empty() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let (usdc_address, _, usdc_admin) = create_usdc(&env, &admin);
+    let (_pool, client) = init_pool(&env, &admin, &usdc_address);
+    fund_pool(&usdc_admin, &_pool, 10_000);
+    assert!(client.get_pending_emergency_drain().is_none());
+}
+
+#[test]
+fn get_pending_returns_proposal_after_propose() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().set_timestamp(1_700_000_000);
+    let admin = Address::generate(&env);
+    let treasury = Address::generate(&env);
+    let (usdc_address, _, usdc_admin) = create_usdc(&env, &admin);
+    let (_pool, client) = init_pool(&env, &admin, &usdc_address);
+    fund_pool(&usdc_admin, &_pool, 10_000);
+
+    client.propose_emergency_drain(&admin, &treasury, &3_000);
+    let pending = client.get_pending_emergency_drain().unwrap();
+    assert_eq!(pending.to, treasury);
+    assert_eq!(pending.amount, 3_000);
+}
+
+// ---------------------------------------------------------------------------
+// edge cases
+// ---------------------------------------------------------------------------
+
+#[test]
+#[should_panic(expected = "timelock overflow")]
+fn timelock_overflow_at_max_timestamp() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().set_timestamp(u64::MAX);
+    let admin = Address::generate(&env);
+    let treasury = Address::generate(&env);
+    let (usdc_address, _, _) = create_usdc(&env, &admin);
+    let (_pool, client) = init_pool(&env, &admin, &usdc_address);
+    client.propose_emergency_drain(&admin, &treasury, &1_000);
+}


### PR DESCRIPTION
## Summary

Add admin emergency drain with multisig + timelock for the revenue pool. This allows the admin (a Stellar multisig account via `require_auth`) to propose, execute, and cancel a timelocked USDC drain to a designated address (typically the treasury).

### Changes

**New file: `contracts/revenue_pool/src/emergency.rs`**
- `PendingEmergencyDrain` struct with `to`, `amount`, `proposed_at`, `execute_after`
- `EMERGENCY_DRAIN_TIMELOCK_SECONDS = 86_400` (24 hours)

**New functions on `RevenuePool`:**
- `propose_emergency_drain(env, caller, to, amount)` — Admin-only, replaces any existing pending proposal, emits `emergency_drain_proposed`
- `execute_emergency_drain(env, caller)` — Admin-only, checks timelock expired, transfers USDC, consumes proposal (replay-safe), emits `emergency_drain_executed`
- `cancel_emergency_drain(env, caller)` — Admin-only, removes pending proposal, emits `emergency_drain_cancelled`
- `get_pending_emergency_drain(env)` — View, returns `Option<PendingEmergencyDrain>`

**Updated: `contracts/revenue_pool/src/events.rs`**
- Added `event_emergency_drain_proposed`, `event_emergency_drain_executed`, `event_emergency_drain_cancelled` with snapshot tests

**Updated: `contracts/revenue_pool/src/lib.rs`**
- Added `mod emergency;`
- Added the four public methods to the `#[contractimpl]` block
- Fixed pre-existing `get_ttl` trait import (`use soroban_sdk::testutils::storage::Instance`)

**New file: `contracts/revenue_pool/src/test_emergency.rs`**
- 25 tests covering:
  - Propose: success, event emission, non-admin, zero amount, self-drain, uninitialized
  - Execute: success, USDC transfer, event emission, before timelock, no proposal, non-admin, insufficient balance, replay protection
  - Cancel: success, event emission, non-admin, no proposal
  - Reproposal replaces existing
  - get_pending: None when empty, Some after propose
  - Edge case: timelock overflow at u64::MAX

### Test Results
```
running 117 tests
115 passed; 2 failed (pre-existing: deposit_yield_transfers_from_treasury_and_updates_metric, stateful_invariant_runner)
```

All 25 new tests pass. The 2 failures are pre-existing in unmodified test files.

### Security
- `require_auth()` on every state-changing entrypoint
- Admin role enforced via address comparison after auth
- Timelock prevents immediate execution (24h window for multisig review)
- Proposal consumed before token transfer (replay protection)
- Overflow-safe math (`checked_add`)
- No `unwrap()` in production paths

### Closes
Closes #526