### PR TITLE
test: checkpoint err stability

### DIFF
--- a/contracts/checkpoint/tests/err_stab.rs
+++ b/contracts/checkpoint/tests/err_stab.rs
@@ -1,0 +1,17 @@
+#![cfg(test)]
+
+use callora_checkpoint::errors::CheckpointError;
+
+#[test]
+fn test_checkpoint_error_stability() {
+    // Freeze client-facing error code numbers for checkpoint.
+    assert_eq!(CheckpointError::NotInitialized as u32, 1);
+    assert_eq!(CheckpointError::AlreadyInitialized as u32, 2);
+    assert_eq!(CheckpointError::Unauthorized as u32, 3);
+    assert_eq!(CheckpointError::BatchEmpty as u32, 4);
+    assert_eq!(CheckpointError::BatchTooLarge as u32, 5);
+    assert_eq!(CheckpointError::CheckpointNotFound as u32, 6);
+    assert_eq!(CheckpointError::AmountNegative as u32, 7);
+    assert_eq!(CheckpointError::InvalidPageSize as u32, 8);
+    assert_eq!(CheckpointError::Overflow as u32, 9);
+}


### PR DESCRIPTION
Closes #670 


This PR introduces a dedicated integration test for the Checkpoint contract to guarantee the stability of client-facing error codes (Buffer #25). Because external indexers, dApps, and off-chain services rely on the raw numeric u32 discriminants emitted by the contract during failures, it is critical that these values remain permanently frozen. Any accidental modification, insertion, or reordering of the CheckpointError enum variants in the future would constitute a silent breaking change for downstream consumers. 

Changes Implemented:
- Added a new, isolated test suite under contracts/checkpoint/tests/err_stab.rs specifically dedicated to verifying error variant stability.
- Implemented an exhaustive assertion block (test_checkpoint_error_stability) that individually checks the u32 casting of every CheckpointError variant against its canonical, documented value.
- The test explicitly hardcodes and verifies the following exact mappings to prevent regressions:
  * NotInitialized = 1
  * AlreadyInitialized = 2
  * Unauthorized = 3
  * BatchEmpty = 4
  * BatchTooLarge = 5
  * CheckpointNotFound = 6
  * AmountNegative = 7
  * InvalidPageSize = 8
  * Overflow = 9

Impact and Safety:
- This addition is strictly a test-level improvement and does not alter any production smart contract logic, state, or gas costs.
- Ensures future pull requests cannot accidentally break the API contract for error handling without immediately failing the continuous integration pipeline.
- Acts as living documentation for the expected error numeric values.

Acceptance Criteria Met:
- Implementation matches the issue description by successfully freezing the error codes via automated tests.
- All current enum variants are explicitly covered.
- Helps maintain the required 95%+ test coverage.
- Code style strictly adheres to the repository's standard linting and formatting rules.