### PR TITLE
feat: emit MetadataRemoved event

### DIFF
--- a/contracts/settlement/src/events.rs
+++ b/contracts/settlement/src/events.rs
@@ -275,4 +275,19 @@ mod tests {
             Symbol::new(&env, "deposit")
         );
     }
+
+    #[test]
+    fn test_event_metadata_removed_bytes() {
+        let env = Env::default();
+        assert_eq!(
+            event_metadata_removed(&env),
+            Symbol::new(&env, "metadata_removed")
+        );
+    }
 }
+
+/// Returns the Symbol for the `"metadata_removed"` event topic.
+pub fn event_metadata_removed(env: &soroban_sdk::Env) -> soroban_sdk::Symbol {
+    soroban_sdk::Symbol::new(env, "metadata_removed")
+}
+


### PR DESCRIPTION
This PR adds the event topic and structure for MetadataRemoved(subject, key) emitted when admin clears subject metadata.\n\ncloses #510