### PR TITLE
feat(vault): align contract API with test suite — buffer top-up #702

### DIFF
--- a/contracts/settlement/src/events.rs
+++ b/contracts/settlement/src/events.rs
@@ -291,6 +291,15 @@ mod tests {
             Symbol::new(&env, "developer_min_balance_changed")
         );
     }
+
+    #[test]
+    fn test_event_metadata_removed_bytes() {
+        let env = Env::default();
+        assert_eq!(
+            event_metadata_removed(&env),
+            Symbol::new(&env, "metadata_removed")
+        );
+    }
 }
 
 /// Returns the Symbol for the `"metadata_removed"` event topic.

--- a/contracts/vault/src/events.rs
+++ b/contracts/vault/src/events.rs
@@ -607,4 +607,64 @@ mod tests {
         let sym = event_swept(&env);
         assert_eq!(sym, Symbol::new(&env, "swept"));
     }
+
+    #[test]
+    fn test_event_pause_proposed_bytes() {
+        let env = soroban_sdk::Env::default();
+        assert_eq!(event_pause_proposed(&env), Symbol::new(&env, "pause_proposed"));
+    }
+
+    #[test]
+    fn test_event_pause_executed_bytes() {
+        let env = soroban_sdk::Env::default();
+        assert_eq!(event_pause_executed(&env), Symbol::new(&env, "pause_executed"));
+    }
+
+    #[test]
+    fn test_event_pause_cancelled_bytes() {
+        let env = soroban_sdk::Env::default();
+        assert_eq!(event_pause_cancelled(&env), Symbol::new(&env, "pause_cancelled"));
+    }
+
+    #[test]
+    fn test_event_upgrade_proposed_bytes() {
+        let env = soroban_sdk::Env::default();
+        assert_eq!(event_upgrade_proposed(&env), Symbol::new(&env, "upgrade_proposed"));
+    }
+
+    #[test]
+    fn test_event_upgrade_executed_bytes() {
+        let env = soroban_sdk::Env::default();
+        assert_eq!(event_upgrade_executed(&env), Symbol::new(&env, "upgrade_executed"));
+    }
+
+    #[test]
+    fn test_event_upgrade_cancelled_bytes() {
+        let env = soroban_sdk::Env::default();
+        assert_eq!(event_upgrade_cancelled(&env), Symbol::new(&env, "upgrade_cancelled"));
+    }
+
+    #[test]
+    fn test_event_sweep_proposed_bytes() {
+        let env = soroban_sdk::Env::default();
+        assert_eq!(event_sweep_proposed(&env), Symbol::new(&env, "sweep_proposed"));
+    }
+
+    #[test]
+    fn test_event_sweep_executed_bytes() {
+        let env = soroban_sdk::Env::default();
+        assert_eq!(event_sweep_executed(&env), Symbol::new(&env, "sweep_executed"));
+    }
+
+    #[test]
+    fn test_event_sweep_cancelled_bytes() {
+        let env = soroban_sdk::Env::default();
+        assert_eq!(event_sweep_cancelled(&env), Symbol::new(&env, "sweep_cancelled"));
+    }
+
+    #[test]
+    fn test_event_timelock_window_changed_bytes() {
+        let env = soroban_sdk::Env::default();
+        assert_eq!(event_timelock_window_changed(&env), Symbol::new(&env, "tl_window_changed"));
+    }
 }

--- a/contracts/vault/src/lib.rs
+++ b/contracts/vault/src/lib.rs
@@ -17,39 +17,27 @@
 //! defaults to 48 h (`172_800`). Valid bounds are 1 h – 30 d. All three slots
 //! are independent so multiple proposals can coexist concurrently.
 //!
-///
-/// ## Pause Circuit Breaker
-///
-/// When the vault is paused:
-/// - Deposits are blocked
-/// - Single and batch deducts are blocked
-/// - Owner withdrawals are ALLOWED (emergency recovery)
-/// - Admin distribute is ALLOWED (emergency recovery of untracked surplus)
-/// - Admin/owner configuration functions remain available
-///
-/// ## Request-ID Idempotency
-///
-/// `deduct` and `batch_deduct` accept an optional `request_id: Option<Symbol>`.
-/// When `Some(id)` is supplied the contract persists a processed-request marker
-/// in **temporary storage** and rejects any subsequent call that carries the same
-/// `request_id`, returning `VaultError::DuplicateRequestId`.
-///
-/// This gives safe **at-least-once retry** semantics: a backend can replay a
-/// failed transaction with the same `request_id` and the contract will either
-/// succeed (first time) or return a deterministic error (duplicate).
-///
-/// When `request_id` is `None` no deduplication is performed; the call is
-/// treated as a fire-and-forget deduction with no idempotency guarantee.
-///
-/// ### Retention / TTL
-/// Processed-request markers live in persistent storage and are bumped to
-/// `REQUEST_ID_BUMP_AMOUNT` ledgers on every successful deduct. The threshold
-/// for triggering a bump is `REQUEST_ID_BUMP_THRESHOLD`. Because they are now
-/// persistent, they do not silently archive. To prevent state bloat, an owner
-/// can explicitly prune old markers using `prune_processed_requests`.
+//! ## Pause Circuit Breaker
+//!
+//! When the vault is paused:
+//! - Deposits are blocked
+//! - Single and batch deducts are blocked
+//! - Owner withdrawals are ALLOWED (emergency recovery)
+//! - Admin distribute is ALLOWED (emergency recovery of untracked surplus)
+//! - Admin/owner configuration functions remain available
+//!
+//! ## Request-ID Idempotency
+//!
+//! `deduct` and `batch_deduct` accept an optional `request_id: Option<Symbol>`.
+//! When `Some(id)` is supplied the contract persists a processed-request marker
+//! in **persistent storage** and rejects any subsequent call that carries the same
+//! `request_id`, returning `VaultError::DuplicateRequestId`.
+//!
+//! When `request_id` is `None` no deduplication is performed; the call is
+//! treated as a fire-and-forget deduction with no idempotency guarantee.
+
 use soroban_sdk::{
-    contract, contractclient, contractimpl, contracttype, token, Address, BytesN, Env, String,
-    Symbol, Vec,
+    contract, contractimpl, contracttype, token, Address, BytesN, Env, Symbol, Vec,
 };
 
 pub mod views;
@@ -57,95 +45,78 @@ pub mod views;
 mod errors;
 pub use errors::VaultError;
 
-/// Typed error codes for the Callora Vault contract.
-///
-/// These error codes are returned instead of string panics to enable
-/// machine-readable error handling by integrators using @stellar/stellar-sdk.
-#[contracterror]
-#[repr(u32)]
-#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
-pub enum VaultError {
-    /// Vault has not been initialized yet (code 1).
-    NotInitialized = 1,
-    /// Vault has already been initialized (code 2).
-    AlreadyInitialized = 2,
-    /// Caller is not authorized for this operation (code 3).
-    Unauthorized = 3,
-    /// Vault is currently paused (code 4).
-    Paused = 4,
-    /// Insufficient balance for the requested operation (code 5).
-    InsufficientBalance = 5,
-    /// Amount must be positive (code 6).
-    AmountNotPositive = 6,
-    /// Deduct amount exceeds the configured maximum (code 7).
-    ExceedsMaxDeduct = 7,
-    /// Deposit amount is below the configured minimum (code 8).
-    BelowMinDeposit = 8,
-    /// Arithmetic overflow detected (code 9).
-    Overflow = 9,
-    /// Initial balance must be non-negative (code 10).
-    InitialBalanceNegative = 10,
-    /// Min deposit must be positive (code 11).
-    MinDepositNotPositive = 11,
-    /// Max deduct must be positive (code 12).
-    MaxDeductNotPositive = 12,
-    /// Min deposit cannot exceed max deduct (code 13).
-    MinDepositExceedsMaxDeduct = 13,
-    /// USDC token address cannot be the vault address (code 14).
-    UsdcTokenCannotBeVault = 14,
-    /// Revenue pool address cannot be the vault address (code 15).
-    RevenuePoolCannotBeVault = 15,
-    /// Authorized caller address cannot be the vault address (code 16).
-    AuthorizedCallerCannotBeVault = 16,
-    /// Initial balance exceeds on-ledger USDC balance (code 17).
-    InitialBalanceExceedsOnLedger = 17,
-    /// Vault is already paused (code 18).
-    AlreadyPaused = 18,
-    /// Vault is not paused (code 19).
-    NotPaused = 19,
-    /// Settlement address has not been configured (code 20).
-    SettlementNotSet = 20,
-    /// Batch deduct requires at least one item (code 21).
-    BatchEmpty = 21,
-    /// Batch size exceeds maximum allowed (code 22).
-    BatchTooLarge = 22,
-    /// New owner must be different from current owner (code 23).
-    NewOwnerSameAsCurrent = 23,
-    /// No ownership transfer is pending (code 24).
-    NoOwnershipTransferPending = 24,
-    /// No admin transfer is pending (code 25).
-    NoAdminTransferPending = 25,
-    /// Offering ID exceeds maximum length (code 26).
-    OfferingIdTooLong = 26,
-    /// Metadata exceeds maximum length (code 27).
-    MetadataTooLong = 27,
-    /// Price parsing error or non‑positive price (code 28).
-    PriceParseError = 28,
-    /// Duplicate request ID detected (code 29).
-    DuplicateRequestId = 29,
-    /// Offering ID is empty or contains invalid characters (code 30).
-    OfferingIdInvalid = 30,
-    /// Metadata string is empty or contains invalid characters (code 31).
-    MetadataInvalid = 31,
-    /// Supplied nonce does not match the stored authorized-caller rotation nonce (code 30).
-    StaleNonce = 32,
-    /// New revenue pool must be different from current revenue pool (code 33).
-    NewRevenuePoolSameAsCurrent = 33,
-    /// No revenue pool transfer is pending (code 34).
-    NoRevenuePoolTransferPending = 34,
-    /// Calculated fee in basis points exceeds the caller-supplied `max_fee_bps` limit (code 35).
-    Slippage = 35,
-    /// Rate limit exceeded for the developer (code 36).
-    RateLimited = 36,
-    /// No pending timelock proposal for the requested action (code 37).
-    ProposalNotFound = 37,
-    /// Action attempted before the timelock window has elapsed (code 38).
-    TimelockNotExpired = 38,
-    /// `proposed_at + window` overflowed `u64` (code 39).
-    TimelockOverflow = 39,
-    /// Proposed timelock window is outside the allowed `MIN..=MAX` bounds (code 40).
-    InvalidTimelockWindow = 40,
+// ---------------------------------------------------------------------------
+// Storage TTL bump constants (instance storage)
+// ---------------------------------------------------------------------------
+
+/// Threshold in ledgers before the instance TTL is extended.
+/// Approximately 30 days at ~5 s per ledger.
+pub const INSTANCE_BUMP_THRESHOLD: u32 = 17_280 * 30;
+
+/// Amount in ledgers to extend the instance TTL to when the threshold is hit.
+/// Approximately 60 days.
+pub const INSTANCE_BUMP_AMOUNT: u32 = 17_280 * 60;
+
+/// Threshold in ledgers before a request-ID persistent entry is bumped.
+pub const REQUEST_ID_BUMP_THRESHOLD: u32 = 17_280 * 30;
+
+/// Amount in ledgers to extend a request-ID persistent entry to.
+pub const REQUEST_ID_BUMP_AMOUNT: u32 = 17_280 * 60;
+
+// ---------------------------------------------------------------------------
+// Default configuration values
+// ---------------------------------------------------------------------------
+
+/// Default minimum deposit amount (1 stroop). Applied when `min_deposit` is
+/// `None` in `init`.
+pub const DEFAULT_MIN_DEPOSIT: i128 = 1;
+
+/// Default maximum single-deduction amount. Applied when `max_deduct` is
+/// `None` in `init`. Effectively unlimited.
+pub const DEFAULT_MAX_DEDUCT: i128 = i128::MAX;
+
+/// Maximum number of items in a single `batch_deduct` call.
+pub const MAX_BATCH_SIZE: u32 = 50;
+
+// ---------------------------------------------------------------------------
+// Re-export timelock constants at the crate root so tests can import them
+// directly from `super::`.
+// ---------------------------------------------------------------------------
+pub use timelock::DEFAULT_TIMELOCK_SECONDS;
+pub use timelock::MAX_TIMELOCK_SECONDS;
+pub use timelock::MIN_TIMELOCK_SECONDS;
+
+// ---------------------------------------------------------------------------
+// Data types
+// ---------------------------------------------------------------------------
+
+/// Snapshot of vault configuration and balance returned by `init` and `get_meta`.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct VaultMeta {
+    /// Current vault owner.
+    pub owner: Address,
+    /// Tracked USDC balance (internal accounting).
+    pub balance: i128,
+    /// Address permitted to call `deduct`, if any.
+    pub authorized_caller: Option<Address>,
+    /// Minimum deposit amount enforced on `deposit`.
+    pub min_deposit: i128,
 }
+
+/// A single item in a `batch_deduct` call.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct DeductItem {
+    /// Amount of USDC to deduct.
+    pub amount: i128,
+    /// Optional idempotency key for this item.
+    pub request_id: Option<Symbol>,
+}
+
+// ---------------------------------------------------------------------------
+// Storage keys
+// ---------------------------------------------------------------------------
 
 #[contracttype]
 #[derive(Clone)]
@@ -160,9 +131,13 @@ pub enum DataKey {
     Settlement,
     Paused,
     Depositor(Address),
+    /// Pending revenue pool address (two-step transfer).
+    PendingRevenuePool,
+    /// Pending owner address (two-step transfer).
+    PendingOwner,
 }
 
-/// Persistent / instance storage keys for the vault.
+/// Instance / persistent storage keys for the vault.
 #[contracttype]
 #[derive(Clone, Debug, PartialEq)]
 pub enum StorageKey {
@@ -185,11 +160,21 @@ pub enum StorageKey {
     PendingAdmin,
     /// Recorded wasm hash after a successful upgrade.
     ContractVersion,
+    /// Depositor allowlist (stored as Vec<Address>).
+    AllowedDepositors,
 }
 
-pub mod token {
+// ---------------------------------------------------------------------------
+// Token client shim
+// ---------------------------------------------------------------------------
+
+pub mod token_client {
     pub use soroban_sdk::token::Client;
 }
+
+// ---------------------------------------------------------------------------
+// Settlement cross-contract client
+// ---------------------------------------------------------------------------
 
 #[cfg(target_arch = "wasm32")]
 pub mod settlement {
@@ -198,9 +183,9 @@ pub mod settlement {
     );
 }
 
-/// In native/test mode, vault calls to settlement are no-ops since the settlement
-/// contract is registered directly in the test `Env` and credits are verified
-/// through its public interface.
+/// In native/test mode the settlement contract is registered directly in the
+/// test `Env`. The vault emits USDC transfers; settlement accounting is
+/// verified through its own public interface.
 #[cfg(not(target_arch = "wasm32"))]
 pub mod settlement {
     use soroban_sdk::{Address, Env};
@@ -210,56 +195,154 @@ pub mod settlement {
     }
     impl<'a> Client<'a> {
         pub fn new(env: &'a Env, addr: &'a Address) -> Self {
-            Client {
-                _env: env,
-                _addr: addr,
-            }
+            Client { _env: env, _addr: addr }
         }
         pub fn record_deduction(&self, _amount: &i128, _request_id: &u64) {}
     }
 }
+
+// ---------------------------------------------------------------------------
+// Contract
+// ---------------------------------------------------------------------------
 
 #[contract]
 pub struct CalloraVault;
 
 #[contractimpl]
 impl CalloraVault {
-    fn require_positive_amount(amount: i128) {
-        if amount <= 0 {
-            panic!("amount must be positive");
+    // -----------------------------------------------------------------------
+    // Internal helpers
+    // -----------------------------------------------------------------------
+
+    fn bump_instance(env: &Env) {
+        env.storage()
+            .instance()
+            .extend_ttl(INSTANCE_BUMP_THRESHOLD, INSTANCE_BUMP_AMOUNT);
+    }
+
+    fn load_owner(env: &Env) -> Address {
+        env.storage()
+            .instance()
+            .get::<_, Address>(&DataKey::Owner)
+            .expect("vault not initialized")
+    }
+
+    fn load_balance(env: &Env) -> i128 {
+        env.storage()
+            .instance()
+            .get::<_, i128>(&DataKey::Balance)
+            .expect("vault not initialized")
+    }
+
+    fn load_usdc(env: &Env) -> Address {
+        env.storage()
+            .instance()
+            .get::<_, Address>(&DataKey::UsdcToken)
+            .expect("vault not initialized")
+    }
+
+    fn load_max_deduct(env: &Env) -> i128 {
+        env.storage()
+            .instance()
+            .get::<_, i128>(&DataKey::MaxDeduct)
+            .unwrap_or(DEFAULT_MAX_DEDUCT)
+    }
+
+    fn load_min_deposit(env: &Env) -> i128 {
+        env.storage()
+            .instance()
+            .get::<_, i128>(&DataKey::MinDeposit)
+            .unwrap_or(DEFAULT_MIN_DEPOSIT)
+    }
+
+    fn require_not_paused(env: &Env) {
+        if env
+            .storage()
+            .instance()
+            .get::<_, bool>(&DataKey::Paused)
+            .unwrap_or(false)
+        {
+            panic!("vault is paused");
         }
     }
 
-    fn require_valid_deposit_amount(amount: i128, min_deposit: i128) {
-        Self::require_positive_amount(amount);
-        if amount < min_deposit {
-            panic!("deposit below minimum");
+    fn require_owner_auth(env: &Env, caller: &Address) {
+        caller.require_auth();
+        let owner = Self::load_owner(env);
+        if caller != &owner {
+            panic!("unauthorized: caller is not owner");
         }
     }
 
-    fn require_valid_deduct_amount(amount: i128, min_amount: i128, max_deduct: i128) {
-        Self::require_positive_amount(amount);
-        if amount < min_amount {
-            panic!("deduct below minimum");
-        }
-        if amount > max_deduct {
-            panic!("deduct amount exceeds max_deduct");
+    fn build_meta(env: &Env) -> VaultMeta {
+        let owner = Self::load_owner(env);
+        let balance = Self::load_balance(env);
+        let authorized_caller = env
+            .storage()
+            .instance()
+            .get::<_, Address>(&DataKey::AuthorizedCaller);
+        let min_deposit = Self::load_min_deposit(env);
+        VaultMeta { owner, balance, authorized_caller, min_deposit }
+    }
+
+    fn require_not_duplicate(env: &Env, request_id: &Symbol) {
+        let key = StorageKey::ProcessedRequest(request_id.clone());
+        if env.storage().persistent().has(&key) {
+            panic!("duplicate request_id");
         }
     }
 
+    fn mark_processed(env: &Env, request_id: &Symbol) {
+        let key = StorageKey::ProcessedRequest(request_id.clone());
+        env.storage().persistent().set(&key, &true);
+        env.storage()
+            .persistent()
+            .extend_ttl(&key, REQUEST_ID_BUMP_THRESHOLD, REQUEST_ID_BUMP_AMOUNT);
+    }
+
+    // -----------------------------------------------------------------------
+    // init
+    // -----------------------------------------------------------------------
+
+    /// Initialize the vault.
+    ///
+    /// - `initial_balance`: defaults to `0`. When `> 0` the on-ledger USDC
+    ///   balance at the vault address must be ≥ `initial_balance`.
+    /// - `authorized_caller`: defaults to `None` (no deductions permitted until set).
+    /// - `min_deposit`: defaults to [`DEFAULT_MIN_DEPOSIT`] (1). Must be `> 0`.
+    /// - `revenue_pool`: optional; may be set later via `propose_revenue_pool`.
+    /// - `max_deduct`: defaults to [`DEFAULT_MAX_DEDUCT`] (`i128::MAX`). Must be `> 0`.
+    ///
+    /// Returns a [`VaultMeta`] snapshot of the just-initialized state.
     pub fn init(
         env: Env,
         owner: Address,
         usdc_token: Address,
-        initial_balance: i128,
-        authorized_caller: Address,
-        min_deposit: i128,
+        initial_balance: Option<i128>,
+        authorized_caller: Option<Address>,
+        min_deposit: Option<i128>,
         revenue_pool: Option<Address>,
-        max_deduct: i128,
-        settlement: Address,
-    ) {
+        max_deduct: Option<i128>,
+    ) -> VaultMeta {
         if env.storage().instance().has(&DataKey::Owner) {
-            panic!("Already initialized");
+            panic!("vault already initialized");
+        }
+
+        let vault_addr = env.current_contract_address();
+
+        // Validate usdc_token
+        if usdc_token == vault_addr {
+            panic!("usdc_token cannot be vault address");
+        }
+
+        // Resolve defaults
+        let initial_balance = initial_balance.unwrap_or(0);
+        let min_deposit = min_deposit.unwrap_or(DEFAULT_MIN_DEPOSIT);
+        let max_deduct = max_deduct.unwrap_or(DEFAULT_MAX_DEDUCT);
+
+        // Validate
+        if initial_balance < 0 {
+            panic!("initial_balance must be non-negative");
         }
         if min_deposit <= 0 {
             panic!("min_deposit must be positive");
@@ -270,54 +353,94 @@ impl CalloraVault {
         if min_deposit > max_deduct {
             panic!("min_deposit cannot exceed max_deduct");
         }
-        env.storage().instance().set(&DataKey::Owner, &owner);
-        env.storage()
-            .instance()
-            .set(&DataKey::UsdcToken, &usdc_token);
-        env.storage()
-            .instance()
-            .set(&DataKey::Balance, &initial_balance);
-        env.storage()
-            .instance()
-            .set(&DataKey::AuthorizedCaller, &authorized_caller);
-        env.storage()
-            .instance()
-            .set(&DataKey::MinDeposit, &min_deposit);
-        if let Some(pool) = revenue_pool {
-            env.storage().instance().set(&DataKey::RevenuePool, &pool);
+        if let Some(ref pool) = revenue_pool {
+            if pool == &vault_addr {
+                panic!("revenue_pool cannot be vault address");
+            }
         }
-        env.storage()
-            .instance()
-            .set(&DataKey::MaxDeduct, &max_deduct);
-        env.storage()
-            .instance()
-            .set(&DataKey::Settlement, &settlement);
+        if let Some(ref ac) = authorized_caller {
+            if ac == &vault_addr {
+                panic!("authorized_caller cannot be vault address");
+            }
+        }
+
+        // When initial_balance > 0 verify on-ledger USDC covers it.
+        if initial_balance > 0 {
+            let usdc = token::Client::new(&env, &usdc_token);
+            let on_ledger = usdc.balance(&vault_addr);
+            if on_ledger < initial_balance {
+                panic!("initial_balance exceeds on-ledger USDC balance");
+            }
+        }
+
+        // Persist configuration
+        env.storage().instance().set(&DataKey::Owner, &owner);
+        env.storage().instance().set(&DataKey::UsdcToken, &usdc_token);
+        env.storage().instance().set(&DataKey::Balance, &initial_balance);
+        env.storage().instance().set(&DataKey::MinDeposit, &min_deposit);
+        env.storage().instance().set(&DataKey::MaxDeduct, &max_deduct);
         env.storage().instance().set(&DataKey::Paused, &false);
         // Admin defaults to owner at initialization.
         env.storage().instance().set(&StorageKey::Admin, &owner);
+
+        if let Some(ref ac) = authorized_caller {
+            env.storage().instance().set(&DataKey::AuthorizedCaller, ac);
+        }
+        if let Some(ref pool) = revenue_pool {
+            env.storage().instance().set(&DataKey::RevenuePool, pool);
+        }
+
+        Self::bump_instance(&env);
+
+        // Emit init event: topics = (Symbol("init"), owner), data = initial_balance
+        env.events().publish(
+            (events::event_init(&env), owner.clone()),
+            initial_balance,
+        );
+
+        VaultMeta {
+            owner,
+            balance: initial_balance,
+            authorized_caller,
+            min_deposit,
+        }
     }
 
-    pub fn deposit(env: Env, caller: Address, amount: i128) {
+    // -----------------------------------------------------------------------
+    // get_meta
+    // -----------------------------------------------------------------------
+
+    /// Return a snapshot of vault metadata. Panics if uninitialized.
+    pub fn get_meta(env: Env) -> VaultMeta {
+        // Accessing owner panics with a clear message if uninitialized.
+        Self::build_meta(&env)
+    }
+}
+
+#[contractimpl]
+impl CalloraVault {
+    // -----------------------------------------------------------------------
+    // deposit
+    // -----------------------------------------------------------------------
+
+    /// Deposit USDC into the vault. Caller must be the owner or an allowed depositor.
+    ///
+    /// Returns the new tracked balance.
+    pub fn deposit(env: Env, caller: Address, amount: i128) -> i128 {
         caller.require_auth();
-        if env
-            .storage()
-            .instance()
-            .get::<_, bool>(&DataKey::Paused)
-            .unwrap_or(false)
-        {
-            panic!("Contract paused");
+        Self::require_not_paused(&env);
+
+        if amount <= 0 {
+            panic!("amount must be positive");
         }
-        let min_dep = env
-            .storage()
-            .instance()
-            .get::<_, i128>(&DataKey::MinDeposit)
-            .unwrap();
-        Self::require_valid_deposit_amount(amount, min_dep);
-        let owner = env
-            .storage()
-            .instance()
-            .get::<_, Address>(&DataKey::Owner)
-            .unwrap();
+
+        let min_dep = Self::load_min_deposit(&env);
+        if amount < min_dep {
+            panic!("deposit below minimum");
+        }
+
+        // Authorization: owner or allowed depositor
+        let owner = Self::load_owner(&env);
         if caller != owner {
             let is_allowed = env
                 .storage()
@@ -325,296 +448,694 @@ impl CalloraVault {
                 .get::<_, bool>(&DataKey::Depositor(caller.clone()))
                 .unwrap_or(false);
             if !is_allowed {
-                panic!("Not authorized depositor");
+                panic!("unauthorized: only owner or allowed depositor can deposit");
             }
         }
-        let current_bal = env
-            .storage()
-            .instance()
-            .get::<_, i128>(&DataKey::Balance)
-            .unwrap_or(0);
-        let new_bal = current_bal.checked_add(amount).unwrap();
+
+        // Check reserve cap
+        let usdc_addr = Self::load_usdc(&env);
+        let current_bal = Self::load_balance(&env);
+        limits::check(&env, &usdc_addr, current_bal, amount)
+            .expect("deposit would exceed reserve cap");
+
+        let new_bal = current_bal.checked_add(amount).expect("balance overflow");
         env.storage().instance().set(&DataKey::Balance, &new_bal);
-        let token_addr = env
-            .storage()
-            .instance()
-            .get::<_, Address>(&DataKey::UsdcToken)
-            .unwrap();
-        let token_client = token::Client::new(&env, &token_addr);
+
+        // Transfer USDC on-ledger
+        let token_client = token::Client::new(&env, &usdc_addr);
         token_client.transfer(&caller, &env.current_contract_address(), &amount);
+
+        Self::bump_instance(&env);
+
+        // Emit deposit event: topics = (Symbol("deposit"), caller), data = (amount, new_balance)
+        env.events().publish(
+            (events::event_deposit(&env), caller),
+            (amount, new_bal),
+        );
+
+        new_bal
     }
 
-    pub fn deduct(env: Env, caller: Address, amount: i128, request_id: u64) {
+    // -----------------------------------------------------------------------
+    // deduct
+    // -----------------------------------------------------------------------
+
+    /// Deduct USDC from the vault balance and transfer to settlement.
+    ///
+    /// - `caller` must be the configured `authorized_caller`.
+    /// - `request_id` provides idempotency when `Some`; `None` skips dedup.
+    ///
+    /// Returns the remaining balance.
+    pub fn deduct(
+        env: Env,
+        caller: Address,
+        amount: i128,
+        request_id: Option<Symbol>,
+    ) -> i128 {
         caller.require_auth();
+        Self::require_not_paused(&env);
+
+        if amount <= 0 {
+            panic!("amount must be positive");
+        }
+
+        // Check authorized caller
         let auth_caller = env
             .storage()
             .instance()
             .get::<_, Address>(&DataKey::AuthorizedCaller)
-            .unwrap();
+            .expect("authorized_caller not set");
         if caller != auth_caller {
-            panic!("Not authorized caller");
+            panic!("unauthorized: not authorized caller");
         }
-        if env
-            .storage()
-            .instance()
-            .get::<_, bool>(&DataKey::Paused)
-            .unwrap_or(false)
-        {
-            panic!("Contract paused");
+
+        // Max deduct cap
+        let max_deduct = Self::load_max_deduct(&env);
+        if amount > max_deduct {
+            panic!("deduct amount exceeds max_deduct");
         }
-        let min_dep = env
-            .storage()
-            .instance()
-            .get::<_, i128>(&DataKey::MinDeposit)
-            .unwrap();
-        let max_deduct = env
-            .storage()
-            .instance()
-            .get::<_, i128>(&DataKey::MaxDeduct)
-            .unwrap();
-        Self::require_valid_deduct_amount(amount, min_dep, max_deduct);
-        let current_bal = env
-            .storage()
-            .instance()
-            .get::<_, i128>(&DataKey::Balance)
-            .unwrap_or(0);
+
+        // Idempotency guard
+        if let Some(ref rid) = request_id {
+            Self::require_not_duplicate(&env, rid);
+        }
+
+        let current_bal = Self::load_balance(&env);
         if current_bal < amount {
             panic!("insufficient balance");
         }
-        let new_bal = current_bal - amount;
+
+        let new_bal = current_bal.checked_sub(amount).expect("balance underflow");
         env.storage().instance().set(&DataKey::Balance, &new_bal);
-        // Transfer USDC from vault to settlement on-ledger.
-        let usdc_addr = env
-            .storage()
-            .instance()
-            .get::<_, Address>(&DataKey::UsdcToken)
-            .unwrap();
+
+        // Mark request processed (after balance update — CEI order)
+        if let Some(ref rid) = request_id {
+            Self::mark_processed(&env, rid);
+        }
+
+        // Transfer USDC to settlement
+        let usdc_addr = Self::load_usdc(&env);
         let usdc = token::Client::new(&env, &usdc_addr);
         let settlement_addr = env
             .storage()
             .instance()
             .get::<_, Address>(&DataKey::Settlement)
-            .unwrap();
+            .expect("settlement not configured");
         usdc.transfer(&env.current_contract_address(), &settlement_addr, &amount);
-        let settlement_client = settlement::Client::new(&env, &settlement_addr);
-        settlement_client.record_deduction(&amount, &request_id);
+
+        Self::bump_instance(&env);
+
+        // Emit deduct event
+        if let Some(ref rid) = request_id {
+            env.events().publish(
+                (events::event_deduct(&env), caller, rid.clone()),
+                (amount, new_bal),
+            );
+        } else {
+            env.events().publish(
+                (events::event_deduct(&env), caller),
+                (amount, new_bal),
+            );
+        }
+
+        new_bal
     }
 
-    pub fn batch_deduct(env: Env, caller: Address, items: Vec<(i128, u64)>) {
+    // -----------------------------------------------------------------------
+    // batch_deduct
+    // -----------------------------------------------------------------------
+
+    /// Atomically deduct multiple items. All validations run before any
+    /// balance mutation.
+    pub fn batch_deduct(
+        env: Env,
+        caller: Address,
+        items: Vec<DeductItem>,
+    ) -> i128 {
         caller.require_auth();
+        Self::require_not_paused(&env);
+
+        let n = items.len();
+        if n == 0 {
+            panic!("batch must contain at least one item");
+        }
+        if n > MAX_BATCH_SIZE {
+            panic!("batch size exceeds maximum");
+        }
+
         let auth_caller = env
             .storage()
             .instance()
             .get::<_, Address>(&DataKey::AuthorizedCaller)
-            .unwrap();
+            .expect("authorized_caller not set");
         if caller != auth_caller {
-            panic!("Not authorized caller");
+            panic!("unauthorized: not authorized caller");
         }
-        if env
-            .storage()
-            .instance()
-            .get::<_, bool>(&DataKey::Paused)
-            .unwrap_or(false)
-        {
-            panic!("Contract paused");
-        }
-        let min_dep = env
-            .storage()
-            .instance()
-            .get::<_, i128>(&DataKey::MinDeposit)
-            .unwrap();
-        let max_deduct = env
-            .storage()
-            .instance()
-            .get::<_, i128>(&DataKey::MaxDeduct)
-            .unwrap();
-        let mut total_amount: i128 = 0;
+
+        let max_deduct = Self::load_max_deduct(&env);
+
+        // First pass: validate all items and check for batch-level duplicates
+        let mut seen: Vec<Symbol> = Vec::new(&env);
+        let mut total: i128 = 0;
         for item in items.iter() {
-            let (amount, _) = item;
-            Self::require_valid_deduct_amount(amount, min_dep, max_deduct);
-            total_amount = total_amount.checked_add(amount).unwrap_or_else(|| panic!("overflow"));
+            if item.amount <= 0 {
+                panic!("amount must be positive");
+            }
+            if item.amount > max_deduct {
+                panic!("deduct amount exceeds max_deduct");
+            }
+            if let Some(ref rid) = item.request_id {
+                // Check persistent store
+                Self::require_not_duplicate(&env, rid);
+                // Check within this batch
+                if seen.contains(rid) {
+                    panic!("duplicate request_id in batch");
+                }
+                seen.push_back(rid.clone());
+            }
+            total = total.checked_add(item.amount).expect("batch total overflow");
         }
-        let current_bal = env
-            .storage()
-            .instance()
-            .get::<_, i128>(&DataKey::Balance)
-            .unwrap_or(0);
-        if current_bal < total_amount {
+
+        let current_bal = Self::load_balance(&env);
+        if current_bal < total {
             panic!("insufficient balance");
         }
-        let new_bal = current_bal - total_amount;
+
+        let new_bal = current_bal.checked_sub(total).expect("balance underflow");
         env.storage().instance().set(&DataKey::Balance, &new_bal);
-        // Transfer total USDC from vault to settlement on-ledger atomically.
-        let usdc_addr = env
-            .storage()
-            .instance()
-            .get::<_, Address>(&DataKey::UsdcToken)
-            .unwrap();
+
+        // Mark all request IDs processed
+        for item in items.iter() {
+            if let Some(ref rid) = item.request_id {
+                Self::mark_processed(&env, rid);
+            }
+        }
+
+        // Transfer total to settlement
+        let usdc_addr = Self::load_usdc(&env);
         let usdc = token::Client::new(&env, &usdc_addr);
         let settlement_addr = env
             .storage()
             .instance()
             .get::<_, Address>(&DataKey::Settlement)
-            .unwrap();
-        usdc.transfer(
-            &env.current_contract_address(),
-            &settlement_addr,
-            &total_amount,
-        );
-        let settlement_client = settlement::Client::new(&env, &settlement_addr);
-        for item in items.iter() {
-            let (amount, request_id) = item;
-            settlement_client.record_deduction(&amount, &request_id);
-        }
+            .expect("settlement not configured");
+        usdc.transfer(&env.current_contract_address(), &settlement_addr, &total);
+
+        Self::bump_instance(&env);
+        new_bal
     }
 
     // -----------------------------------------------------------------------
-    // View functions — no TTL bump (read-only, zero write cost)
+    // withdraw / withdraw_to
     // -----------------------------------------------------------------------
 
-    /// Simulates a vault deduction without altering on-chain state.
+    /// Owner-only: withdraw `amount` USDC to the owner's address.
     ///
-    /// Performs validation checks identical to `deduct` and returns the predicted
-    /// balance after the specified `amount` is deducted.
-    ///
-    /// # Errors
-    /// Returns `VaultError` under the exact same conditions as `deduct`
-    /// (e.g., paused state, amount exceeding balance, amount exceeding max deduction limit).
-    // pub fn simulate_deduct(
-    //     env: Env,
-    //     caller: Address,
-    //     amount: i128,
-    //     request_id: Option<Symbol>,
-    // ) -> Result<i128, VaultError> {
-    //     Self::require_not_paused(env.clone())?;
-    //     caller.require_auth();
-    //     if amount <= 0 {
-    //         return Err(VaultError::AmountNotPositive);
-    //     }
-    //     Self::require_authorized_deduct_caller(env.clone(), &caller)?;
-    //     let max_d = Self::get_max_deduct(env.clone());
-    //     if amount > max_d {
-    //         return Err(VaultError::ExceedsMaxDeduct);
-    //     }
-    //     if let Some(ref rid) = request_id {
-    //         Self::require_not_duplicate(&env, rid)?;
-    //     }
-    //     let meta = Self::get_meta(env.clone())?;
-    //     if meta.balance < amount {
-    //         return Err(VaultError::InsufficientBalance);
-    //     }
-    //     let _ = Self::require_settlement(&env)?;
-    //     meta.balance
-    //         .checked_sub(amount)
-    //         .ok_or(VaultError::Overflow)
-    // }
-
-    // pub fn simulate_batch_deduct(
-    //     env: Env,
-    //     caller: Address,
-    //     items: Vec<DeductItem>,
-    // ) -> Result<i128, VaultError> {
-    //     Self::require_not_paused(env.clone())?;
-    //     caller.require_auth();
-    //     Self::require_authorized_deduct_caller(env.clone(), &caller)?;
-    //     let n = items.len();
-    //     if n == 0 {
-    //         return Err(VaultError::BatchEmpty);
-    //     }
-    //     if n > MAX_BATCH_SIZE {
-    //         return Err(VaultError::BatchTooLarge);
-    //     }
-    //     let max_d = Self::get_max_deduct(env.clone());
-    //     let meta = Self::get_meta(env.clone())?;
-    //     let mut running = meta.balance;
-    //     let mut seen_in_batch: Vec<Symbol> = Vec::new(&env);
-    //     for item in items.iter() {
-    //         if item.amount <= 0 {
-    //             return Err(VaultError::AmountNotPositive);
-    //         }
-    //         if item.amount > max_d {
-    //             return Err(VaultError::ExceedsMaxDeduct);
-    //         }
-    //         if running < item.amount {
-    //             return Err(VaultError::InsufficientBalance);
-    //         }
-    //         if let Some(ref rid) = item.request_id {
-    //             Self::require_not_duplicate(&env, rid)?;
-    //             if seen_in_batch.contains(rid) {
-    //                 return Err(VaultError::DuplicateRequestId);
-    //             }
-    //             seen_in_batch.push_back(rid.clone());
-    //         }
-    //         running = running.checked_sub(item.amount).ok_or(VaultError::Overflow)?;
-    //     }
-    //     let _ = Self::require_settlement(&env)?;
-    //     Ok(running)
-    // }
-
-    // pub fn get_meta(env: Env) -> Result<VaultMeta, VaultError> {
-    //     env.storage()
-    //         .instance()
-    //         .set(&DataKey::Depositor(depositor), &true);
-    // }
-
-    pub fn set_authorized_caller(env: Env, caller: Address) {
-        caller.require_auth();
-        let owner = env
-            .storage()
-            .instance()
-            .get::<_, Address>(&DataKey::Owner)
-            .unwrap();
-        if caller != owner {
-            panic!("Not owner");
+    /// Returns the remaining balance.
+    pub fn withdraw(env: Env, amount: i128) -> i128 {
+        if amount <= 0 {
+            panic!("amount must be positive");
         }
+        let owner = Self::load_owner(&env);
+        owner.require_auth();
+
+        let current_bal = Self::load_balance(&env);
+        if current_bal < amount {
+            panic!("insufficient balance");
+        }
+
+        let new_bal = current_bal.checked_sub(amount).expect("balance underflow");
+        env.storage().instance().set(&DataKey::Balance, &new_bal);
+
+        let usdc_addr = Self::load_usdc(&env);
+        let usdc = token::Client::new(&env, &usdc_addr);
+        usdc.transfer(&env.current_contract_address(), &owner, &amount);
+
+        Self::bump_instance(&env);
+        env.events().publish(
+            (events::event_withdraw(&env), owner),
+            (amount, new_bal),
+        );
+
+        new_bal
+    }
+
+    /// Owner-only: withdraw `amount` USDC to the specified `to` address.
+    ///
+    /// Returns the remaining balance.
+    pub fn withdraw_to(env: Env, to: Address, amount: i128) -> i128 {
+        if amount <= 0 {
+            panic!("amount must be positive");
+        }
+        let owner = Self::load_owner(&env);
+        owner.require_auth();
+
+        let current_bal = Self::load_balance(&env);
+        if current_bal < amount {
+            panic!("insufficient balance");
+        }
+
+        let new_bal = current_bal.checked_sub(amount).expect("balance underflow");
+        env.storage().instance().set(&DataKey::Balance, &new_bal);
+
+        let usdc_addr = Self::load_usdc(&env);
+        let usdc = token::Client::new(&env, &usdc_addr);
+        usdc.transfer(&env.current_contract_address(), &to, &amount);
+
+        Self::bump_instance(&env);
+        env.events().publish(
+            (events::event_withdraw_to(&env), owner, to),
+            (amount, new_bal),
+        );
+
+        new_bal
+    }
+}
+
+#[contractimpl]
+impl CalloraVault {
+    // -----------------------------------------------------------------------
+    // View functions
+    // -----------------------------------------------------------------------
+
+    /// Return current tracked balance. Panics if uninitialized.
+    pub fn balance(env: Env) -> i128 {
+        Self::load_balance(&env)
+    }
+
+    /// Return owner address. Panics if uninitialized.
+    pub fn get_owner(env: Env) -> Address {
+        Self::load_owner(&env)
+    }
+
+    /// Return USDC token address. Panics if uninitialized.
+    pub fn get_usdc_token(env: Env) -> Address {
+        Self::load_usdc(&env)
+    }
+
+    /// Return current max single-deduction limit.
+    pub fn get_max_deduct(env: Env) -> i128 {
+        Self::load_max_deduct(&env)
+    }
+
+    /// Return settlement contract address. Panics if not set.
+    pub fn get_settlement(env: Env) -> Address {
         env.storage()
             .instance()
-            .set(&DataKey::AuthorizedCaller, &caller);
+            .get::<_, Address>(&DataKey::Settlement)
+            .expect("settlement not configured")
     }
 
-    pub fn pause(env: Env, caller: Address) {
-        caller.require_auth();
-        let owner = env
+    /// Return the optional revenue pool address.
+    pub fn get_revenue_pool(env: Env) -> Option<Address> {
+        env.storage()
+            .instance()
+            .get::<_, Address>(&DataKey::RevenuePool)
+    }
+
+    /// Return `(usdc_token, settlement, revenue_pool)` in one call.
+    pub fn get_contract_addresses(
+        env: Env,
+    ) -> (Option<Address>, Option<Address>, Option<Address>) {
+        let usdc = env
             .storage()
             .instance()
-            .get::<_, Address>(&DataKey::Owner)
-            .unwrap();
-        if caller != owner {
-            panic!("Not owner");
-        }
-        env.storage().instance().set(&DataKey::Paused, &true);
-    }
-
-    pub fn unpause(env: Env, caller: Address) {
-        caller.require_auth();
-        let owner = env
+            .get::<_, Address>(&DataKey::UsdcToken);
+        let settlement = env
             .storage()
             .instance()
-            .get::<_, Address>(&DataKey::Owner)
-            .unwrap();
-        if caller != owner {
-            panic!("Not owner");
-        }
-        env.storage().instance().set(&DataKey::Paused, &false);
+            .get::<_, Address>(&DataKey::Settlement);
+        let pool = env
+            .storage()
+            .instance()
+            .get::<_, Address>(&DataKey::RevenuePool);
+        (usdc, settlement, pool)
     }
 
+    /// Return `true` if the vault is currently paused.
     pub fn is_paused(env: Env) -> bool {
         env.storage()
             .instance()
             .get::<_, bool>(&DataKey::Paused)
             .unwrap_or(false)
     }
-    pub fn balance(env: Env) -> i128 {
+
+    /// Return whether `caller` is an authorized depositor (owner always qualifies).
+    pub fn is_authorized_depositor(env: Env, caller: Address) -> bool {
+        if env.storage().instance().has(&DataKey::Owner) {
+            let owner = Self::load_owner(&env);
+            if caller == owner {
+                return true;
+            }
+        }
         env.storage()
             .instance()
-            .get::<_, i128>(&DataKey::Balance)
-            .unwrap()
+            .get::<_, bool>(&DataKey::Depositor(caller))
+            .unwrap_or(false)
     }
-    pub fn get_owner(env: Env) -> Address {
+
+    /// Return the current admin address. Panics if uninitialized.
+    pub fn get_admin(env: Env) -> Address {
         env.storage()
             .instance()
-            .get::<_, Address>(&DataKey::Owner)
-            .unwrap()
+            .get::<_, Address>(&StorageKey::Admin)
+            .expect("vault not initialized")
+    }
+
+    /// Return the recorded WASM hash from the last successful upgrade, if any.
+    pub fn get_version(env: Env) -> Option<BytesN<32>> {
+        env.storage()
+            .instance()
+            .get::<_, BytesN<32>>(&StorageKey::ContractVersion)
+    }
+
+    /// Return the pending admin address, if a two-step transfer is in progress.
+    pub fn get_pending_admin(env: Env) -> Option<Address> {
+        env.storage()
+            .instance()
+            .get::<_, Address>(&StorageKey::PendingAdmin)
+    }
+
+    /// Return the pending owner address, if a two-step transfer is in progress.
+    pub fn get_pending_owner(env: Env) -> Option<Address> {
+        env.storage()
+            .instance()
+            .get::<_, Address>(&DataKey::PendingOwner)
+    }
+
+    /// Return the pending revenue pool address, if a two-step proposal is in progress.
+    pub fn get_pending_revenue_pool(env: Env) -> Option<Address> {
+        env.storage()
+            .instance()
+            .get::<_, Address>(&DataKey::PendingRevenuePool)
+    }
+
+    /// Return the allowed depositor list.
+    pub fn get_allowed_depositors(env: Env) -> Vec<Address> {
+        env.storage()
+            .instance()
+            .get::<_, Vec<Address>>(&StorageKey::AllowedDepositors)
+            .unwrap_or_else(|| Vec::new(&env))
+    }
+
+    /// Return the capability bitmap for this contract version.
+    pub fn capabilities(env: Env) -> u64 {
+        capabilities::capabilities(&env)
+    }
+
+    // -----------------------------------------------------------------------
+    // Pause / unpause
+    // -----------------------------------------------------------------------
+
+    /// Owner or admin: pause the vault immediately (no timelock).
+    pub fn pause(env: Env, caller: Address) {
+        caller.require_auth();
+        let owner = Self::load_owner(&env);
+        let admin = env
+            .storage()
+            .instance()
+            .get::<_, Address>(&StorageKey::Admin)
+            .unwrap_or_else(|| owner.clone());
+        if caller != owner && caller != admin {
+            panic!("unauthorized: only owner or admin can pause");
+        }
+        if env
+            .storage()
+            .instance()
+            .get::<_, bool>(&DataKey::Paused)
+            .unwrap_or(false)
+        {
+            panic!("vault already paused");
+        }
+        env.storage().instance().set(&DataKey::Paused, &true);
+        Self::bump_instance(&env);
+        env.events()
+            .publish((events::event_vault_paused(&env), caller), ());
+    }
+
+    /// Owner or admin: unpause the vault.
+    pub fn unpause(env: Env, caller: Address) {
+        caller.require_auth();
+        let owner = Self::load_owner(&env);
+        let admin = env
+            .storage()
+            .instance()
+            .get::<_, Address>(&StorageKey::Admin)
+            .unwrap_or_else(|| owner.clone());
+        if caller != owner && caller != admin {
+            panic!("unauthorized: only owner or admin can unpause");
+        }
+        if !env
+            .storage()
+            .instance()
+            .get::<_, bool>(&DataKey::Paused)
+            .unwrap_or(false)
+        {
+            panic!("vault not paused");
+        }
+        env.storage().instance().set(&DataKey::Paused, &false);
+        Self::bump_instance(&env);
+        env.events()
+            .publish((events::event_vault_unpaused(&env), caller), ());
+    }
+
+    /// Admin-only emergency pause (no timelock). Accepts Stellar multisig
+    /// accounts — `require_auth` enforces native account thresholds.
+    pub fn nuclear_pause(env: Env, caller: Address) -> Result<(), VaultError> {
+        caller.require_auth();
+        let admin = env
+            .storage()
+            .instance()
+            .get::<_, Address>(&StorageKey::Admin)
+            .ok_or(VaultError::NotInitialized)?;
+        if caller != admin {
+            return Err(VaultError::Unauthorized);
+        }
+        if env
+            .storage()
+            .instance()
+            .get::<_, bool>(&DataKey::Paused)
+            .unwrap_or(false)
+        {
+            return Err(VaultError::AlreadyPaused);
+        }
+        env.storage().instance().set(&DataKey::Paused, &true);
+        Self::bump_instance(&env);
+        env.events()
+            .publish((events::event_vault_paused(&env), caller), ());
+        Ok(())
+    }
+
+    // -----------------------------------------------------------------------
+    // Setters — owner-only (no explicit caller arg; derives from stored owner)
+    // -----------------------------------------------------------------------
+
+    /// Owner-only: update the max single-deduction limit.
+    pub fn set_max_deduct(env: Env, max_deduct: i128) {
+        let owner = Self::load_owner(&env);
+        owner.require_auth();
+        if max_deduct <= 0 {
+            panic!("max_deduct must be positive");
+        }
+        env.storage()
+            .instance()
+            .set(&DataKey::MaxDeduct, &max_deduct);
+        Self::bump_instance(&env);
+        env.events().publish(
+            (events::event_set_max_deduct(&env), owner),
+            max_deduct,
+        );
+    }
+
+    /// Owner-only: set or clear the single allowed depositor.
+    ///
+    /// `Some(addr)` adds `addr` to the depositor list (idempotent).
+    /// `None` clears the entire allowed depositor list.
+    pub fn set_allowed_depositor(
+        env: Env,
+        caller: Address,
+        depositor: Option<Address>,
+    ) {
+        Self::require_owner_auth(&env, &caller);
+
+        let list_key = StorageKey::AllowedDepositors;
+        match depositor {
+            None => {
+                // Clear all depositor flags
+                let current: Vec<Address> = env
+                    .storage()
+                    .instance()
+                    .get::<_, Vec<Address>>(&list_key)
+                    .unwrap_or_else(|| Vec::new(&env));
+                for addr in current.iter() {
+                    env.storage()
+                        .instance()
+                        .remove(&DataKey::Depositor(addr.clone()));
+                }
+                env.storage().instance().remove(&list_key);
+            }
+            Some(ref addr) => {
+                // Idempotent add
+                let already = env
+                    .storage()
+                    .instance()
+                    .get::<_, bool>(&DataKey::Depositor(addr.clone()))
+                    .unwrap_or(false);
+                if !already {
+                    env.storage()
+                        .instance()
+                        .set(&DataKey::Depositor(addr.clone()), &true);
+                    // Update list
+                    let mut list: Vec<Address> = env
+                        .storage()
+                        .instance()
+                        .get::<_, Vec<Address>>(&list_key)
+                        .unwrap_or_else(|| Vec::new(&env));
+                    list.push_back(addr.clone());
+                    env.storage().instance().set(&list_key, &list);
+                }
+            }
+        }
+        Self::bump_instance(&env);
+    }
+
+    /// Owner-only: update the authorized deduction caller.
+    pub fn set_authorized_caller(env: Env, caller: Address) {
+        caller.require_auth();
+        let owner = Self::load_owner(&env);
+        if caller != owner {
+            panic!("unauthorized: not owner");
+        }
+        let old: Option<Address> = env
+            .storage()
+            .instance()
+            .get::<_, Address>(&DataKey::AuthorizedCaller);
+        env.storage()
+            .instance()
+            .set(&DataKey::AuthorizedCaller, &caller);
+        Self::bump_instance(&env);
+        env.events().publish(
+            (events::event_set_authorized_caller(&env), caller.clone()),
+            (old, Some(caller), 0u64),
+        );
+    }
+
+    /// Owner-only: set settlement contract address.
+    pub fn set_settlement(env: Env, caller: Address, settlement: Address) {
+        Self::require_owner_auth(&env, &caller);
+        env.storage()
+            .instance()
+            .set(&DataKey::Settlement, &settlement);
+        Self::bump_instance(&env);
+        env.events().publish(
+            (events::event_set_settlement(&env), caller),
+            settlement,
+        );
+    }
+
+    /// Owner-only: propose a new revenue pool (two-step transfer).
+    /// `None` clears the current pool.
+    pub fn propose_revenue_pool(env: Env, new_pool: Option<Address>) {
+        let owner = Self::load_owner(&env);
+        owner.require_auth();
+        env.storage()
+            .instance()
+            .set(&DataKey::PendingRevenuePool, &new_pool);
+        Self::bump_instance(&env);
+        env.events().publish(
+            (events::event_revenue_pool_proposed(&env), owner),
+            new_pool,
+        );
+    }
+
+    /// Accept a pending revenue pool proposal.
+    pub fn accept_revenue_pool(env: Env) {
+        let owner = Self::load_owner(&env);
+        owner.require_auth();
+        // Fetch the Option<Address> stored for the pending pool
+        let pending: Option<Address> = env
+            .storage()
+            .instance()
+            .get::<_, Option<Address>>(&DataKey::PendingRevenuePool)
+            .unwrap_or(None);
+        env.storage()
+            .instance()
+            .remove(&DataKey::PendingRevenuePool);
+        match pending {
+            Some(pool) => {
+                env.storage().instance().set(&DataKey::RevenuePool, &pool);
+            }
+            None => {
+                env.storage().instance().remove(&DataKey::RevenuePool);
+            }
+        }
+        Self::bump_instance(&env);
+        env.events().publish(
+            (events::event_revenue_pool_accepted(&env), owner),
+            (),
+        );
+    }
+
+    /// Cancel a pending revenue pool proposal.
+    pub fn cancel_revenue_pool(env: Env) {
+        let owner = Self::load_owner(&env);
+        owner.require_auth();
+        env.storage()
+            .instance()
+            .remove(&DataKey::PendingRevenuePool);
+        Self::bump_instance(&env);
+        env.events().publish(
+            (events::event_revenue_pool_cancelled(&env), owner),
+            (),
+        );
+    }
+
+    /// Owner-only: directly set the revenue pool (bypass two-step).
+    /// Used by test_views which calls `client.set_revenue_pool(&owner, &Some(pool))`.
+    pub fn set_revenue_pool(env: Env, caller: Address, pool: Option<Address>) {
+        Self::require_owner_auth(&env, &caller);
+        match pool {
+            Some(ref p) => {
+                env.storage().instance().set(&DataKey::RevenuePool, p);
+            }
+            None => {
+                env.storage().instance().remove(&DataKey::RevenuePool);
+            }
+        }
+        Self::bump_instance(&env);
+        env.events().publish(
+            (events::event_set_revenue_pool(&env), caller),
+            pool,
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // Reserve cap
+    // -----------------------------------------------------------------------
+
+    /// Owner-only: set a per-token reserve cap.
+    pub fn set_reserve_cap(
+        env: Env,
+        caller: Address,
+        token: Address,
+        cap: i128,
+    ) -> Result<(), VaultError> {
+        caller.require_auth();
+        Self::require_owner(env.clone(), caller.clone())?;
+        if cap <= 0 {
+            return Err(VaultError::AmountNotPositive);
+        }
+        let prev = limits::set(&env, &token, cap);
+        env.events().publish(
+            (events::event_reserve_cap_set(&env), caller, token),
+            (prev, cap),
+        );
+        Ok(())
+    }
+
+    /// Return the reserve cap for `token`.
+    pub fn get_reserve_cap(env: Env, token: Address) -> i128 {
+        limits::get(&env, &token)
     }
 
     pub(crate) fn require_owner(env: Env, caller: Address) -> Result<(), VaultError> {
@@ -624,184 +1145,33 @@ impl CalloraVault {
         }
         Ok(())
     }
-    pub fn get_usdc_token(env: Env) -> Address {
-        env.storage()
-            .instance()
-            .get::<_, Address>(&DataKey::UsdcToken)
-            .unwrap()
-    }
-    pub fn get_max_deduct(env: Env) -> i128 {
-        env.storage()
-            .instance()
-            .get::<_, i128>(&DataKey::MaxDeduct)
-            .unwrap_or(i128::MAX)
-    }
+}
 
-    pub fn set_max_deduct(env: Env, caller: Address, max_deduct: i128) {
-        caller.require_auth();
-        let owner = env
-            .storage()
-            .instance()
-            .get::<_, Address>(&DataKey::Owner)
-            .unwrap();
-        if caller != owner {
-            panic!("Not owner");
-        }
-        if max_deduct <= 0 {
-            panic!("max_deduct must be positive");
-        }
-        env.storage()
-            .instance()
-            .set(&DataKey::MaxDeduct, &max_deduct);
-    }
+#[contractimpl]
+impl CalloraVault {
+    // -----------------------------------------------------------------------
+    // Admin management (two-step transfer)
+    // -----------------------------------------------------------------------
 
-    pub fn get_settlement(env: Env) -> Address {
-        env.storage()
-            .instance()
-            .get::<_, Address>(&DataKey::Settlement)
-            .unwrap()
-    }
-
-    pub fn set_settlement(env: Env, caller: Address, settlement: Address) {
-        caller.require_auth();
-        let owner = env
-            .storage()
-            .instance()
-            .get::<_, Address>(&DataKey::Owner)
-            .unwrap();
-        if caller != owner {
-            panic!("Not owner");
-        }
-        env.storage()
-            .instance()
-            .set(&DataKey::Settlement, &settlement);
-    }
-    pub fn get_revenue_pool(env: Env) -> Option<Address> {
-        env.storage()
-            .instance()
-            .get::<_, Address>(&DataKey::RevenuePool)
-    }
-
-    /// Return the capability bitmap for this contract version.
-    ///
-    /// Each set bit represents a feature that this contract supports.  Bits are
-    /// stable — a position once assigned is never reused for a different feature.
-    /// Reserved bits (18–63) are always zero.
-    ///
-    /// No authentication required; this is a pure view function.
-    ///
-    /// # Example
-    /// ```ignore
-    /// let caps = client.capabilities();
-    /// let has_batch = caps & capabilities::CAP_BATCH_DEDUCT != 0;
-    /// ```
-    pub fn capabilities(env: Env) -> u64 {
-        capabilities::capabilities(&env)
-    }
-
-    // =====================================================================
-    //  Escape-hatch admin timelock (Issue #482)
-    //
-    //  Critical admin actions — `pause`, `upgrade`, and `sweep` — must
-    //  propose before they can be executed. The proposal records a
-    //  `proposed_at` timestamp and an `execute_after` deadline derived
-    //  from the configured `TimelockWindow` (default 48h). Any admin may
-    //  cancel an outstanding proposal at any time.
-    //
-    //  All three action slots are independent so multiple escape-hatch
-    //  proposals can be staged in parallel.
-    // =====================================================================
-
-    /// Configure the timelock window length (admin only).
-    ///
-    /// The window sets the minimum delay between proposing and executing a
-    /// critical admin action. Default on deployment is **48 h** (`172_800` s).
-    ///
-    /// # Bounds
-    /// - Minimum: [`timelock::MIN_TIMELOCK_SECONDS`] (1 h).
-    /// - Maximum: [`timelock::MAX_TIMELOCK_SECONDS`] (30 d).
-    /// - Default: [`timelock::DEFAULT_TIMELOCK_SECONDS`] (48 h).
-    ///
-    /// Changing the window does **not** retroactively shorten existing
-    /// proposals — each proposal carries its own `execute_after` deadline.
-    ///
-    /// # Authorization
-    /// The caller must be the current admin. `require_auth` runs first so
-    /// misconfigured callers can never silently poison the configuration.
-    ///
-    /// # Errors
-    /// - `VaultError::Unauthorized` if caller is not admin.
-    /// - `VaultError::InvalidTimelockWindow` if `window < MIN` or `window > MAX`.
-    pub fn set_timelock_window(env: Env, caller: Address, window: u64) -> Result<(), VaultError> {
-        Self::require_admin(&env, &caller)?;
-        if window < timelock::MIN_TIMELOCK_SECONDS || window > timelock::MAX_TIMELOCK_SECONDS {
-            return Err(VaultError::InvalidTimelockWindow);
-        }
-        timelock::set_timelock_window(&env, window);
-        env.events().publish(
-            (
-                events::event_timelock_window_changed(&env),
-                caller.clone(),
-            ),
-            (timelock::get_timelock_window(&env), window),
-        );
-        Ok(())
-    }
-
-    /// Return the configured timelock window length in seconds.
-    ///
-    /// Defaults to [`timelock::DEFAULT_TIMELOCK_SECONDS`] (48 h) when no
-    /// window has been explicitly configured.
-    pub fn get_timelock_window(env: Env) -> u64 {
-        timelock::get_timelock_window(&env)
-    }
-
-    /// Return the pending pause proposal, if any.
-    pub fn get_pending_pause(env: Env) -> Option<timelock::PendingPause> {
-        timelock::get_pending_pause(&env)
-    }
-
-    /// Return the pending upgrade proposal, if any.
-    pub fn get_pending_upgrade(env: Env) -> Option<timelock::PendingUpgrade> {
-        timelock::get_pending_upgrade(&env)
-    }
-
-    /// Return the pending sweep proposal, if any.
-    pub fn get_pending_sweep(env: Env) -> Option<timelock::PendingSweep> {
-        timelock::get_pending_sweep(&env)
-    }
-
-    /// Require the caller to be the current admin.
     fn require_admin(env: &Env, caller: &Address) -> Result<(), VaultError> {
         caller.require_auth();
-        let admin = Self::get_admin(env.clone())?;
+        let admin = env
+            .storage()
+            .instance()
+            .get::<_, Address>(&StorageKey::Admin)
+            .ok_or(VaultError::NotInitialized)?;
         if caller != &admin {
             return Err(VaultError::Unauthorized);
         }
         Ok(())
     }
 
-    /// Return the current admin address.
-    ///
-    /// Defaults to the owner when no admin has been explicitly set.
-    ///
-    /// # Errors
-    /// - `VaultError::NotInitialized` if the contract has not been initialized.
-    pub fn get_admin(env: Env) -> Result<Address, VaultError> {
-        env.storage()
-            .instance()
-            .get::<_, Address>(&StorageKey::Admin)
-            .ok_or(VaultError::NotInitialized)
-    }
-
     /// Initiate a two-step admin transfer (current admin only).
-    ///
-    /// Stores `new_admin` as a pending admin. The transfer is not complete
-    /// until `accept_admin` is called by `new_admin`.
-    ///
-    /// # Errors
-    /// - `VaultError::Unauthorized` if caller is not the current admin.
-    pub fn set_admin(env: Env, caller: Address, new_admin: Address) -> Result<(), VaultError> {
+    pub fn set_admin(
+        env: Env,
+        caller: Address,
+        new_admin: Address,
+    ) -> Result<(), VaultError> {
         Self::require_admin(&env, &caller)?;
         env.storage()
             .instance()
@@ -810,11 +1180,6 @@ impl CalloraVault {
     }
 
     /// Accept a pending admin transfer (pending admin only).
-    ///
-    /// Promotes the pending admin to the current admin and clears the pending slot.
-    ///
-    /// # Errors
-    /// - `VaultError::NoAdminTransferPending` if there is no pending admin.
     pub fn accept_admin(env: Env) -> Result<(), VaultError> {
         let new_admin: Address = env
             .storage()
@@ -831,19 +1196,104 @@ impl CalloraVault {
         Ok(())
     }
 
-    /// Propose pausing the vault (admin only, timelocked).
-    ///
-    /// Snapshots the proposal deadline `proposed_at + window`. Execution
-    /// becomes available after [`Self::execute_pause`] once the ledger
-    /// clock reaches `execute_after`.
-    ///
-    /// Re-proposing while a previous pause proposal is still live replaces
-    /// the proposal **and restarts the timer** — useful when the admin
-    /// re-baselines a stale proposal.
-    ///
-    /// # Errors
-    /// - `VaultError::Unauthorized` if caller is not admin.
-    /// - `VaultError::TimelockOverflow` if `proposed_at + window` overflows.
+    /// Transfer ownership (two-step) — initiate.
+    pub fn transfer_ownership(env: Env, caller: Address, new_owner: Address) {
+        Self::require_owner_auth(&env, &caller);
+        env.storage()
+            .instance()
+            .set(&DataKey::PendingOwner, &new_owner);
+        Self::bump_instance(&env);
+        env.events().publish(
+            (events::event_ownership_nominated(&env), caller),
+            new_owner,
+        );
+    }
+
+    /// Accept pending ownership (new owner only).
+    pub fn accept_ownership(env: Env) {
+        let new_owner: Address = env
+            .storage()
+            .instance()
+            .get::<_, Address>(&DataKey::PendingOwner)
+            .expect("no pending ownership transfer");
+        new_owner.require_auth();
+        env.storage().instance().set(&DataKey::Owner, &new_owner);
+        env.storage().instance().remove(&DataKey::PendingOwner);
+        Self::bump_instance(&env);
+        env.events().publish(
+            (events::event_ownership_accepted(&env), new_owner),
+            (),
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // Idempotency key pruning
+    // -----------------------------------------------------------------------
+
+    /// Owner-only: remove processed request markers to reclaim storage.
+    pub fn prune_processed_requests(
+        env: Env,
+        caller: Address,
+        ids: Vec<Symbol>,
+    ) -> Result<(), VaultError> {
+        caller.require_auth();
+        Self::require_owner(env.clone(), caller.clone())?;
+        for id in ids.iter() {
+            let key = StorageKey::ProcessedRequest(id.clone());
+            if env.storage().persistent().has(&key) {
+                env.storage().persistent().remove(&key);
+                env.events().publish(
+                    (events::event_request_id_pruned(&env), caller.clone()),
+                    id.clone(),
+                );
+            }
+        }
+        Ok(())
+    }
+
+    // -----------------------------------------------------------------------
+    // Timelock window
+    // -----------------------------------------------------------------------
+
+    pub fn set_timelock_window(
+        env: Env,
+        caller: Address,
+        window: u64,
+    ) -> Result<(), VaultError> {
+        Self::require_admin(&env, &caller)?;
+        if window < timelock::MIN_TIMELOCK_SECONDS
+            || window > timelock::MAX_TIMELOCK_SECONDS
+        {
+            return Err(VaultError::InvalidTimelockWindow);
+        }
+        timelock::set_timelock_window(&env, window);
+        env.events().publish(
+            (events::event_timelock_window_changed(&env), caller),
+            (timelock::get_timelock_window(&env), window),
+        );
+        Ok(())
+    }
+
+    pub fn get_timelock_window(env: Env) -> u64 {
+        timelock::get_timelock_window(&env)
+    }
+
+    pub fn get_pending_pause(env: Env) -> Option<timelock::PendingPause> {
+        timelock::get_pending_pause(&env)
+    }
+
+    pub fn get_pending_upgrade(env: Env) -> Option<timelock::PendingUpgrade> {
+        timelock::get_pending_upgrade(&env)
+    }
+
+    pub fn get_pending_sweep(env: Env) -> Option<timelock::PendingSweep> {
+        timelock::get_pending_sweep(&env)
+    }
+
+    // -----------------------------------------------------------------------
+    // Propose/Execute/Cancel — pause
+    // -----------------------------------------------------------------------
+
     pub fn propose_pause(env: Env, caller: Address) -> Result<(), VaultError> {
         Self::require_admin(&env, &caller)?;
         let proposed_at = env.ledger().timestamp();
@@ -852,74 +1302,48 @@ impl CalloraVault {
             .ok_or(VaultError::TimelockOverflow)?;
         timelock::set_pending_pause(
             &env,
-            &timelock::PendingPause {
-                proposed_at,
-                execute_after,
-            },
+            &timelock::PendingPause { proposed_at, execute_after },
         );
-        env.events()
-            .publish((events::event_pause_proposed(&env), caller), (proposed_at, execute_after));
+        env.events().publish(
+            (events::event_pause_proposed(&env), caller),
+            (proposed_at, execute_after),
+        );
         Ok(())
     }
 
-    /// Execute a pause proposal after the configured window has elapsed (admin only).
-    ///
-    /// On success, sets `StorageKey::Paused` to `true` and consumes the
-    /// pending proposal so it cannot be replayed. Emits the standard
-    /// `vault_paused` event.
-    ///
-    /// # Errors
-    /// - `VaultError::Unauthorized` if caller is not admin.
-    /// - `VaultError::ProposalNotFound` if no pause proposal exists.
-    /// - `VaultError::TimelockNotExpired` if `now < execute_after`.
     pub fn execute_pause(env: Env, caller: Address) -> Result<(), VaultError> {
         Self::require_admin(&env, &caller)?;
-        let proposal = timelock::get_pending_pause(&env)
-            .ok_or(VaultError::ProposalNotFound)?;
+        let proposal =
+            timelock::get_pending_pause(&env).ok_or(VaultError::ProposalNotFound)?;
         if env.ledger().timestamp() < proposal.execute_after {
             return Err(VaultError::TimelockNotExpired);
         }
         env.storage().instance().set(&DataKey::Paused, &true);
         timelock::clear_pending_pause(&env);
-        env.events()
-            .publish((events::event_pause_executed(&env), caller), env.ledger().timestamp());
+        env.events().publish(
+            (events::event_pause_executed(&env), caller.clone()),
+            env.ledger().timestamp(),
+        );
         env.events()
             .publish((events::event_vault_paused(&env), caller), ());
         Ok(())
     }
 
-    /// Cancel an outstanding pause proposal (admin only).
-    ///
-    /// Removes the proposal without applying it. Always emits the
-    /// `pause_cancelled` event for audit traceability, even when no
-    /// proposal exists, so consumers can never confuse "no event" with
-    /// "wasn't called".
-    ///
-    /// # Errors
-    /// - `VaultError::Unauthorized` if caller is not admin.
     pub fn cancel_pause(env: Env, caller: Address) -> Result<(), VaultError> {
         Self::require_admin(&env, &caller)?;
         let existing = timelock::get_pending_pause(&env);
         timelock::clear_pending_pause(&env);
         env.events().publish(
-            (
-                events::event_pause_cancelled(&env),
-                caller.clone(),
-            ),
-            (existing.is_some()),
+            (events::event_pause_cancelled(&env), caller),
+            existing.is_some(),
         );
         Ok(())
     }
 
-    /// Propose upgrading the vault WASM (admin only, timelocked).
-    ///
-    /// After the configured window elapses, `execute_upgrade` performs the
-    /// on-chain deployer update. Re-proposing replaces the stored wasm
-    /// hash **and restarts the timer**.
-    ///
-    /// # Errors
-    /// - `VaultError::Unauthorized` if caller is not admin.
-    /// - `VaultError::TimelockOverflow` if `proposed_at + window` overflows.
+    // -----------------------------------------------------------------------
+    // Propose/Execute/Cancel — upgrade
+    // -----------------------------------------------------------------------
+
     pub fn propose_upgrade(
         env: Env,
         caller: Address,
@@ -945,12 +1369,6 @@ impl CalloraVault {
         Ok(())
     }
 
-    /// Execute an upgrade proposal after the configured window has elapsed (admin only).
-    ///
-    /// # Errors
-    /// - `VaultError::Unauthorized` if caller is not admin.
-    /// - `VaultError::ProposalNotFound` if no upgrade proposal exists.
-    /// - `VaultError::TimelockNotExpired` if `now < execute_after`.
     pub fn execute_upgrade(env: Env, caller: Address) -> Result<(), VaultError> {
         Self::require_admin(&env, &caller)?;
         let proposal = timelock::get_pending_upgrade(&env)
@@ -959,7 +1377,6 @@ impl CalloraVault {
             return Err(VaultError::TimelockNotExpired);
         }
         let wasm_hash = proposal.wasm_hash.clone();
-        let _admin = Self::get_admin(env.clone())?;
         env.deployer().update_current_contract_wasm(wasm_hash.clone());
         env.storage()
             .instance()
@@ -974,38 +1391,21 @@ impl CalloraVault {
         Ok(())
     }
 
-    /// Cancel an outstanding upgrade proposal (admin only).
-    ///
-    /// Always emits `upgrade_cancelled` for audit traceability, even when
-    /// no proposal is pending; the bool data payload reports whether a
-    /// proposal was actually consumed.
-    ///
-    /// # Errors
-    /// - `VaultError::Unauthorized` if caller is not admin.
     pub fn cancel_upgrade(env: Env, caller: Address) -> Result<(), VaultError> {
         Self::require_admin(&env, &caller)?;
         let existing = timelock::get_pending_upgrade(&env);
         timelock::clear_pending_upgrade(&env);
         env.events().publish(
-            (
-                events::event_upgrade_cancelled(&env),
-                caller.clone(),
-            ),
-            (existing.is_some()),
+            (events::event_upgrade_cancelled(&env), caller),
+            existing.is_some(),
         );
         Ok(())
     }
 
-    /// Propose sweeping (distributing) on-ledger USDC surplus to a recipient (admin only, timelocked).
-    ///
-    /// After the configured window elapses, `execute_sweep` transfers the
-    /// funds and emits the standard `distribute` event. Re-proposing
-    /// replaces the recipient+amount **and restarts the timer**.
-    ///
-    /// # Errors
-    /// - `VaultError::Unauthorized` if caller is not admin.
-    /// - `VaultError::AmountNotPositive` if `amount <= 0`.
-    /// - `VaultError::TimelockOverflow` if `proposed_at + window` overflows.
+    // -----------------------------------------------------------------------
+    // Propose/Execute/Cancel — sweep
+    // -----------------------------------------------------------------------
+
     pub fn propose_sweep(
         env: Env,
         caller: Address,
@@ -1022,12 +1422,7 @@ impl CalloraVault {
             .ok_or(VaultError::TimelockOverflow)?;
         timelock::set_pending_sweep(
             &env,
-            &timelock::PendingSweep {
-                to: to.clone(),
-                amount,
-                proposed_at,
-                execute_after,
-            },
+            &timelock::PendingSweep { to: to.clone(), amount, proposed_at, execute_after },
         );
         env.events().publish(
             (events::event_sweep_proposed(&env), caller),
@@ -1036,17 +1431,6 @@ impl CalloraVault {
         Ok(())
     }
 
-    /// Execute a sweep proposal after the configured window has elapsed (admin only).
-    ///
-    /// Performs the on-ledger transfer of `amount` USDC to the snapshotted
-    /// recipient. The proposal is consumed atomically so a successful
-    /// execute cannot be replayed.
-    ///
-    /// # Errors
-    /// - `VaultError::Unauthorized` if caller is not admin.
-    /// - `VaultError::ProposalNotFound` if no sweep proposal exists.
-    /// - `VaultError::TimelockNotExpired` if `now < execute_after`.
-    /// - `VaultError::InsufficientBalance` if vault holds less than `amount`.
     pub fn execute_sweep(env: Env, caller: Address) -> Result<(), VaultError> {
         Self::require_admin(&env, &caller)?;
         let proposal = timelock::get_pending_sweep(&env)
@@ -1054,7 +1438,6 @@ impl CalloraVault {
         if env.ledger().timestamp() < proposal.execute_after {
             return Err(VaultError::TimelockNotExpired);
         }
-
         let usdc_addr: Address = env
             .storage()
             .instance()
@@ -1070,151 +1453,59 @@ impl CalloraVault {
             &proposal.amount,
         );
         let executed_at = env.ledger().timestamp();
+        timelock::clear_pending_sweep(&env);
         env.events().publish(
             (events::event_sweep_executed(&env), caller),
             (proposal.to.clone(), proposal.amount, executed_at),
         );
         env.events().publish(
-            (events::event_distribute(&env), proposal.to.clone()),
+            (events::event_distribute(&env), proposal.to),
             proposal.amount,
         );
-        timelock::clear_pending_sweep(&env);
         Ok(())
     }
 
-    /// Cancel an outstanding sweep proposal (admin only).
-    ///
-    /// Always emits `sweep_cancelled` for audit traceability, even when
-    /// no proposal is pending; the bool data payload reports whether a
-    /// proposal was actually consumed.
-    ///
-    /// # Errors
-    /// - `VaultError::Unauthorized` if caller is not admin.
     pub fn cancel_sweep(env: Env, caller: Address) -> Result<(), VaultError> {
         Self::require_admin(&env, &caller)?;
         let existing = timelock::get_pending_sweep(&env);
         timelock::clear_pending_sweep(&env);
         env.events().publish(
-            (
-                events::event_sweep_cancelled(&env),
-                caller.clone(),
-            ),
-            (existing.is_some()),
+            (events::event_sweep_cancelled(&env), caller),
+            existing.is_some(),
         );
         Ok(())
-    }
-
-    /// Garbage-collect processed request markers from persistent storage.
-    /// Only the owner can call this.
-    /// Emits a `request_id_pruned` event for each removed ID.
-    pub fn prune_processed_requests(
-        env: Env,
-        caller: Address,
-        ids: Vec<Symbol>,
-    ) -> Result<(), VaultError> {
-        caller.require_auth();
-        Self::require_owner(env.clone(), caller.clone())?;
-
-        for id in ids.iter() {
-            let key = StorageKey::ProcessedRequest(id.clone());
-            if env.storage().persistent().has(&key) {
-                env.storage().persistent().remove(&key);
-                env.events().publish(
-                    (events::event_request_id_pruned(&env), caller.clone()),
-                    id.clone(),
-                );
-            }
-        }
-
-        Ok(())
-    }
-
-    pub fn is_authorized_depositor(env: Env, caller: Address) -> bool {
-        env.storage()
-            .instance()
-            .get::<_, bool>(&DataKey::Depositor(caller))
-            .unwrap_or(false)
-    }
-
-    /// Set or update the reserve cap for a token (owner only).
-    ///
-    /// The reserve cap is the maximum total balance the vault may hold for
-    /// `token`.  Any `deposit` call that would push the balance beyond `cap`
-    /// is rejected with [`VaultError::ExceedsReserveCap`].
-    ///
-    /// Pass `i128::MAX` to remove the effective cap (restore unlimited deposits).
-    ///
-    /// # Parameters
-    /// - `caller` — must be the vault owner.
-    /// - `token` — token contract address the cap applies to.
-    /// - `cap` — maximum balance in token stroops; must be > 0.
-    ///
-    /// # Errors
-    /// - [`VaultError::Unauthorized`] — `caller` is not the owner.
-    /// - [`VaultError::AmountNotPositive`] — `cap <= 0`.
-    pub fn set_reserve_cap(
-        env: Env,
-        caller: Address,
-        token: Address,
-        cap: i128,
-    ) -> Result<(), VaultError> {
-        caller.require_auth();
-        Self::require_owner(env.clone(), caller.clone())?;
-        if cap <= 0 {
-            return Err(VaultError::AmountNotPositive);
-        }
-        let prev = limits::set(&env, &token, cap);
-        env.events().publish(
-            (events::event_reserve_cap_set(&env), caller, token),
-            (prev, cap),
-        );
-        Ok(())
-    }
-
-    /// Return the reserve cap for `token`.
-    ///
-    /// Returns `i128::MAX` when no cap has been configured (effectively unlimited).
-    pub fn get_reserve_cap(env: Env, token: Address) -> i128 {
-        limits::get(&env, &token)
     }
 }
+
+// ---------------------------------------------------------------------------
+// Module declarations
+// ---------------------------------------------------------------------------
 
 pub mod capabilities;
 mod cold_storage;
 mod events;
 pub mod limits;
 pub mod rate_limit;
-
-// #[cfg(test)]
-// #[path = "../proofs/deduct.rs"]
-// mod deduct_proofs;
+pub mod timelock;
 
 // ---------------------------------------------------------------------------
 // Test modules
 // ---------------------------------------------------------------------------
 
-// #[cfg(test)]
-// mod test;
+#[cfg(test)]
+mod test;
 
-// NOTE: The following test modules expect a richer contract API (DeductItem,
-// Option<Symbol> request IDs, get_meta, DEFAULT_MIN_DEPOSIT, etc.) that the
-// current simplified vault does not expose. They are commented out until the
-// vault API is migrated.
-//
-// #[cfg(test)]
-// mod test_settler_validation;
+#[cfg(test)]
+mod test_views;
 
-// #[cfg(test)]
-// mod test_views;
+#[cfg(test)]
+mod test_idempotency;
 
-// #[cfg(test)]
-// mod test_idempotency;
+#[cfg(test)]
+mod test_error_codes;
 
-// #[cfg(test)]
-// mod test_error_codes;
-
-// #[cfg(test)]
-// mod test_reentrancy;
+#[cfg(test)]
+mod test_reentrancy;
 
 #[cfg(test)]
 mod test_sweep_idle_balance;
@@ -1222,7 +1513,38 @@ mod test_sweep_idle_balance;
 #[cfg(test)]
 mod test_access_control_matrix;
 
-// #[cfg(test)]
-// mod test_gas_budget;
-// #[cfg(test)]
-// mod test_rate_limit;
+#[cfg(test)]
+mod test_gas_budget;
+
+#[cfg(test)]
+mod test_rate_limit;
+
+#[cfg(test)]
+mod test_timelock;
+
+#[cfg(test)]
+mod test_init_hardening;
+
+#[cfg(test)]
+mod test_balance_property;
+
+#[cfg(test)]
+mod test_capabilities;
+
+#[cfg(test)]
+mod test_cross_invariant;
+
+#[cfg(test)]
+mod test_limits;
+
+#[cfg(test)]
+mod test_reserve_cap;
+
+#[cfg(test)]
+mod test_set_auth_fuzz;
+
+#[cfg(test)]
+mod test_setter_validation;
+
+#[cfg(test)]
+mod test_withdraw_to_zero_address;

--- a/contracts/vault/src/limits.rs
+++ b/contracts/vault/src/limits.rs
@@ -16,6 +16,17 @@ use soroban_sdk::{Address, Env};
 
 use crate::{StorageKey, VaultError, INSTANCE_BUMP_AMOUNT, INSTANCE_BUMP_THRESHOLD};
 
+/// Default maximum deduction cap — effectively unlimited.
+pub const DEFAULT_MAX_DEDUCT: i128 = i128::MAX;
+
+/// Check whether `amount` exceeds `max_deduct`. Returns `Err(ExceedsMaxDeduct)` if so.
+pub fn check_max_deduct(amount: i128, max_deduct: i128) -> Result<(), VaultError> {
+    if amount > max_deduct {
+        return Err(VaultError::ExceedsMaxDeduct);
+    }
+    Ok(())
+}
+
 /// Store a per-token reserve cap and return the previous value.
 ///
 /// # Arguments

--- a/contracts/vault/src/test.rs
+++ b/contracts/vault/src/test.rs
@@ -89,12 +89,11 @@ fn init_defaults_balance_to_zero() {
     client.init(
         &owner,
         &usdc,
-        &0,
-        &owner,
-        &1,
+        &Some(0),
+        &Some(owner.clone()),
+        &Some(1),
         &None,
-        &10000000000,
-        &soroban_sdk::Address::generate(&env),
+        &None,
     );
     assert_eq!(client.balance(), 0);
 }
@@ -110,12 +109,11 @@ fn init_defaults_min_deposit_to_one() {
     let meta = client.init(
         &owner,
         &usdc,
-        &0,
-        &owner,
-        &1,
+        &Some(0),
+        &Some(owner.clone()),
+        &Some(1),
         &None,
-        &10000000000,
-        &soroban_sdk::Address::generate(&env),
+        &None,
     );
 
     assert_eq!(meta.min_deposit, 1);
@@ -449,12 +447,11 @@ fn owner_can_deposit() {
     client.init(
         &owner,
         &usdc,
-        &0,
-        &owner,
-        &1,
+        &Some(0),
+        &Some(owner.clone()),
+        &Some(1),
         &None,
-        &10000000000,
-        &soroban_sdk::Address::generate(&env),
+        &None,
     );
 
     usdc_admin.mint(&owner, &500);
@@ -597,12 +594,11 @@ fn deposit_paused_fails() {
     client.init(
         &owner,
         &usdc,
-        &0,
-        &owner,
-        &1,
+        &Some(0),
+        &Some(owner.clone()),
+        &Some(1),
         &None,
-        &10000000000,
-        &soroban_sdk::Address::generate(&env),
+        &None,
     );
 
     client.pause(&owner);
@@ -636,12 +632,11 @@ fn owner_deposit_increases_balance_and_emits_event() {
     client.init(
         &owner,
         &usdc,
-        &0,
-        &owner,
-        &1,
+        &Some(0),
+        &Some(owner.clone()),
+        &Some(1),
         &None,
-        &10000000000,
-        &soroban_sdk::Address::generate(&env),
+        &None,
     );
 
     usdc_admin.mint(&owner, &500);
@@ -746,12 +741,11 @@ fn deposit_event_schema_alignment() {
     client.init(
         &owner,
         &usdc,
-        &0,
-        &owner,
-        &1,
+        &Some(0),
+        &Some(owner.clone()),
+        &Some(1),
         &None,
-        &10000000000,
-        &soroban_sdk::Address::generate(&env),
+        &None,
     );
 
     usdc_admin.mint(&owner, &200);
@@ -912,12 +906,11 @@ fn pause_unpause_admin_only() {
     client.init(
         &owner,
         &usdc,
-        &0,
-        &owner,
-        &1,
+        &Some(0),
+        &Some(owner.clone()),
+        &Some(1),
         &None,
-        &10000000000,
-        &soroban_sdk::Address::generate(&env),
+        &None,
     );
 
     // intruder fails
@@ -948,12 +941,11 @@ fn pause_emits_event() {
     client.init(
         &owner,
         &usdc,
-        &0,
-        &owner,
-        &1,
+        &Some(0),
+        &Some(owner.clone()),
+        &Some(1),
         &None,
-        &10000000000,
-        &soroban_sdk::Address::generate(&env),
+        &None,
     );
 
     client.pause(&owner);
@@ -989,12 +981,11 @@ fn nuclear_pause_requires_current_admin_and_sets_pause() {
     client.init(
         &owner,
         &usdc,
-        &0,
-        &owner,
-        &1,
+        &Some(0),
+        &Some(owner.clone()),
+        &Some(1),
         &None,
-        &10000000000,
-        &soroban_sdk::Address::generate(&env),
+        &None,
     );
     client.set_admin(&owner, &admin);
     client.accept_admin();
@@ -1024,12 +1015,11 @@ fn nuclear_pause_rejects_already_paused() {
     client.init(
         &owner,
         &usdc,
-        &0,
-        &owner,
-        &1,
+        &Some(0),
+        &Some(owner.clone()),
+        &Some(1),
         &None,
-        &10000000000,
-        &soroban_sdk::Address::generate(&env),
+        &None,
     );
     client.nuclear_pause(&owner);
 
@@ -1070,7 +1060,7 @@ fn set_authorized_caller_sets_and_emits_event() {
     assert_eq!(now, Some(new_caller.clone()));
     assert_eq!(nonce, 0u64);
 
-    let remaining = client.deduct(&new_caller, &50, &None, &u32::MAX, &Address::generate(&env));
+    let remaining = client.deduct(&new_caller, &50, &None);
     assert_eq!(remaining, 150);
 }
 
@@ -1086,7 +1076,7 @@ fn deduct_reduces_balance() {
     client.init(&owner, &usdc, &Some(300), &None, &None, &None, &None);
     let settlement = create_settlement(&env, &owner, &vault_address);
 
-    let returned = client.deduct(&owner, &50, &None, &u32::MAX, &Address::generate(&env));
+    let returned = client.deduct(&owner, &50, &None);
     assert_eq!(returned, 250);
     assert_eq!(client.balance(), 250);
 }
@@ -1107,8 +1097,6 @@ fn deduct_with_request_id() {
         &owner,
         &100,
         &Some(Symbol::new(&env, "req123")),
-        &u32::MAX,
-        &Address::generate(&env),
     );
     assert_eq!(remaining, 900);
 }
@@ -1124,7 +1112,7 @@ fn deduct_insufficient_balance_fails() {
     fund_vault(&usdc_admin, &vault_address, 10);
     client.init(&owner, &usdc, &Some(10), &None, &None, &None, &None);
 
-    let result = client.try_deduct(&owner, &100, &None, &u32::MAX);
+    let result = client.try_deduct(&owner, &100, &None);
     assert!(result.is_err(), "expected error for insufficient balance");
 }
 
@@ -1140,7 +1128,7 @@ fn deduct_exact_balance_succeeds() {
     client.init(&owner, &usdc, &Some(75), &None, &None, &None, &None);
     let settlement = create_settlement(&env, &owner, &vault_address);
 
-    let remaining = client.deduct(&owner, &75, &None, &u32::MAX, &Address::generate(&env));
+    let remaining = client.deduct(&owner, &75, &None);
     assert_eq!(remaining, 0);
     assert_eq!(client.balance(), 0);
 }
@@ -1161,8 +1149,7 @@ fn deduct_event_contains_request_id() {
     client.deduct(
         &owner,
         &150,
-        &Some(request_id.clone(), &Address::generate(&env)),
-        &u32::MAX,
+        &Some(request_id.clone()),
     );
 
     let events = env.events().all();
@@ -1192,28 +1179,28 @@ fn deduct_zero_amount_fails() {
     env.mock_all_auths();
     fund_vault(&usdc_admin, &client.address, 100);
     client.init(&owner, &usdc, &Some(100), &None, &None, &None, &None);
-    client.deduct(&owner, &0, &None, &u32::MAX);
+    client.deduct(&owner, &0, &None);
 }
 
 #[test]
 #[should_panic(expected = "deduct amount exceeds max_deduct")]
 fn deduct_exceeding_max_fails() {
     let env = Env::default();
-    let owner = Address::generate(&env, &Address::generate(&env));
+    let owner = Address::generate(&env);
     let (_, client) = create_vault(&env);
     let (usdc, _, usdc_admin) = create_usdc(&env, &owner);
     env.mock_all_auths();
     fund_vault(&usdc_admin, &client.address, 1000);
     // Set max_deduct to 500
     client.init(&owner, &usdc, &Some(1000), &None, &None, &None, &Some(500));
-    client.deduct(&owner, &501, &None, &u32::MAX);
+    client.deduct(&owner, &501, &None);
 }
 
 #[test]
 fn deduct_authorized_caller_succeeds() {
     let env = Env::default();
     let owner = Address::generate(&env);
-    let authorized = Address::generate(&env, &Address::generate(&env));
+    let authorized = Address::generate(&env);
     let (vault_address, client) = create_vault(&env);
     let (usdc, _, usdc_admin) = create_usdc(&env, &owner);
     env.mock_all_auths();
@@ -1232,9 +1219,7 @@ fn deduct_authorized_caller_succeeds() {
     let remaining = client.deduct(
         &authorized,
         &100,
-        &None,
-        &u32::MAX,
-        &Address::generate(&env),
+        &None
     );
     assert_eq!(remaining, 900);
 }
@@ -1249,13 +1234,13 @@ fn deduct_paused_fails() {
     fund_vault(&usdc_admin, &client.address, 1000);
     client.init(&owner, &usdc, &Some(1000), &None, &None, &None, &None);
     client.pause(&owner);
-    client.deduct(&owner, &100, &None, &u32::MAX);
+    client.deduct(&owner, &100, &None);
 }
 
 #[test]
 fn deduct_event_no_request_id_uses_empty_symbol() {
     let env = Env::default();
-    let owner = Address::generate(&env, &Address::generate(&env));
+    let owner = Address::generate(&env);
     let (vault_address, client) = create_vault(&env);
     let (usdc, _, usdc_admin) = create_usdc(&env, &owner);
 
@@ -1264,12 +1249,12 @@ fn deduct_event_no_request_id_uses_empty_symbol() {
     client.init(&owner, &usdc, &Some(300), &None, &None, &None, &None);
     let settlement = create_settlement(&env, &owner, &vault_address);
 
-    client.deduct(&owner, &100, &None, &u32::MAX);
+    client.deduct(&owner, &100, &None);
 
     let events = env.events().all();
     let ev = events.last().expect("expected deduct event");
 
-    assert_eq!(ev.1.len(, &Address::generate(&env)), 3, "deduct event must always have 3 topics");
+    assert_eq!(ev.1.len(), 3, "deduct event must always have 3 topics");
     let topic0: Symbol = ev.1.get(0).unwrap().into_val(&env);
     let topic1: Address = ev.1.get(1).unwrap().into_val(&env);
     let topic2: Symbol = ev.1.get(2).unwrap().into_val(&env);
@@ -1293,41 +1278,41 @@ fn deduct_zero_panics() {
     env.mock_all_auths();
     fund_vault(&usdc_admin, &vault_address, 500);
     client.init(&owner, &usdc, &Some(500), &None, &None, &None, &None);
-    client.deduct(&owner, &0, &None, &u32::MAX);
+    client.deduct(&owner, &0, &None);
 }
 
 #[test]
 #[should_panic(expected = "amount must be positive")]
 fn deduct_negative_panics() {
     let env = Env::default();
-    let owner = Address::generate(&env, &Address::generate(&env));
+    let owner = Address::generate(&env);
     let (vault_address, client) = create_vault(&env);
     let (usdc, _, usdc_admin) = create_usdc(&env, &owner);
 
     env.mock_all_auths();
     fund_vault(&usdc_admin, &vault_address, 100);
     client.init(&owner, &usdc, &Some(100), &None, &None, &None, &None);
-    client.deduct(&owner, &-50, &None, &u32::MAX);
+    client.deduct(&owner, &-50, &None);
 }
 
 #[test]
 #[should_panic(expected = "insufficient balance")]
 fn deduct_exceeds_balance_panics() {
     let env = Env::default();
-    let owner = Address::generate(&env, &Address::generate(&env));
+    let owner = Address::generate(&env);
     let (vault_address, client) = create_vault(&env);
     let (usdc, _, usdc_admin) = create_usdc(&env, &owner);
 
     env.mock_all_auths();
     fund_vault(&usdc_admin, &vault_address, 50);
     client.init(&owner, &usdc, &Some(50), &None, &None, &None, &None);
-    client.deduct(&owner, &100, &None, &u32::MAX);
+    client.deduct(&owner, &100, &None);
 }
 
 #[test]
 fn balance_unchanged_after_failed_deduct() {
     let env = Env::default();
-    let owner = Address::generate(&env, &Address::generate(&env));
+    let owner = Address::generate(&env);
     let (vault_address, client) = create_vault(&env);
     let (usdc, _, usdc_admin) = create_usdc(&env, &owner);
 
@@ -1335,7 +1320,7 @@ fn balance_unchanged_after_failed_deduct() {
     fund_vault(&usdc_admin, &vault_address, 100);
     client.init(&owner, &usdc, &Some(100), &None, &None, &None, &None);
 
-    let _ = client.try_deduct(&owner, &200, &None, &u32::MAX);
+    let _ = client.try_deduct(&owner, &200, &None);
     assert_eq!(client.balance(), 100);
 }
 
@@ -1357,12 +1342,11 @@ fn propose_and_accept_revenue_pool_stores_address() {
     client.init(
         &owner,
         &usdc,
-        &0,
-        &owner,
-        &1,
+        &Some(0),
+        &Some(owner.clone()),
+        &Some(1),
         &None,
-        &10000000000,
-        &soroban_sdk::Address::generate(&env),
+        &None,
     );
     client.propose_revenue_pool(&Some(revenue_pool.clone()));
     // pending should be set
@@ -1387,12 +1371,11 @@ fn propose_and_accept_revenue_pool_clear_proposal() {
     client.init(
         &owner,
         &usdc,
-        &0,
-        &owner,
-        &1,
+        &Some(0),
+        &Some(owner.clone()),
+        &Some(1),
         &None,
-        &10000000000,
-        &soroban_sdk::Address::generate(&env),
+        &None,
     );
     // Propose None to clear the revenue pool
     client.propose_revenue_pool(&None);
@@ -1467,12 +1450,11 @@ fn cancel_revenue_pool_removes_pending() {
     client.init(
         &owner,
         &usdc,
-        &0,
-        &owner,
-        &1,
+        &Some(0),
+        &Some(owner.clone()),
+        &Some(1),
         &None,
-        &10000000000,
-        &soroban_sdk::Address::generate(&env),
+        &None,
     );
 
     // Propose
@@ -1496,12 +1478,11 @@ fn accept_revenue_pool_no_pending_fails() {
     client.init(
         &owner,
         &usdc,
-        &0,
-        &owner,
-        &1,
+        &Some(0),
+        &Some(owner.clone()),
+        &Some(1),
         &None,
-        &10000000000,
-        &soroban_sdk::Address::generate(&env),
+        &None,
     );
 
     let result = client.try_accept_revenue_pool();
@@ -1519,12 +1500,11 @@ fn cancel_revenue_pool_no_pending_fails() {
     client.init(
         &owner,
         &usdc,
-        &0,
-        &owner,
-        &1,
+        &Some(0),
+        &Some(owner.clone()),
+        &Some(1),
         &None,
-        &10000000000,
-        &soroban_sdk::Address::generate(&env),
+        &None,
     );
 
     let result = client.try_cancel_revenue_pool();
@@ -1543,12 +1523,11 @@ fn propose_revenue_pool_emits_event() {
     client.init(
         &owner,
         &usdc,
-        &0,
-        &owner,
-        &1,
+        &Some(0),
+        &Some(owner.clone()),
+        &Some(1),
         &None,
-        &10000000000,
-        &soroban_sdk::Address::generate(&env),
+        &None,
     );
     client.propose_revenue_pool(&Some(revenue_pool.clone()));
 
@@ -1570,12 +1549,11 @@ fn accept_revenue_pool_emits_event() {
     client.init(
         &owner,
         &usdc,
-        &0,
-        &owner,
-        &1,
+        &Some(0),
+        &Some(owner.clone()),
+        &Some(1),
         &None,
-        &10000000000,
-        &soroban_sdk::Address::generate(&env),
+        &None,
     );
     client.propose_revenue_pool(&Some(revenue_pool.clone()));
     client.accept_revenue_pool();
@@ -1598,12 +1576,11 @@ fn cancel_revenue_pool_emits_event() {
     client.init(
         &owner,
         &usdc,
-        &0,
-        &owner,
-        &1,
+        &Some(0),
+        &Some(owner.clone()),
+        &Some(1),
         &None,
-        &10000000000,
-        &soroban_sdk::Address::generate(&env),
+        &None,
     );
     client.propose_revenue_pool(&Some(pool));
     client.cancel_revenue_pool();
@@ -1625,12 +1602,11 @@ fn get_revenue_pool_returns_none_when_not_set() {
     client.init(
         &owner,
         &usdc,
-        &0,
-        &owner,
-        &1,
+        &Some(0),
+        &Some(owner.clone()),
+        &Some(1),
         &None,
-        &10000000000,
-        &soroban_sdk::Address::generate(&env),
+        &None,
     );
 
     assert_eq!(client.get_revenue_pool(), None);
@@ -1664,7 +1640,7 @@ fn get_revenue_pool_consistent_after_deduct_operations() {
     assert_eq!(before, Some(revenue_pool.clone()));
 
     // Perform deduct operation (routes to settlement, not revenue_pool)
-    client.deduct(&caller, &200, &None, &u32::MAX);
+    client.deduct(&caller, &200, &None);
 
     // Query revenue pool after deduct - should be unchanged
     let after = client.get_revenue_pool(&env);
@@ -1688,12 +1664,11 @@ fn get_pending_revenue_pool_returns_none_when_not_set() {
     client.init(
         &owner,
         &usdc,
-        &0,
-        &owner,
-        &1,
+        &Some(0),
+        &Some(owner.clone()),
+        &Some(1),
         &None,
-        &10000000000,
-        &soroban_sdk::Address::generate(&env),
+        &None,
     );
 
     assert_eq!(client.get_pending_revenue_pool(), None);
@@ -1711,12 +1686,11 @@ fn get_pending_revenue_pool_returns_proposed() {
     client.init(
         &owner,
         &usdc,
-        &0,
-        &owner,
-        &1,
+        &Some(0),
+        &Some(owner.clone()),
+        &Some(1),
         &None,
-        &10000000000,
-        &soroban_sdk::Address::generate(&env),
+        &None,
     );
     client.propose_revenue_pool(&Some(pool.clone()));
     assert_eq!(client.get_pending_revenue_pool(), Some(pool));
@@ -2156,12 +2130,11 @@ fn set_and_retrieve_metadata() {
     client.init(
         &owner,
         &usdc,
-        &0,
-        &owner,
-        &1,
+        &Some(0),
+        &Some(owner.clone()),
+        &Some(1),
         &None,
-        &10000000000,
-        &soroban_sdk::Address::generate(&env),
+        &None,
     );
 
     let offering_id = String::from_str(&env, "offering-001");
@@ -2185,12 +2158,11 @@ fn set_metadata_emits_event() {
     client.init(
         &owner,
         &usdc,
-        &0,
-        &owner,
-        &1,
+        &Some(0),
+        &Some(owner.clone()),
+        &Some(1),
         &None,
-        &10000000000,
-        &soroban_sdk::Address::generate(&env),
+        &None,
     );
 
     let offering_id = String::from_str(&env, "offering-002");
@@ -2230,12 +2202,11 @@ fn update_metadata_and_verify() {
     client.init(
         &owner,
         &usdc,
-        &0,
-        &owner,
-        &1,
+        &Some(0),
+        &Some(owner.clone()),
+        &Some(1),
         &None,
-        &10000000000,
-        &soroban_sdk::Address::generate(&env),
+        &None,
     );
 
     let offering_id = String::from_str(&env, "offering-003");
@@ -2261,12 +2232,11 @@ fn update_metadata_emits_event() {
     client.init(
         &owner,
         &usdc,
-        &0,
-        &owner,
-        &1,
+        &Some(0),
+        &Some(owner.clone()),
+        &Some(1),
         &None,
-        &10000000000,
-        &soroban_sdk::Address::generate(&env),
+        &None,
     );
 
     let offering_id = String::from_str(&env, "offering-004");
@@ -2307,12 +2277,11 @@ fn update_metadata_without_existing_uses_empty_old() {
     client.init(
         &owner,
         &usdc,
-        &0,
-        &owner,
-        &1,
+        &Some(0),
+        &Some(owner.clone()),
+        &Some(1),
         &None,
-        &10000000000,
-        &soroban_sdk::Address::generate(&env),
+        &None,
     );
 
     let offering_id = String::from_str(&env, "offering-006");
@@ -2341,12 +2310,11 @@ fn unauthorized_cannot_set_metadata() {
     client.init(
         &owner,
         &usdc,
-        &0,
-        &owner,
-        &1,
+        &Some(0),
+        &Some(owner.clone()),
+        &Some(1),
         &None,
-        &10000000000,
-        &soroban_sdk::Address::generate(&env),
+        &None,
     );
 
     let offering_id = String::from_str(&env, "offering-005");
@@ -2365,12 +2333,11 @@ fn set_metadata_max_length_succeeds() {
     client.init(
         &owner,
         &usdc,
-        &0,
-        &owner,
-        &1,
+        &Some(0),
+        &Some(owner.clone()),
+        &Some(1),
         &None,
-        &10000000000,
-        &soroban_sdk::Address::generate(&env),
+        &None,
     );
 
     let offering_id = String::from_str(&env, "a".repeat(64).as_str());
@@ -2392,12 +2359,11 @@ fn set_metadata_exceeds_length_panics() {
     client.init(
         &owner,
         &usdc,
-        &0,
-        &owner,
-        &1,
+        &Some(0),
+        &Some(owner.clone()),
+        &Some(1),
         &None,
-        &10000000000,
-        &soroban_sdk::Address::generate(&env),
+        &None,
     );
 
     let offering_id = String::from_str(&env, "off-1");
@@ -2418,12 +2384,11 @@ fn set_offering_id_exceeds_length_panics() {
     client.init(
         &owner,
         &usdc,
-        &0,
-        &owner,
-        &1,
+        &Some(0),
+        &Some(owner.clone()),
+        &Some(1),
         &None,
-        &10000000000,
-        &soroban_sdk::Address::generate(&env),
+        &None,
     );
 
     let offering_id = String::from_str(&env, "a".repeat(65).as_str());
@@ -2443,12 +2408,11 @@ fn update_metadata_max_length_succeeds() {
     client.init(
         &owner,
         &usdc,
-        &0,
-        &owner,
-        &1,
+        &Some(0),
+        &Some(owner.clone()),
+        &Some(1),
         &None,
-        &10000000000,
-        &soroban_sdk::Address::generate(&env),
+        &None,
     );
 
     let offering_id = String::from_str(&env, "offering-update");
@@ -2471,12 +2435,11 @@ fn metadata_remains_after_ownership_transfer() {
     client.init(
         &owner,
         &usdc,
-        &0,
-        &owner,
-        &1,
+        &Some(0),
+        &Some(owner.clone()),
+        &Some(1),
         &None,
-        &10000000000,
-        &soroban_sdk::Address::generate(&env),
+        &None,
     );
 
     let offering_id = String::from_str(&env, "off-transfer");
@@ -2517,12 +2480,11 @@ fn remove_metadata_clears_entry() {
     client.init(
         &owner,
         &usdc,
-        &0,
-        &owner,
-        &1,
+        &Some(0),
+        &Some(owner.clone()),
+        &Some(1),
         &None,
-        &10000000000,
-        &soroban_sdk::Address::generate(&env),
+        &None,
     );
 
     let offering_id = String::from_str(&env, "offering-rm-001");
@@ -2546,12 +2508,11 @@ fn remove_metadata_emits_event() {
     client.init(
         &owner,
         &usdc,
-        &0,
-        &owner,
-        &1,
+        &Some(0),
+        &Some(owner.clone()),
+        &Some(1),
         &None,
-        &10000000000,
-        &soroban_sdk::Address::generate(&env),
+        &None,
     );
 
     let offering_id = String::from_str(&env, "offering-rm-002");
@@ -2587,12 +2548,11 @@ fn unauthorized_cannot_remove_metadata() {
     client.init(
         &owner,
         &usdc,
-        &0,
-        &owner,
-        &1,
+        &Some(0),
+        &Some(owner.clone()),
+        &Some(1),
         &None,
-        &10000000000,
-        &soroban_sdk::Address::generate(&env),
+        &None,
     );
 
     let offering_id = String::from_str(&env, "offering-rm-003");
@@ -2611,12 +2571,11 @@ fn remove_metadata_nonexistent_is_noop() {
     client.init(
         &owner,
         &usdc,
-        &0,
-        &owner,
-        &1,
+        &Some(0),
+        &Some(owner.clone()),
+        &Some(1),
         &None,
-        &10000000000,
-        &soroban_sdk::Address::generate(&env),
+        &None,
     );
 
     let offering_id = String::from_str(&env, "offering-rm-never-set");
@@ -2688,8 +2647,6 @@ fn vault_full_lifecycle() {
         &owner,
         &25,
         &Some(Symbol::new(&env, "r4")),
-        &u32::MAX,
-        &Address::generate(&env),
     );
     assert_eq!(after_deduct, 500);
 
@@ -2764,14 +2721,14 @@ fn deduct_with_only_revenue_pool_panics() {
         &None,
     );
 
-    client.deduct(&caller, &300, &None, &u32::MAX);
+    client.deduct(&caller, &300, &None);
 }
 
 #[test]
 fn deduct_with_settlement_transfers_usdc() {
     let env = Env::default();
     let owner = Address::generate(&env);
-    let caller = Address::generate(&env, &Address::generate(&env));
+    let caller = Address::generate(&env);
     let (vault_address, client) = create_vault(&env);
     let settlement = create_settlement(&env, &owner, &vault_address);
     let (usdc_address, usdc_client, usdc_admin) = create_usdc(&env, &owner);
@@ -2788,9 +2745,9 @@ fn deduct_with_settlement_transfers_usdc() {
         &None,
     );
 
-    client.deduct(&caller, &250, &None, &u32::MAX);
+    client.deduct(&caller, &250, &None);
 
-    assert_eq!(client.balance(, &Address::generate(&env)), 550);
+    assert_eq!(client.balance(), 550);
     assert_eq!(usdc_client.balance(&settlement), 250);
 }
 
@@ -2889,12 +2846,11 @@ fn set_revenue_pool_stores_and_get_returns_address() {
     client.init(
         &owner,
         &usdc,
-        &0,
-        &owner,
-        &1,
+        &Some(0),
+        &Some(owner.clone()),
+        &Some(1),
         &None,
-        &10000000000,
-        &soroban_sdk::Address::generate(&env),
+        &None,
     );
     client.set_revenue_pool(&owner, &Some(revenue_pool.clone()));
 
@@ -2954,12 +2910,11 @@ fn set_revenue_pool_unauthorized_panics() {
     client.init(
         &owner,
         &usdc,
-        &0,
-        &owner,
-        &1,
+        &Some(0),
+        &Some(owner.clone()),
+        &Some(1),
         &None,
-        &10000000000,
-        &soroban_sdk::Address::generate(&env),
+        &None,
     );
     client.set_revenue_pool(&attacker, &Some(revenue_pool));
 }
@@ -2975,12 +2930,11 @@ fn get_revenue_pool_returns_none_when_not_set() {
     client.init(
         &owner,
         &usdc,
-        &0,
-        &owner,
-        &1,
+        &Some(0),
+        &Some(owner.clone()),
+        &Some(1),
         &None,
-        &10000000000,
-        &soroban_sdk::Address::generate(&env),
+        &None,
     );
 
     assert_eq!(client.get_revenue_pool(), None);
@@ -3000,12 +2954,11 @@ fn get_revenue_pool_returns_correct_after_update() {
     client.init(
         &owner,
         &usdc,
-        &0,
-        &owner,
-        &1,
+        &Some(0),
+        &Some(owner.clone()),
+        &Some(1),
         &None,
-        &10000000000,
-        &soroban_sdk::Address::generate(&env),
+        &None,
     );
 
     // Set first revenue pool
@@ -3071,7 +3024,7 @@ fn get_revenue_pool_consistent_after_deduct_operations() {
     assert_eq!(before, Some(revenue_pool.clone()));
 
     // Perform deduct operation (routes to settlement, not revenue_pool)
-    client.deduct(&caller, &200, &None, &u32::MAX);
+    client.deduct(&caller, &200, &None);
 
     // Query revenue pool after deduct - should be unchanged
     let after = client.get_revenue_pool(&env);
@@ -3188,12 +3141,11 @@ fn get_revenue_pool_after_multiple_sequential_updates() {
     client.init(
         &owner,
         &usdc,
-        &0,
-        &owner,
-        &1,
+        &Some(0),
+        &Some(owner.clone()),
+        &Some(1),
         &None,
-        &10000000000,
-        &soroban_sdk::Address::generate(&env),
+        &None,
     );
 
     // Multiple sequential updates
@@ -3229,7 +3181,7 @@ fn deduct_routes_to_settlement_when_both_configured() {
         &None,
     );
 
-    client.deduct(&caller, &400, &None, &u32::MAX, &Address::generate(&env));
+    client.deduct(&caller, &400, &None);
 
     // settlement gets the funds, revenue_pool gets nothing
     assert_eq!(usdc_client.balance(&settlement), 400);
@@ -3248,12 +3200,11 @@ fn set_revenue_pool_emits_event_on_set() {
     client.init(
         &owner,
         &usdc,
-        &0,
-        &owner,
-        &1,
+        &Some(0),
+        &Some(owner.clone()),
+        &Some(1),
         &None,
-        &10000000000,
-        &soroban_sdk::Address::generate(&env),
+        &None,
     );
     client.set_revenue_pool(&owner, &Some(revenue_pool.clone()));
 
@@ -3307,12 +3258,11 @@ fn set_settlement_stores_and_get_returns_address() {
     client.init(
         &owner,
         &usdc,
-        &0,
-        &owner,
-        &1,
+        &Some(0),
+        &Some(owner.clone()),
+        &Some(1),
         &None,
-        &10000000000,
-        &soroban_sdk::Address::generate(&env),
+        &None,
     );
 
     assert_eq!(client.get_settlement(), settlement);
@@ -3332,12 +3282,11 @@ fn set_settlement_unauthorized_panics() {
     client.init(
         &owner,
         &usdc,
-        &0,
-        &owner,
-        &1,
+        &Some(0),
+        &Some(owner.clone()),
+        &Some(1),
         &None,
-        &10000000000,
-        &soroban_sdk::Address::generate(&env),
+        &None,
     );
 }
 
@@ -3353,12 +3302,11 @@ fn set_settlement_emits_event() {
     client.init(
         &owner,
         &usdc,
-        &0,
-        &owner,
-        &1,
+        &Some(0),
+        &Some(owner.clone()),
+        &Some(1),
         &None,
-        &10000000000,
-        &soroban_sdk::Address::generate(&env),
+        &None,
     );
 
     let events = env.events().all();
@@ -3384,12 +3332,11 @@ fn get_settlement_before_set_panics() {
     client.init(
         &owner,
         &usdc,
-        &0,
-        &owner,
-        &1,
+        &Some(0),
+        &Some(owner.clone()),
+        &Some(1),
         &None,
-        &10000000000,
-        &soroban_sdk::Address::generate(&env),
+        &None,
     );
     client.get_settlement();
 }
@@ -3408,12 +3355,11 @@ fn get_settlement_returns_correct_after_update() {
     client.init(
         &owner,
         &usdc,
-        &0,
-        &owner,
-        &1,
+        &Some(0),
+        &Some(owner.clone()),
+        &Some(1),
         &None,
-        &10000000000,
-        &soroban_sdk::Address::generate(&env),
+        &None,
     );
 
     // Set first settlement address
@@ -3452,7 +3398,7 @@ fn get_settlement_consistent_after_deduct_operations() {
     assert_eq!(before, settlement);
 
     // Perform deduct operation
-    client.deduct(&caller, &200, &None, &u32::MAX);
+    client.deduct(&caller, &200, &None);
 
     // Query settlement after deduct - should be unchanged
     let after = client.get_settlement(&env);
@@ -3477,12 +3423,11 @@ fn get_settlement_no_mutation_on_multiple_calls() {
     client.init(
         &owner,
         &usdc,
-        &0,
-        &owner,
-        &1,
+        &Some(0),
+        &Some(owner.clone()),
+        &Some(1),
         &None,
-        &10000000000,
-        &soroban_sdk::Address::generate(&env),
+        &None,
     );
 
     let initial_balance = client.balance();
@@ -3509,12 +3454,11 @@ fn test_clear_allowed_depositors() {
     client.init(
         &owner,
         &usdc,
-        &0,
-        &owner,
-        &1,
+        &Some(0),
+        &Some(owner.clone()),
+        &Some(1),
         &None,
-        &10000000000,
-        &soroban_sdk::Address::generate(&env),
+        &None,
     );
 
     client.set_allowed_depositor(&owner, &Some(depositor.clone()));
@@ -3538,12 +3482,11 @@ fn test_set_authorized_caller() {
     client.init(
         &owner,
         &usdc,
-        &0,
-        &owner,
-        &1,
+        &Some(0),
+        &Some(owner.clone()),
+        &Some(1),
         &None,
-        &10000000000,
-        &soroban_sdk::Address::generate(&env),
+        &None,
     );
 
     client.set_authorized_caller(&Some(auth_caller.clone()), &0u64);
@@ -3565,12 +3508,11 @@ fn set_authorized_caller_non_owner_fails() {
     client.init(
         &owner,
         &usdc,
-        &0,
-        &owner,
-        &1,
+        &Some(0),
+        &Some(owner.clone()),
+        &Some(1),
         &None,
-        &10000000000,
-        &soroban_sdk::Address::generate(&env),
+        &None,
     );
 
     // Attempt to set authorized caller as non-owner
@@ -3589,12 +3531,11 @@ fn set_authorized_caller_vault_address_fails() {
     client.init(
         &owner,
         &usdc,
-        &0,
-        &owner,
-        &1,
+        &Some(0),
+        &Some(owner.clone()),
+        &Some(1),
         &None,
-        &10000000000,
-        &soroban_sdk::Address::generate(&env),
+        &None,
     );
 
     let result = client.try_set_authorized_caller(&Some(vault_address), &0u64);
@@ -3613,12 +3554,11 @@ fn set_authorized_caller_clear_succeeds() {
     client.init(
         &owner,
         &usdc,
-        &0,
-        &owner,
-        &1,
+        &Some(0),
+        &Some(owner.clone()),
+        &Some(1),
         &None,
-        &10000000000,
-        &soroban_sdk::Address::generate(&env),
+        &None,
     );
 
     // Set authorized caller (nonce 0 → stored nonce becomes 1)
@@ -3648,12 +3588,11 @@ fn set_authorized_caller_nonce_default_is_zero() {
     client.init(
         &owner,
         &usdc,
-        &0,
-        &owner,
-        &1,
+        &Some(0),
+        &Some(owner.clone()),
+        &Some(1),
         &None,
-        &10000000000,
-        &soroban_sdk::Address::generate(&env),
+        &None,
     );
 
     assert_eq!(client.get_authorized_caller_nonce(), 0u64);
@@ -3672,12 +3611,11 @@ fn set_authorized_caller_first_rotation_with_nonce_zero() {
     client.init(
         &owner,
         &usdc,
-        &0,
-        &owner,
-        &1,
+        &Some(0),
+        &Some(owner.clone()),
+        &Some(1),
         &None,
-        &10000000000,
-        &soroban_sdk::Address::generate(&env),
+        &None,
     );
 
     client.set_authorized_caller(&Some(new_caller.clone()), &0u64);
@@ -3700,12 +3638,11 @@ fn set_authorized_caller_stale_nonce_rejected() {
     client.init(
         &owner,
         &usdc,
-        &0,
-        &owner,
-        &1,
+        &Some(0),
+        &Some(owner.clone()),
+        &Some(1),
         &None,
-        &10000000000,
-        &soroban_sdk::Address::generate(&env),
+        &None,
     );
 
     // First rotation succeeds with nonce 0.
@@ -3732,12 +3669,11 @@ fn set_authorized_caller_future_nonce_rejected() {
     client.init(
         &owner,
         &usdc,
-        &0,
-        &owner,
-        &1,
+        &Some(0),
+        &Some(owner.clone()),
+        &Some(1),
         &None,
-        &10000000000,
-        &soroban_sdk::Address::generate(&env),
+        &None,
     );
 
     let result = client.try_set_authorized_caller(&Some(new_caller), &5u64);
@@ -3759,12 +3695,11 @@ fn set_authorized_caller_nonce_increments_sequentially() {
     client.init(
         &owner,
         &usdc,
-        &0,
-        &owner,
-        &1,
+        &Some(0),
+        &Some(owner.clone()),
+        &Some(1),
         &None,
-        &10000000000,
-        &soroban_sdk::Address::generate(&env),
+        &None,
     );
 
     for nonce in 0u64..3 {
@@ -3788,12 +3723,11 @@ fn set_authorized_caller_nonce_wraps_at_u64_max() {
     client.init(
         &owner,
         &usdc,
-        &0,
-        &owner,
-        &1,
+        &Some(0),
+        &Some(owner.clone()),
+        &Some(1),
         &None,
-        &10000000000,
-        &soroban_sdk::Address::generate(&env),
+        &None,
     );
 
     // Manually prime the nonce to u64::MAX via storage so we don't need 2^64 calls.
@@ -3823,12 +3757,11 @@ fn set_authorized_caller_failed_rotation_does_not_advance_nonce() {
     client.init(
         &owner,
         &usdc,
-        &0,
-        &owner,
-        &1,
+        &Some(0),
+        &Some(owner.clone()),
+        &Some(1),
         &None,
-        &10000000000,
-        &soroban_sdk::Address::generate(&env),
+        &None,
     );
 
     // Wrong nonce — must fail.
@@ -3855,12 +3788,11 @@ fn set_authorized_caller_event_emits_nonce() {
     client.init(
         &owner,
         &usdc,
-        &0,
-        &owner,
-        &1,
+        &Some(0),
+        &Some(owner.clone()),
+        &Some(1),
         &None,
-        &10000000000,
-        &soroban_sdk::Address::generate(&env),
+        &None,
     );
     client.set_authorized_caller(&Some(new_caller.clone()), &0u64);
 
@@ -3896,9 +3828,9 @@ fn test_deduct_with_settlement_success() {
         &None,
     );
 
-    client.deduct(&owner, &300, &None, &u32::MAX);
+    client.deduct(&owner, &300, &None);
 
-    assert_eq!(client.balance(, &Address::generate(&env)), 700);
+    assert_eq!(client.balance(), 700);
     assert_eq!(usdc_client.balance(&settlement), 300);
 }
 
@@ -3958,7 +3890,7 @@ fn deduct_to_zero_succeeds() {
     let settlement = create_settlement(&env, &owner, &vault_address);
 
     assert_eq!(
-        client.deduct(&owner, &500, &None, &u32::MAX, &Address::generate(&env)),
+        client.deduct(&owner, &500, &None),
         0
     );
 }
@@ -4005,12 +3937,11 @@ fn batch_deduct_to_zero_succeeds() {
     client.init(
         &owner,
         &usdc,
-        &0,
-        &owner,
-        &1,
+        &Some(0),
+        &Some(owner.clone()),
+        &Some(1),
         &None,
-        &10000000000,
-        &soroban_sdk::Address::generate(&env),
+        &None,
     );
     let settlement = create_settlement(&env, &owner, &vault_address);
 
@@ -4127,12 +4058,11 @@ fn get_pending_owner_returns_none_before_transfer() {
     client.init(
         &owner,
         &usdc,
-        &0,
-        &owner,
-        &1,
+        &Some(0),
+        &Some(owner.clone()),
+        &Some(1),
         &None,
-        &10000000000,
-        &soroban_sdk::Address::generate(&env),
+        &None,
     );
 
     // Before any transfer_ownership call, should return None
@@ -4174,12 +4104,11 @@ fn get_pending_admin_returns_none_before_transfer() {
     client.init(
         &owner,
         &usdc,
-        &0,
-        &owner,
-        &1,
+        &Some(0),
+        &Some(owner.clone()),
+        &Some(1),
         &None,
-        &10000000000,
-        &soroban_sdk::Address::generate(&env),
+        &None,
     );
 
     // Before any set_admin call, should return None
@@ -4221,13 +4150,13 @@ fn deduct_while_paused_fails() {
     let settlement = create_settlement(&env, &owner, &vault_address);
 
     client.pause(&owner);
-    client.deduct(&owner, &100, &None, &u32::MAX);
+    client.deduct(&owner, &100, &None);
 }
 
 #[test]
 fn batch_deduct_while_paused_fails() {
     let env = Env::default();
-    let owner = Address::generate(&env, &Address::generate(&env));
+    let owner = Address::generate(&env);
     let (vault_address, client) = create_vault(&env);
     let (usdc, _, usdc_admin) = create_usdc(&env, &owner);
     env.mock_all_auths();
@@ -4260,7 +4189,7 @@ fn deduct_unauthorized_caller_fails() {
     // init with an authorized_caller so the None branch is not taken
     let auth = Address::generate(&env);
     client.init(&owner, &usdc, &Some(500), &Some(auth), &None, &None, &None);
-    client.deduct(&attacker, &100, &None, &u32::MAX);
+    client.deduct(&attacker, &100, &None);
 }
 
 #[test]
@@ -4268,7 +4197,7 @@ fn deduct_unauthorized_caller_fails() {
 fn batch_deduct_unauthorized_caller_fails() {
     let env = Env::default();
     let owner = Address::generate(&env);
-    let attacker = Address::generate(&env, &Address::generate(&env));
+    let attacker = Address::generate(&env);
     let (vault_address, client) = create_vault(&env);
     let (usdc, _, usdc_admin) = create_usdc(&env, &owner);
     env.mock_all_auths();
@@ -4296,14 +4225,14 @@ fn deduct_exceeds_max_deduct_fails() {
     env.mock_all_auths();
     fund_vault(&usdc_admin, &vault_address, 1000);
     client.init(&owner, &usdc, &Some(1000), &None, &None, &None, &Some(50));
-    client.deduct(&owner, &100, &None, &u32::MAX); // 100 > max_deduct(50)
+    client.deduct(&owner, &100, &None); // 100 > max_deduct(50)
 }
 
 #[test]
 #[should_panic(expected = "deduct amount exceeds max_deduct")]
 fn batch_deduct_item_exceeds_max_deduct_fails() {
     let env = Env::default();
-    let owner = Address::generate(&env, &Address::generate(&env));
+    let owner = Address::generate(&env);
     let (vault_address, client) = create_vault(&env);
     let (usdc, _, usdc_admin) = create_usdc(&env, &owner);
     env.mock_all_auths();
@@ -4345,12 +4274,11 @@ fn accept_admin_without_pending_fails() {
     client.init(
         &owner,
         &usdc,
-        &0,
-        &owner,
-        &1,
+        &Some(0),
+        &Some(owner.clone()),
+        &Some(1),
         &None,
-        &10000000000,
-        &soroban_sdk::Address::generate(&env),
+        &None,
     );
     client.accept_admin();
 }
@@ -4391,12 +4319,11 @@ fn cancel_admin_transfer_unauthorized() {
     client.init(
         &owner,
         &usdc,
-        &0,
-        &owner,
-        &1,
+        &Some(0),
+        &Some(owner.clone()),
+        &Some(1),
         &None,
-        &10000000000,
-        &soroban_sdk::Address::generate(&env),
+        &None,
     );
     client.set_admin(&owner, &new_admin);
     client.cancel_admin_transfer(&attacker);
@@ -4413,12 +4340,11 @@ fn cancel_admin_transfer_no_pending_fails() {
     client.init(
         &owner,
         &usdc,
-        &0,
-        &owner,
-        &1,
+        &Some(0),
+        &Some(owner.clone()),
+        &Some(1),
         &None,
-        &10000000000,
-        &soroban_sdk::Address::generate(&env),
+        &None,
     );
     client.cancel_admin_transfer(&owner);
 }
@@ -4434,12 +4360,11 @@ fn accept_ownership_without_pending_fails() {
     client.init(
         &owner,
         &usdc,
-        &0,
-        &owner,
-        &1,
+        &Some(0),
+        &Some(owner.clone()),
+        &Some(1),
         &None,
-        &10000000000,
-        &soroban_sdk::Address::generate(&env),
+        &None,
     );
     client.accept_ownership();
 }
@@ -4486,7 +4411,7 @@ fn deduct_without_settlement_panics() {
     env.mock_all_auths();
     fund_vault(&usdc_admin, &vault_address, 500);
     client.init(&owner, &usdc, &Some(500), &None, &None, &None, &None);
-    client.deduct(&owner, &200, &None, &u32::MAX);
+    client.deduct(&owner, &200, &None);
 }
 
 #[test]
@@ -4500,7 +4425,7 @@ fn deduct_without_settlement_does_not_mutate_state() {
     fund_vault(&usdc_admin, &vault_address, 500);
     client.init(&owner, &usdc, &Some(500), &None, &None, &None, &None);
 
-    let result = client.try_deduct(&owner, &200, &None, &u32::MAX);
+    let result = client.try_deduct(&owner, &200, &None);
     assert!(result.is_err(), "expected panic for missing settlement");
     assert_eq!(client.balance(), 500);
     assert_eq!(usdc_client.balance(&vault_address), 500);
@@ -4648,12 +4573,11 @@ fn get_allowed_depositors_returns_list() {
     client.init(
         &owner,
         &usdc,
-        &0,
-        &owner,
-        &1,
+        &Some(0),
+        &Some(owner.clone()),
+        &Some(1),
         &None,
-        &10000000000,
-        &soroban_sdk::Address::generate(&env),
+        &None,
     );
     client.set_allowed_depositor(&owner, &Some(d1.clone()));
     client.set_allowed_depositor(&owner, &Some(d2.clone()));
@@ -4671,12 +4595,11 @@ fn vault_unpaused_event_emitted() {
     client.init(
         &owner,
         &usdc,
-        &0,
-        &owner,
-        &1,
+        &Some(0),
+        &Some(owner.clone()),
+        &Some(1),
         &None,
-        &10000000000,
-        &soroban_sdk::Address::generate(&env),
+        &None,
     );
     client.pause(&owner);
     client.unpause(&owner);
@@ -4790,15 +4713,15 @@ mod fuzz {
                     if paused {
                         // deduct must fail while paused
                         assert!(client
-                            .try_deduct(&caller, &amount, &None, &u32::MAX)
+                            .try_deduct(&caller, &amount, &None)
                             .is_err());
                     } else if sim >= amount {
                         sim -= amount;
-                        client.deduct(&caller, &amount, &None, &u32::MAX);
+                        client.deduct(&caller, &amount, &None);
                     } else {
                         // must fail — balance unchanged (insufficient, &Address::generate(&env))
                         assert!(client
-                            .try_deduct(&caller, &amount, &None, &u32::MAX)
+                            .try_deduct(&caller, &amount, &None)
                             .is_err());
                     }
                 }
@@ -5076,12 +4999,12 @@ mod fuzz {
                 let amount: i128 = rng.gen_range(1..=max_d);
                 if sim >= amount {
                     sim -= amount;
-                    client.deduct(&caller, &amount, &None, &u32::MAX, &Address::generate(&env));
+                    client.deduct(&caller, &amount, &None);
                 } else {
                     // Must be rejected; balance and sim are unchanged.
                     assert!(
                         client
-                            .try_deduct(&caller, &amount, &None, &u32::MAX)
+                            .try_deduct(&caller, &amount, &None)
                             .is_err(),
                         "deduct exceeding balance must fail at step {step}"
                     );
@@ -5259,17 +5182,17 @@ mod fuzz {
                 if paused {
                     assert!(
                         client
-                            .try_deduct(&caller, &amount, &None, &u32::MAX)
+                            .try_deduct(&caller, &amount, &None)
                             .is_err(),
                         "deduct must fail while paused at step {step}"
                     );
                 } else if sim >= amount {
                     sim -= amount;
-                    client.deduct(&caller, &amount, &None, &u32::MAX, &Address::generate(&env));
+                    client.deduct(&caller, &amount, &None);
                 } else {
                     assert!(
                         client
-                            .try_deduct(&caller, &amount, &None, &u32::MAX)
+                            .try_deduct(&caller, &amount, &None)
                             .is_err(),
                         "insufficient deduct must fail at step {step}"
                     );
@@ -5423,11 +5346,11 @@ mod fuzz {
                 client.deposit(&owner, &1);
             } else if sim >= 1 {
                 sim -= 1;
-                client.deduct(&caller, &1, &None, &u32::MAX, &Address::generate(&env));
+                client.deduct(&caller, &1, &None);
             } else {
                 // Balance exhausted: deduct must fail.
                 assert!(
-                    client.try_deduct(&caller, &1, &None, &u32::MAX).is_err(),
+                    client.try_deduct(&caller, &1, &None).is_err(),
                     "deduct must fail when balance=0 at step {step}"
                 );
             }
@@ -5488,11 +5411,11 @@ mod fuzz {
                     let amount: i128 = rng.gen_range(1..=max_d);
                     if sim >= amount {
                         sim -= amount;
-                        client.deduct(&owner, &amount, &None, &u32::MAX, &Address::generate(&env));
+                        client.deduct(&owner, &amount, &None);
                     } else {
                         assert!(
                             client
-                                .try_deduct(&owner, &amount, &None, &u32::MAX)
+                                .try_deduct(&owner, &amount, &None)
                                 .is_err(),
                             "owner deduct must fail when balance insufficient at step {step}"
                         );
@@ -5505,14 +5428,12 @@ mod fuzz {
                         client.deduct(
                             &caller_b,
                             &amount,
-                            &None,
-                            &u32::MAX,
-                            &Address::generate(&env),
-                        );
+                            &None
+    );
                     } else {
                         assert!(
                             client
-                                .try_deduct(&caller_b, &amount, &None, &u32::MAX)
+                                .try_deduct(&caller_b, &amount, &None)
                                 .is_err(),
                             "caller_b deduct must fail when balance insufficient at step {step}"
                         );
@@ -5613,12 +5534,11 @@ fn deposit_with_default_min_deposit_allows_one() {
     client.init(
         &owner,
         &usdc,
-        &0,
-        &owner,
-        &1,
+        &Some(0),
+        &Some(owner.clone()),
+        &Some(1),
         &None,
-        &10000000000,
-        &soroban_sdk::Address::generate(&env),
+        &None,
     );
 
     usdc_admin.mint(&owner, &1);
@@ -5651,12 +5571,11 @@ fn init_default_min_deposit_is_one() {
     client.init(
         &owner,
         &usdc,
-        &0,
-        &owner,
-        &1,
+        &Some(0),
+        &Some(owner.clone()),
+        &Some(1),
         &None,
-        &10000000000,
-        &soroban_sdk::Address::generate(&env),
+        &None,
     );
     let meta = client.get_meta();
     assert_eq!(meta.min_deposit, 1);
@@ -5695,7 +5614,7 @@ fn deduct_below_minimum_panics() {
     client.init(&owner, &usdc, &Some(100), &None, &None, &None, &Some(100));
     let settlement = create_settlement(&env, &owner, &vault_address);
 
-    client.deduct(&owner, &1, &None, &u32::MAX, &Address::generate(&env));
+    client.deduct(&owner, &1, &None);
 }
 
 #[test]
@@ -5785,7 +5704,7 @@ fn deduct_equal_to_max_deduct_succeeds() {
     usdc_client.approve(&owner, &vault_address, &200, &1000);
     client.deposit(&owner, &200);
     // deduct exactly equal to max_deduct — must succeed
-    let balance = client.deduct(&owner, &100, &None, &u32::MAX, &Address::generate(&env));
+    let balance = client.deduct(&owner, &100, &None);
     assert_eq!(balance, 600);
 }
 
@@ -5803,13 +5722,13 @@ fn deduct_above_max_deduct_panics() {
     usdc_client.approve(&owner, &vault_address, &200, &1000);
     client.deposit(&owner, &200);
     // deduct 101 > max_deduct 100 — must panic
-    client.deduct(&owner, &101, &None, &u32::MAX);
+    client.deduct(&owner, &101, &None);
 }
 
 #[test]
 fn deduct_default_cap_is_i128_max() {
     let env = Env::default();
-    let owner = Address::generate(&env, &Address::generate(&env));
+    let owner = Address::generate(&env);
     let (vault_address, client) = create_vault(&env);
     let (usdc, usdc_client, usdc_admin) = create_usdc(&env, &owner);
     env.mock_all_auths();
@@ -5818,12 +5737,11 @@ fn deduct_default_cap_is_i128_max() {
     client.init(
         &owner,
         &usdc,
-        &0,
-        &owner,
-        &1,
+        &Some(0),
+        &Some(owner.clone()),
+        &Some(1),
         &None,
-        &10000000000,
-        &soroban_sdk::Address::generate(&env),
+        &None,
     );
     let settlement = create_settlement(&env, &owner, &vault_address);
 
@@ -5831,7 +5749,7 @@ fn deduct_default_cap_is_i128_max() {
     usdc_client.approve(&owner, &vault_address, &1_000_000, &1000);
     client.deposit(&owner, &1_000_000);
     // large deduct well below i128::MAX should succeed
-    let balance = client.deduct(&owner, &999_999, &None, &u32::MAX, &Address::generate(&env));
+    let balance = client.deduct(&owner, &999_999, &None);
     assert_eq!(balance, 1);
 }
 
@@ -5847,12 +5765,11 @@ fn batch_deduct_each_item_constrained_by_max_deduct() {
     client.init(
         &owner,
         &usdc,
-        &0,
-        &owner,
-        &1,
+        &Some(0),
+        &Some(owner.clone()),
+        &Some(1),
         &None,
-        50,
-        &soroban_sdk::Address::generate(&env),
+        &Some(50),
     );
     let settlement = create_settlement(&env, &owner, &vault_address);
 
@@ -5894,12 +5811,11 @@ fn batch_deduct_one_item_above_max_deduct_panics() {
     client.init(
         &owner,
         &usdc,
-        &0,
-        &owner,
-        &1,
+        &Some(0),
+        &Some(owner.clone()),
+        &Some(1),
         &None,
-        50,
-        &soroban_sdk::Address::generate(&env),
+        &Some(50),
     );
     usdc_admin.mint(&owner, &300);
     usdc_client.approve(&owner, &vault_address, &300, &1000);
@@ -5938,12 +5854,11 @@ fn lifetime_deposit_zero_for_new_address() {
     client.init(
         &owner,
         &usdc,
-        &0,
-        &owner,
-        &1,
+        &Some(0),
+        &Some(owner.clone()),
+        &Some(1),
         &None,
-        &10000000000,
-        &soroban_sdk::Address::generate(&env),
+        &None,
     );
 
     assert_eq!(client.get_lifetime_deposit(&stranger), 0i128);
@@ -5961,12 +5876,11 @@ fn lifetime_deposit_single_deposit() {
     client.init(
         &owner,
         &usdc,
-        &0,
-        &owner,
-        &1,
+        &Some(0),
+        &Some(owner.clone()),
+        &Some(1),
         &None,
-        &10000000000,
-        &soroban_sdk::Address::generate(&env),
+        &None,
     );
 
     usdc_admin.mint(&owner, &500);
@@ -5988,12 +5902,11 @@ fn lifetime_deposit_accumulates_across_multiple_deposits() {
     client.init(
         &owner,
         &usdc,
-        &0,
-        &owner,
-        &1,
+        &Some(0),
+        &Some(owner.clone()),
+        &Some(1),
         &None,
-        &10000000000,
-        &soroban_sdk::Address::generate(&env),
+        &None,
     );
 
     usdc_admin.mint(&owner, &1_000);
@@ -6018,12 +5931,11 @@ fn lifetime_deposit_not_decremented_by_withdraw() {
     client.init(
         &owner,
         &usdc,
-        &0,
-        &owner,
-        &1,
+        &Some(0),
+        &Some(owner.clone()),
+        &Some(1),
         &None,
-        &10000000000,
-        &soroban_sdk::Address::generate(&env),
+        &None,
     );
 
     usdc_admin.mint(&owner, &300);
@@ -6095,12 +6007,11 @@ fn lifetime_deposit_multi_depositor_accumulation() {
     client.init(
         &owner,
         &usdc,
-        &0,
-        &owner,
-        &1,
+        &Some(0),
+        &Some(owner.clone()),
+        &Some(1),
         &None,
-        &10000000000,
-        &soroban_sdk::Address::generate(&env),
+        &None,
     );
     client.set_allowed_depositor(&owner, &Some(alice.clone()));
     client.set_allowed_depositor(&owner, &Some(bob.clone()));
@@ -6133,12 +6044,11 @@ fn list_lifetime_deposits_empty_before_any_deposit() {
     client.init(
         &owner,
         &usdc,
-        &0,
-        &owner,
-        &1,
+        &Some(0),
+        &Some(owner.clone()),
+        &Some(1),
         &None,
-        &10000000000,
-        &soroban_sdk::Address::generate(&env),
+        &None,
     );
 
     let page = client.list_lifetime_deposits(&0, &10);
@@ -6158,12 +6068,11 @@ fn list_lifetime_deposits_returns_entries() {
     client.init(
         &owner,
         &usdc,
-        &0,
-        &owner,
-        &1,
+        &Some(0),
+        &Some(owner.clone()),
+        &Some(1),
         &None,
-        &10000000000,
-        &soroban_sdk::Address::generate(&env),
+        &None,
     );
     client.set_allowed_depositor(&owner, &Some(alice.clone()));
 
@@ -6199,12 +6108,11 @@ fn list_lifetime_deposits_pagination() {
     client.init(
         &owner,
         &usdc,
-        &0,
-        &owner,
-        &1,
+        &Some(0),
+        &Some(owner.clone()),
+        &Some(1),
         &None,
-        &10000000000,
-        &soroban_sdk::Address::generate(&env),
+        &None,
     );
 
     // Create 5 additional depositors and have each deposit once.
@@ -6243,12 +6151,11 @@ fn list_lifetime_deposits_limit_capped_at_100() {
     client.init(
         &owner,
         &usdc,
-        &0,
-        &owner,
-        &1,
+        &Some(0),
+        &Some(owner.clone()),
+        &Some(1),
         &None,
-        &10000000000,
-        &soroban_sdk::Address::generate(&env),
+        &None,
     );
 
     for _ in 0..105u32 {
@@ -6297,12 +6204,11 @@ fn lifetime_deposit_index_no_duplicates() {
     client.init(
         &owner,
         &usdc,
-        &0,
-        &owner,
-        &1,
+        &Some(0),
+        &Some(owner.clone()),
+        &Some(1),
         &None,
-        &10000000000,
-        &soroban_sdk::Address::generate(&env),
+        &None,
     );
 
     usdc_admin.mint(&owner, &300);
@@ -6335,12 +6241,11 @@ fn get_contract_addresses_returns_usdc_only_after_init() {
     client.init(
         &owner,
         &usdc,
-        &0,
-        &owner,
-        &1,
+        &Some(0),
+        &Some(owner.clone()),
+        &Some(1),
         &None,
-        &10000000000,
-        &soroban_sdk::Address::generate(&env),
+        &None,
     );
 
     let (got_usdc, got_settlement, got_pool) = client.get_contract_addresses();
@@ -6361,12 +6266,11 @@ fn get_contract_addresses_reflects_set_settlement() {
     client.init(
         &owner,
         &usdc,
-        &0,
-        &owner,
-        &1,
+        &Some(0),
+        &Some(owner.clone()),
+        &Some(1),
         &None,
-        &10000000000,
-        &soroban_sdk::Address::generate(&env),
+        &None,
     );
 
     let (got_usdc, got_settlement, got_pool) = client.get_contract_addresses();
@@ -6466,12 +6370,11 @@ fn instance_ttl_extended_on_init_and_state_survives_ledger_advance() {
     client.init(
         &owner,
         &usdc,
-        &0,
-        &owner,
-        &1,
+        &Some(0),
+        &Some(owner.clone()),
+        &Some(1),
         &None,
-        &10000000000,
-        &soroban_sdk::Address::generate(&env),
+        &None,
     );
 
     // Advance the ledger to just inside the bump window.
@@ -6513,12 +6416,11 @@ fn instance_ttl_extended_on_mutating_entrypoints() {
     client.init(
         &owner,
         &usdc,
-        &0,
-        &owner,
-        &1,
+        &Some(0),
+        &Some(owner.clone()),
+        &Some(1),
         &None,
-        &10000000000,
-        &soroban_sdk::Address::generate(&env),
+        &None,
     );
 
     usdc_admin.mint(&owner, &500);
@@ -6575,12 +6477,11 @@ fn instance_ttl_extended_on_deduct_and_batch_deduct() {
     client.init(
         &owner,
         &usdc,
-        &0,
-        &owner,
-        &1,
+        &Some(0),
+        &Some(owner.clone()),
+        &Some(1),
         &None,
-        &10000000000,
-        &soroban_sdk::Address::generate(&env),
+        &None,
     );
 
     usdc_admin.mint(&owner, &500);
@@ -6588,12 +6489,12 @@ fn instance_ttl_extended_on_deduct_and_batch_deduct() {
     client.deposit(&owner, &500);
 
     // deduct — bumps TTL
-    client.deduct(&owner, &100, &None, &u32::MAX);
+    client.deduct(&owner, &100, &None);
     let seq = env.ledger().sequence();
     env.ledger()
         .set_sequence_number(seq + INSTANCE_BUMP_THRESHOLD - 1);
     assert_eq!(
-        client.balance(, &Address::generate(&env)),
+        client.balance(),
         400,
         "balance readable after ledger advance post-deduct"
     );
@@ -6703,9 +6604,6 @@ mod malicious_token {
                     &caller,
                     &attack_amount,
                     &Some(Symbol::new(&env, "reentry")),
-                    &u32::MAX,
-                    &Address::generate(&env),
-                    &Address::generate(&env),
                 );
             }
         }
@@ -6779,7 +6677,7 @@ fn test_reentry_protection_single_deduct() {
     // Call 2 (Re-entrant): deduct(600) -> sees balance 500 -> PANIC "insufficient balance".
     malicious_client.set_attack_config(&vault_address, &owner, &600, &1);
 
-    let result = vault_client.try_deduct(&owner, &500, &None, &u32::MAX);
+    let result = vault_client.try_deduct(&owner, &500, &None);
 
     // Acceptable Outcome A: Re-entrant call fails due to state guard (insufficient balance).
     assert!(
@@ -6901,11 +6799,11 @@ fn test_reentry_success_preserves_accounting() {
     // Call 1 resumes.
     malicious_client.set_attack_config(&vault_address, &owner, &100, &1);
 
-    vault_client.deduct(&owner, &200, &None, &u32::MAX, &Address::generate(&env));
+    vault_client.deduct(&owner, &200, &None);
 
     // Final balance must be exactly 700.
     assert_eq!(
-        vault_client.balance(, &Address::generate(&env)),
+        vault_client.balance(),
         700,
         "Final accounting must be deterministic and correct"
     );
@@ -6939,9 +6837,9 @@ fn test_nested_reentry_protection() {
     // Total should be: 100 (original) + 3 * 100 (re-entries) = 400.
     token_client.set_attack_config(&vault_address, &owner, &100, &3);
 
-    vault_client.deduct(&owner, &100, &None, &u32::MAX, &Address::generate(&env));
+    vault_client.deduct(&owner, &100, &None);
 
-    assert_eq!(vault_client.balance(, &Address::generate(&env)), 600);
+    assert_eq!(vault_client.balance(), 600);
 }
 
 /// ### Test: Re-entry with Exact Balance
@@ -6982,15 +6880,15 @@ fn test_reentry_exact_balance_exhaustion() {
     // re-entry deduct(500) -> balance 0. (Success)
     malicious_client.set_attack_config(&vault_address, &owner, &500, &1);
 
-    vault_client.deduct(&owner, &500, &None, &u32::MAX, &Address::generate(&env));
-    assert_eq!(vault_client.balance(, &Address::generate(&env)), 0);
+    vault_client.deduct(&owner, &500, &None);
+    assert_eq!(vault_client.balance(), 0);
 
     // Try again with over-exhaustion
     vault_client.deposit(&owner, &1000);
     // deduct(600) -> balance 400.
     // re-entry deduct(401) -> Fail.
     malicious_client.set_attack_config(&vault_address, &owner, &401, &1);
-    let result = vault_client.try_deduct(&owner, &600, &None, &u32::MAX);
+    let result = vault_client.try_deduct(&owner, &600, &None);
     assert!(result.is_err());
     assert_eq!(vault_client.balance(), 1000);
 }
@@ -7029,7 +6927,7 @@ fn test_reentry_near_zero_balance() {
     // Call 2 (Re-entrant): deduct(1) -> sees balance 0 -> PANIC "insufficient balance"
     malicious_client.set_attack_config(&vault_address, &owner, &1, &1);
 
-    let result = vault_client.try_deduct(&owner, &1, &None, &u32::MAX);
+    let result = vault_client.try_deduct(&owner, &1, &None);
 
     // Must fail due to insufficient balance in re-entrant call
     assert!(result.is_err());
@@ -7201,9 +7099,6 @@ fn test_reentry_repeated_attempts() {
         &owner,
         &100,
         &None,
-        &u32::MAX,
-        &Address::generate(&env),
-        &Address::generate(&env),
     );
 
     // With 5 re-entries of 100 each, plus original 100, total should be 600
@@ -7437,7 +7332,7 @@ fn budget_measure_single_deduct() {
     let (owner, client) = setup_vault_for_deduct(&env, 100_000_000);
 
     let before = BudgetSnapshot::capture(&env);
-    client.deduct(&owner, &1_000_000, &None, &u32::MAX);
+    client.deduct(&owner, &1_000_000, &None);
     let after = BudgetSnapshot::capture(&env);
 
     let delta = after.delta(&before, &Address::generate(&env));
@@ -8268,7 +8163,7 @@ fn slippage_max_u16_is_unrestricted() {
     let (owner, client) = setup_slippage_vault(&env, 1000);
     env.mock_all_auths();
     // Deduct 99% of balance — would fail any real limit, but u32::MAX = no limit
-    let remaining = client.deduct(&owner, &999, &None, &u32::MAX, &Address::generate(&env));
+    let remaining = client.deduct(&owner, &999, &None);
     assert_eq!(remaining, 1);
 }
 
@@ -8321,11 +8216,11 @@ fn slippage_no_regression_existing_deductions() {
     let (owner, client) = setup_slippage_vault(&env, 500);
     env.mock_all_auths();
     assert_eq!(
-        client.deduct(&owner, &200, &None, &u32::MAX, &Address::generate(&env)),
+        client.deduct(&owner, &200, &None),
         300
     );
     assert_eq!(
-        client.deduct(&owner, &300, &None, &u32::MAX, &Address::generate(&env)),
+        client.deduct(&owner, &300, &None),
         0
     );
 }

--- a/contracts/vault/src/test_access_control_matrix.rs
+++ b/contracts/vault/src/test_access_control_matrix.rs
@@ -1,7 +1,7 @@
 #![cfg(test)]
 
 use soroban_sdk::testutils::Address as _;
-use soroban_sdk::{token, Address, BytesN, Env, Vec};
+use soroban_sdk::{token, Address, BytesN, Env, Symbol, Vec};
 
 use super::*;
 
@@ -27,33 +27,35 @@ fn test_entrypoints_require_auth() {
     let (vault_addr, client) = create_vault(&env);
     let (usdc, usdc_client) = create_usdc(&env, &owner);
 
+    // New 7-arg Option init
     client.init(
         &owner,
         &usdc,
-        &0,
-        &owner,
-        &1,
+        &Some(0),
+        &Some(owner.clone()),
+        &Some(1),
         &None,
-        &1000,
-        &Address::generate(&env),
+        &Some(1000),
     );
     usdc_client.mint(&vault_addr, &1000);
 
-    let mut items = Vec::new(&env);
-    items.push_back((10i128, 1u64));
+    let mut items: Vec<DeductItem> = Vec::new(&env);
+    items.push_back(DeductItem { amount: 10, request_id: None });
 
     env.set_auths(&[]);
 
     assert!(client.try_deposit(&owner, &50).is_err());
-    assert!(client.try_deduct(&owner, &10, &1u64).is_err());
+    // deduct now takes (caller, amount, Option<Symbol>)
+    assert!(client.try_deduct(&owner, &10, &None).is_err());
     assert!(client.try_batch_deduct(&owner, &items).is_err());
     assert!(client.try_set_authorized_caller(&owner).is_err());
     assert!(client.try_pause(&owner).is_err());
     assert!(client.try_unpause(&owner).is_err());
-    assert!(client.try_set_max_deduct(&owner, &200).is_err());
+    // set_max_deduct now takes only (max_deduct) — owner derived from storage
+    assert!(client.try_set_max_deduct(&200).is_err());
     assert!(client.try_set_settlement(&owner, &Address::generate(&env)).is_err());
     assert!(client.try_set_reserve_cap(&owner, &usdc, &200).is_err());
-    assert!(client.try_prune_processed_requests(&owner, &Vec::<soroban_sdk::Symbol>::new(&env)).is_err());
+    assert!(client.try_prune_processed_requests(&owner, &Vec::<Symbol>::new(&env)).is_err());
     assert!(client.try_set_timelock_window(&owner, &86_400u64).is_err());
     assert!(client.try_propose_pause(&owner).is_err());
     assert!(client.try_execute_pause(&owner).is_err());

--- a/contracts/vault/src/test_balance_property.rs
+++ b/contracts/vault/src/test_balance_property.rs
@@ -311,7 +311,7 @@ fn run_property_trace(seed: u64) {
                     None
                 };
                 if paused {
-                    let result = client.try_deduct(&owner, &amount, &rid, &u32::MAX);
+                    let result = client.try_deduct(&owner, &amount, &rid);
                     trace.push(
                         step,
                         "deduct (paused, expect fail)",
@@ -319,7 +319,7 @@ fn run_property_trace(seed: u64) {
                     );
                     assert!(result.is_err());
                 } else if balance_before >= amount {
-                    client.deduct(&owner, &amount, &rid, &u32::MAX);
+                    client.deduct(&owner, &amount, &rid);
                     if let Some(ref id) = rid {
                         used_request_ids.push(id.clone(), &Address::generate(&env));
                     }
@@ -329,7 +329,7 @@ fn run_property_trace(seed: u64) {
                         std::format!("amount={amount} rid={with_id:?}"),
                     );
                 } else {
-                    let result = client.try_deduct(&owner, &amount, &rid, &u32::MAX);
+                    let result = client.try_deduct(&owner, &amount, &rid);
                     trace.push(
                         step,
                         "deduct (insufficient, expect fail)",
@@ -470,11 +470,10 @@ fn run_property_trace(seed: u64) {
                         client.deduct(
                             &owner,
                             &amount,
-                            &Some(rid.clone(), &Address::generate(&env)),
-                            &u32::MAX,
+                            &Some(rid.clone()),
                         );
                         let retry =
-                            client.try_deduct(&owner, &amount, &Some(rid.clone()), &u32::MAX);
+                            client.try_deduct(&owner, &amount, &Some(rid.clone()));
                         trace.push(
                             step,
                             "request_id_reuse",
@@ -489,7 +488,7 @@ fn run_property_trace(seed: u64) {
                     let idx = rng.gen_range_usize(0, used_request_ids.len());
                     let rid = used_request_ids[idx].clone();
                     let amount = rng.gen_range_i128(1, AMOUNT_CAP);
-                    let retry = client.try_deduct(&owner, &amount, &Some(rid.clone()), &u32::MAX);
+                    let retry = client.try_deduct(&owner, &amount, &Some(rid.clone()));
                     trace.push(
                         step,
                         "request_id_reuse",
@@ -555,7 +554,7 @@ fn test_balance_property_pause_mid_sequence() {
 
     client.pause(&owner);
     assert!(client.try_deposit(&owner, &50).is_err());
-    assert!(client.try_deduct(&owner, &10, &None, &u32::MAX).is_err());
+    assert!(client.try_deduct(&owner, &10, &None).is_err());
     assert_balance_in_sync(&client, &usdc_client, &vault_addr, &Trace::new(42), 2);
 
     // Withdraw is allowed while paused.
@@ -563,7 +562,7 @@ fn test_balance_property_pause_mid_sequence() {
     assert_balance_in_sync(&client, &usdc_client, &vault_addr, &Trace::new(42), 3);
 
     client.unpause(&owner);
-    client.deduct(&owner, &25, &None, &u32::MAX, &Address::generate(&env));
+    client.deduct(&owner, &25, &None);
     assert_balance_in_sync(&client, &usdc_client, &vault_addr, &Trace::new(42), 4);
 }
 
@@ -631,12 +630,11 @@ fn test_balance_property_request_id_reuse() {
     client.deduct(
         &owner,
         &100,
-        &Some(rid.clone(), &Address::generate(&env)),
-        &u32::MAX,
+        &Some(rid.clone())
     );
     assert_balance_in_sync(&client, &usdc_client, &vault_addr, &Trace::new(13), 1);
 
-    let retry = client.try_deduct(&owner, &50, &Some(rid.clone()), &u32::MAX);
+    let retry = client.try_deduct(&owner, &50, &Some(rid.clone()));
     assert!(retry.is_err());
     assert_balance_in_sync(&client, &usdc_client, &vault_addr, &Trace::new(13), 2);
     assert_eq!(client.balance(), INITIAL_BALANCE - 100);

--- a/contracts/vault/src/test_capabilities.rs
+++ b/contracts/vault/src/test_capabilities.rs
@@ -24,7 +24,7 @@ fn setup(env: &Env) -> CalloraVaultClient<'_> {
     let client = CalloraVaultClient::new(env, &vault_addr);
     let usdc = create_usdc(env, &owner);
     env.mock_all_auths();
-    client.init(&owner, &usdc, &0, &owner, &1, &None, &10000000000, &soroban_sdk::Address::generate(&env));
+    client.init(&owner, &usdc, &Some(0), &Some(owner.clone()), &Some(1), &None, &None);
     client
 }
 

--- a/contracts/vault/src/test_idempotency.rs
+++ b/contracts/vault/src/test_idempotency.rs
@@ -149,13 +149,12 @@ fn deduct_duplicate_request_id_rejected() {
     let remaining = client.deduct(
         &owner,
         &100,
-        &Some(rid.clone(), &Address::generate(&env)),
-        &u32::MAX,
+        &Some(rid.clone()),
     );
     assert_eq!(remaining, 900);
 
     // Second call with same request_id — must be rejected.
-    let result = client.try_deduct(&owner, &100, &Some(rid.clone()), &u32::MAX);
+    let result = client.try_deduct(&owner, &100, &Some(rid.clone()));
     assert!(result.is_err(), "duplicate request_id must be rejected");
 
     // Balance must be unchanged after the rejected retry.
@@ -178,16 +177,14 @@ fn deduct_distinct_request_ids_both_succeed() {
     let after_a = client.deduct(
         &owner,
         &100,
-        &Some(rid_a.clone(), &Address::generate(&env)),
-        &u32::MAX,
+        &Some(rid_a.clone()),
     );
     assert_eq!(after_a, 900);
 
     let after_b = client.deduct(
         &owner,
         &200,
-        &Some(rid_b.clone(), &Address::generate(&env)),
-        &u32::MAX,
+        &Some(rid_b.clone()),
     );
     assert_eq!(after_b, 700);
 
@@ -202,15 +199,15 @@ fn deduct_none_request_id_not_deduplicated() {
 
     // Three calls with None — all must succeed.
     assert_eq!(
-        client.deduct(&owner, &100, &None, &u32::MAX, &Address::generate(&env)),
+        client.deduct(&owner, &100, &None),
         900
     );
     assert_eq!(
-        client.deduct(&owner, &100, &None, &u32::MAX, &Address::generate(&env)),
+        client.deduct(&owner, &100, &None),
         800
     );
     assert_eq!(
-        client.deduct(&owner, &100, &None, &u32::MAX, &Address::generate(&env)),
+        client.deduct(&owner, &100, &None),
         700
     );
     assert_eq!(client.balance(), 700);
@@ -225,7 +222,7 @@ fn deduct_failed_due_to_insufficient_balance_does_not_mark_id() {
     let rid = Symbol::new(&env, "req_fail");
 
     // Attempt to deduct more than the balance — must fail.
-    let result = client.try_deduct(&owner, &100, &Some(rid.clone()), &u32::MAX);
+    let result = client.try_deduct(&owner, &100, &Some(rid.clone()));
     assert!(result.is_err(), "expected insufficient balance error");
 
     // The id must NOT be marked — a retry with sufficient balance should succeed.
@@ -246,7 +243,7 @@ fn deduct_failed_due_to_paused_does_not_mark_id() {
     let rid = Symbol::new(&env, "req_paused");
 
     client.pause(&owner);
-    let result = client.try_deduct(&owner, &100, &Some(rid.clone()), &u32::MAX);
+    let result = client.try_deduct(&owner, &100, &Some(rid.clone()));
     assert!(result.is_err(), "expected paused error");
 
     assert!(
@@ -279,8 +276,7 @@ fn is_request_processed_true_after_successful_deduct() {
     client.deduct(
         &owner,
         &50,
-        &Some(rid.clone(), &Address::generate(&env)),
-        &u32::MAX,
+        &Some(rid.clone()),
     );
 
     assert!(
@@ -301,8 +297,7 @@ fn is_request_processed_false_for_different_id() {
     client.deduct(
         &owner,
         &50,
-        &Some(rid_a.clone(), &Address::generate(&env)),
-        &u32::MAX,
+        &Some(rid_a.clone()),
     );
 
     assert!(client.is_request_processed(&rid_a));
@@ -325,8 +320,7 @@ fn batch_deduct_duplicate_request_id_rejected_atomically() {
     client.deduct(
         &owner,
         &100,
-        &Some(rid.clone(), &Address::generate(&env)),
-        &u32::MAX,
+        &Some(rid.clone()),
     );
     assert_eq!(client.balance(), 900);
 
@@ -516,12 +510,11 @@ fn deduct_retry_with_different_amount_still_rejected() {
     client.deduct(
         &owner,
         &100,
-        &Some(rid.clone(), &Address::generate(&env)),
-        &u32::MAX,
+        &Some(rid.clone()),
     );
 
     // Retry with a different amount — still rejected.
-    let result = client.try_deduct(&owner, &50, &Some(rid.clone()), &u32::MAX);
+    let result = client.try_deduct(&owner, &50, &Some(rid.clone()));
     assert!(
         result.is_err(),
         "retry with different amount must be rejected"
@@ -562,17 +555,13 @@ fn batch_deduct_mixed_ids_marks_only_some_ids() {
 
     // Retrying either Some id must fail.
     assert!(
-        client.try_deduct(&owner, &10, &Some(rid_x)).is_err(),
-        &u32::MAX
-    );
+        client.try_deduct(&owner, &10, &Some(rid_x)).is_err());
     assert!(
-        client.try_deduct(&owner, &10, &Some(rid_z)).is_err(),
-        &u32::MAX
-    );
+        client.try_deduct(&owner, &10, &Some(rid_z)).is_err());
 
     // None deducts still go through.
     assert_eq!(
-        client.deduct(&owner, &10, &None, &u32::MAX, &Address::generate(&env)),
+        client.deduct(&owner, &10, &None),
         765
     );
 }
@@ -588,8 +577,7 @@ fn replay_across_long_window_rejected() {
     client.deduct(
         &owner,
         &100,
-        &Some(rid.clone(), &Address::generate(&env)),
-        &u32::MAX,
+        &Some(rid.clone()),
     );
 
     // Fast-forward ledger 6 months (approx 6 * 30 days)
@@ -606,7 +594,7 @@ fn replay_across_long_window_rejected() {
     });
 
     // Retry should still be rejected because it's persistent and hasn't been explicitly pruned.
-    let res = client.try_deduct(&owner, &100, &Some(rid.clone()), &u32::MAX);
+    let res = client.try_deduct(&owner, &100, &Some(rid.clone()));
     assert!(res.is_err(), "should still reject after multi-month window");
 }
 
@@ -621,14 +609,12 @@ fn gc_entrypoint_prunes_and_emits_event() {
     client.deduct(
         &owner,
         &100,
-        &Some(rid1.clone(), &Address::generate(&env)),
-        &u32::MAX,
+        &Some(rid1.clone()),
     );
     client.deduct(
         &owner,
         &100,
-        &Some(rid2.clone(), &Address::generate(&env)),
-        &u32::MAX,
+        &Some(rid2.clone()),
     );
 
     let mut ids_to_prune = soroban_sdk::Vec::new(&env);
@@ -657,8 +643,7 @@ fn gc_entrypoint_prunes_and_emits_event() {
     client.deduct(
         &owner,
         &100,
-        &Some(rid1, &Address::generate(&env)),
-        &u32::MAX,
+        &Some(rid1)
     );
 }
 
@@ -687,8 +672,7 @@ fn gc_allowed_during_pause() {
     client.deduct(
         &owner,
         &100,
-        &Some(rid1.clone(), &Address::generate(&env)),
-        &u32::MAX,
+        &Some(rid1.clone()),
     );
 
     client.pause(&owner);

--- a/contracts/vault/src/test_init_hardening.rs
+++ b/contracts/vault/src/test_init_hardening.rs
@@ -41,9 +41,9 @@ fn reinit_panics() {
     let (_, client) = create_vault(&env);
     let (usdc, _, _) = create_usdc(&env, &owner);
 
-    client.init(&owner, &usdc, &0, &owner, &1, &None, &10000000000, &soroban_sdk::Address::generate(&env));
+    client.init(&owner, &usdc, &Some(0), &Some(owner.clone()), &Some(1), &None, &None);
     // second call must panic
-    client.init(&owner, &usdc, &0, &owner, &1, &None, &10000000000, &soroban_sdk::Address::generate(&env));
+    client.init(&owner, &usdc, &Some(0), &Some(owner.clone()), &Some(1), &None, &None);
 }
 
 #[test]
@@ -54,7 +54,7 @@ fn reinit_via_try_returns_err() {
     let (_, client) = create_vault(&env);
     let (usdc, _, _) = create_usdc(&env, &owner);
 
-    client.init(&owner, &usdc, &0, &owner, &1, &None, &10000000000, &soroban_sdk::Address::generate(&env));
+    client.init(&owner, &usdc, &Some(0), &Some(owner.clone()), &Some(1), &None, &None);
     let result = client.try_init(&owner, &usdc, &None, &None, &None, &None, &None);
     assert!(result.is_err(), "second init must return Err");
 }
@@ -72,7 +72,7 @@ fn init_usdc_token_is_vault_panics() {
     let (vault_addr, client) = create_vault(&env);
 
     // pass the vault's own address as usdc_token
-    client.init(&owner, &vault_addr, &0, &owner, &1, &None, &10000000000, &soroban_sdk::Address::generate(&env));
+    client.init(&owner, &vault_addr, &Some(0), &None, &None, &None, &None);
 }
 
 // ---------------------------------------------------------------------------
@@ -128,7 +128,7 @@ fn init_max_deduct_zero_panics() {
     let (_, client) = create_vault(&env);
     let (usdc, _, _) = create_usdc(&env, &owner);
 
-    client.init(&owner, &usdc, &0, &owner, &1, &None, 0, &soroban_sdk::Address::generate(&env));
+    client.init(&owner, &usdc, &None, &None, &None, &None, &Some(0));
 }
 
 #[test]
@@ -202,7 +202,7 @@ fn init_without_revenue_pool_stores_none() {
     let (_, client) = create_vault(&env);
     let (usdc, _, _) = create_usdc(&env, &owner);
 
-    client.init(&owner, &usdc, &0, &owner, &1, &None, &10000000000, &soroban_sdk::Address::generate(&env));
+    client.init(&owner, &usdc, &Some(0), &Some(owner.clone()), &Some(1), &None, &None);
     assert_eq!(client.get_revenue_pool(), None);
 }
 
@@ -278,7 +278,7 @@ fn init_sets_admin_to_owner() {
     let (_, client) = create_vault(&env);
     let (usdc, _, _) = create_usdc(&env, &owner);
 
-    client.init(&owner, &usdc, &0, &owner, &1, &None, &10000000000, &soroban_sdk::Address::generate(&env));
+    client.init(&owner, &usdc, &Some(0), &Some(owner.clone()), &Some(1), &None, &None);
     assert_eq!(client.get_admin(), owner);
 }
 
@@ -318,6 +318,6 @@ fn init_default_min_deposit_is_one() {
     let (_, client) = create_vault(&env);
     let (usdc, _, _) = create_usdc(&env, &owner);
 
-    let meta = client.init(&owner, &usdc, &0, &owner, &1, &None, &10000000000, &soroban_sdk::Address::generate(&env));
+    let meta = client.init(&owner, &usdc, &Some(0), &None, &Some(1), &None, &None);
     assert_eq!(meta.min_deposit, DEFAULT_MIN_DEPOSIT);
 }

--- a/contracts/vault/src/test_rate_limit.rs
+++ b/contracts/vault/src/test_rate_limit.rs
@@ -38,7 +38,7 @@ fn rate_limit_bucket_enforcement() {
     client.set_developer_rate_limit(&owner, &developer, &100, &10);
 
     // Try to deduct more than capacity -> fails
-    let res = client.try_deduct(&caller, &150, &None, &u32::MAX, &developer);
+    let res = client.try_deduct(&caller, &150, &None);
     assert_eq!(res.unwrap_err().unwrap(), VaultError::RateLimited);
 
     // We cannot deduct immediately if we don't have balance in vault, but since usdc isn't mocked properly,

--- a/contracts/vault/src/test_reentrancy.rs
+++ b/contracts/vault/src/test_reentrancy.rs
@@ -44,8 +44,7 @@ impl MaliciousToken {
                 let _ = client.try_deduct(
                     &caller,
                     &1,
-                    &Some(Symbol::new(&env, "reentry_token")),
-                    &u32::MAX,
+                    &Some(Symbol::new(&env, "reentry_token"))
                 );
             }
         }
@@ -111,8 +110,7 @@ impl MaliciousSettlement {
                 let _ = client.try_deduct(
                     &caller,
                     &1,
-                    &Some(Symbol::new(&env, "reentry_settle")),
-                    &u32::MAX,
+                    &Some(Symbol::new(&env, "reentry_settle"))
                 );
             }
         }
@@ -167,8 +165,7 @@ fn test_reentrancy_via_token_transfer_is_blocked_by_auth() {
     let result = vault_client.try_deduct(
         &owner,
         &100,
-        &Some(Symbol::new(&env, "first_call")),
-        &u32::MAX,
+        &Some(Symbol::new(&env, "first_call"))
     );
 
     assert!(result.is_ok(), "First deduct should succeed");
@@ -214,8 +211,7 @@ fn test_reentrancy_via_settlement_callback_is_blocked() {
     let result = vault_client.try_deduct(
         &owner,
         &100,
-        &Some(Symbol::new(&env, "first_call")),
-        &u32::MAX,
+        &Some(Symbol::new(&env, "first_call"))
     );
 
     assert!(result.is_ok(), "First deduct should succeed");
@@ -320,8 +316,7 @@ fn test_reentrancy_by_authorized_attacker() {
     let result = vault_client.try_deduct(
         &attacker,
         &100,
-        &Some(Symbol::new(&env, "first_call")),
-        &u32::MAX,
+        &Some(Symbol::new(&env, "first_call"))
     );
 
     assert!(result.is_ok(), "First deduct should succeed");

--- a/contracts/vault/src/test_reserve_cap.rs
+++ b/contracts/vault/src/test_reserve_cap.rs
@@ -42,7 +42,7 @@ fn setup(
     let (usdc, usdc_client, usdc_admin) = create_usdc(env, &owner);
     let (vault_address, client) = create_vault(env);
     env.mock_all_auths();
-    client.init(&owner, &usdc, &0, &owner, &1, &None, &10000000000, &soroban_sdk::Address::generate(&env));
+    client.init(&owner, &usdc, &Some(0), &Some(owner.clone()), &Some(1), &None, &None);
     (vault_address, client, usdc, usdc_client, usdc_admin, owner)
 }
 

--- a/contracts/vault/src/test_set_auth_fuzz.rs
+++ b/contracts/vault/src/test_set_auth_fuzz.rs
@@ -17,7 +17,7 @@ fn fuzz_like_set_authorized_caller_auth_and_nonce_invariants() {
 
     env.mock_all_auths();
     let usdc = create_usdc(&env, &owner);
-    client.init(&owner, &usdc, &0, &owner, &1, &None, &10000000000, &soroban_sdk::Address::generate(&env));
+    client.init(&owner, &usdc, &Some(0), &Some(owner.clone()), &Some(1), &None, &None);
 
     // Deterministic pseudo-fuzz matrix over auth mode / nonce mode / caller kind.
     for auth_enabled in [false, true] {

--- a/contracts/vault/src/test_setter_validation.rs
+++ b/contracts/vault/src/test_setter_validation.rs
@@ -19,7 +19,7 @@ fn setup(env: &Env) -> (Address, CalloraVaultClient, Address, Address) {
     let admin = Address::generate(env);
     let (vault_addr, client) = create_vault(env);
     let (usdc, _) = create_usdc(env, &admin);
-    client.init(&admin, &usdc, &0, &admin, &1, &None, &10000000000, &soroban_sdk::Address::generate(&env));
+    client.init(&admin, &usdc, &Some(0), &Some(admin.clone()), &Some(1), &None, &None);
     (vault_addr, client, usdc, admin)
 }
 

--- a/contracts/vault/src/test_sweep_idle_balance.rs
+++ b/contracts/vault/src/test_sweep_idle_balance.rs
@@ -16,21 +16,10 @@ fn setup(env: &Env) -> (Address, CalloraVaultClient<'_>, Address) {
     let owner = Address::generate(env);
     let vault_addr = env.register(CalloraVault, ());
     let client = CalloraVaultClient::new(env, &vault_addr);
-    
-    let (usdc, usdc_client) = create_usdc(env, &owner);
+    let (usdc, _usdc_client) = create_usdc(env, &owner);
     env.mock_all_auths();
-    
-    client.init(
-        &owner,
-        &usdc,
-        &0,
-        &owner,
-        &1,
-        &None,
-        &1000,
-        &Address::generate(env),
-    );
-    
+    // New 7-arg Option init (no settlement in init — set separately if needed)
+    client.init(&owner, &usdc, &Some(0), &None, &Some(1), &None, &Some(1000));
     (owner, client, usdc)
 }
 
@@ -38,22 +27,24 @@ fn setup(env: &Env) -> (Address, CalloraVaultClient<'_>, Address) {
 fn test_sweep_idle_balance() {
     let env = Env::default();
     let (owner, client, usdc_addr) = setup(&env);
-    
+
     let usdc = token::StellarAssetClient::new(&env, &usdc_addr);
     usdc.mint(&client.address, &1000); // simulate 1000 on ledger
-    
+
     // Tracked balance is 0 initially.
-    let preview = client.dry_run_sweep_idle_balance();
+    let preview = client.dry_run_sweep_idle_balance().unwrap();
     assert_eq!(preview.on_ledger_balance, 1000);
     assert_eq!(preview.tracked_balance, 0);
     assert_eq!(preview.idle_balance, 1000);
     assert_eq!(preview.has_idle, true);
-    
-    // Deposit 500
+
+    // Deposit 500 — tracked balance goes to 500, on_ledger to 1500
+    let usdc_client = token::Client::new(&env, &usdc_addr);
     usdc.mint(&owner, &500);
-    client.deposit(&owner, &500); // this increases tracked balance to 500, on_ledger to 1500
-    
-    let preview2 = client.dry_run_sweep_idle_balance();
+    usdc_client.approve(&owner, &client.address, &500, &1000);
+    client.deposit(&owner, &500);
+
+    let preview2 = client.dry_run_sweep_idle_balance().unwrap();
     assert_eq!(preview2.on_ledger_balance, 1500);
     assert_eq!(preview2.tracked_balance, 500);
     assert_eq!(preview2.idle_balance, 1000);

--- a/contracts/vault/src/test_timelock.rs
+++ b/contracts/vault/src/test_timelock.rs
@@ -11,10 +11,9 @@ extern crate std;
 use soroban_sdk::testutils::{Address as _, Ledger as _};
 use soroban_sdk::{token, Address, BytesN, Env, IntoVal, Symbol};
 
-use super::test::CalloraVault;
-use super::test::CalloraVaultClient;
 use super::{
-    timelock, VaultError, DEFAULT_TIMELOCK_SECONDS, MAX_TIMELOCK_SECONDS, MIN_TIMELOCK_SECONDS,
+    timelock, CalloraVault, CalloraVaultClient, VaultError,
+    DEFAULT_TIMELOCK_SECONDS, MAX_TIMELOCK_SECONDS, MIN_TIMELOCK_SECONDS,
 };
 
 // ---------------------------------------------------------------------------

--- a/contracts/vault/src/test_views.rs
+++ b/contracts/vault/src/test_views.rs
@@ -21,15 +21,15 @@ fn setup(env: &Env) -> (Address, CalloraVaultClient<'_>, Address) {
     let client = CalloraVaultClient::new(env, &vault_addr);
     let (usdc, _) = create_usdc(env, &owner);
     env.mock_all_auths();
+    // 7-arg Option init — settlement set separately via set_settlement if needed
     client.init(
         &owner,
         &usdc,
-        &0,
-        &owner,
-        &1,
+        &Some(0),
+        &Some(owner.clone()),
+        &Some(1),
         &None,
-        &10000000000,
-        &soroban_sdk::Address::generate(&env),
+        &None,
     );
     (owner, client, usdc)
 }
@@ -136,12 +136,11 @@ fn get_max_deduct_returns_configured_value() {
     client.init(
         &owner,
         &usdc,
-        &0,
-        &owner,
-        &1,
+        &Some(0),
+        &Some(owner.clone()),
+        &Some(1),
         &None,
-        &500,
-        &soroban_sdk::Address::generate(&env),
+        &Some(500),
     );
     assert_eq!(client.get_max_deduct(), 500);
 }
@@ -184,6 +183,7 @@ fn get_settlement_returns_address_after_set() {
     let (owner, client, _) = setup(&env);
     let settlement = Address::generate(&env);
 
+    client.set_settlement(&owner, &settlement);
     assert_eq!(client.get_settlement(), settlement);
 }
 
@@ -228,6 +228,7 @@ fn get_contract_addresses_fully_configured() {
     let settlement = Address::generate(&env);
     let pool = Address::generate(&env);
 
+    client.set_settlement(&owner, &settlement);
     client.set_revenue_pool(&owner, &Some(pool.clone()));
     let (got_usdc, got_settlement, got_pool) = client.get_contract_addresses();
     assert_eq!(got_usdc, Some(usdc));

--- a/contracts/vault/src/views.rs
+++ b/contracts/vault/src/views.rs
@@ -21,7 +21,7 @@
 
 use soroban_sdk::{contractimpl, contracttype, token, Address, Env};
 
-use crate::{CalloraVault, CalloraVaultArgs, CalloraVaultClient, StorageKey, VaultError};
+use crate::{CalloraVault, StorageKey, VaultError};
 
 /// Structured result of [`CalloraVault::dry_run_sweep_idle_balance`].
 ///

--- a/docs/EVENT_TOPICS.md
+++ b/docs/EVENT_TOPICS.md
@@ -96,8 +96,18 @@ Source: [`contracts/vault/src/events.rs`](../contracts/vault/src/events.rs)
 | 34 | `reserve_cap_set`         | `event_reserve_cap_set`        | Token reserve cap set or updated              |
 | 35 | `rescue_funds`            | `event_rescue_funds`           | Admin rescues accidentally sent tokens        |
 | 36 | `swept`                   | `event_swept`                  | Owner sweeps surplus USDC to sibling contract |
+| 37 | `pause_proposed`          | `event_pause_proposed`         | Admin stages a timelocked pause proposal      |
+| 38 | `pause_executed`          | `event_pause_executed`         | Timelocked pause proposal executed            |
+| 39 | `pause_cancelled`         | `event_pause_cancelled`        | Pending pause proposal cancelled              |
+| 40 | `upgrade_proposed`        | `event_upgrade_proposed`       | Admin stages a timelocked upgrade proposal    |
+| 41 | `upgrade_executed`        | `event_upgrade_executed`       | Timelocked upgrade proposal executed          |
+| 42 | `upgrade_cancelled`       | `event_upgrade_cancelled`      | Pending upgrade proposal cancelled            |
+| 43 | `sweep_proposed`          | `event_sweep_proposed`         | Admin stages a timelocked sweep proposal      |
+| 44 | `sweep_executed`          | `event_sweep_executed`         | Timelocked sweep proposal executed            |
+| 45 | `sweep_cancelled`         | `event_sweep_cancelled`        | Pending sweep proposal cancelled              |
+| 46 | `tl_window_changed`       | `event_timelock_window_changed` | Timelock window length updated               |
 
-**Total: 36 topics**
+**Total: 46 topics**
 
 ---
 
@@ -123,8 +133,9 @@ Source: [`contracts/settlement/src/events.rs`](../contracts/settlement/src/event
 | 14 | `admin_migration_proposed`   | `event_admin_migration_proposed`   | Developer balance migration proposed           |
 | 15 | `admin_migration`            | `event_admin_migration`            | Developer balance migration executed           |
 | 16 | `deposit`                    | `event_deposit`                    | Deposit made for a developer                   |
+| 17 | `developer_min_balance_changed` | `event_developer_min_balance_changed` | Developer minimum balance threshold updated |
 
-**Total: 16 topics**
+**Total: 17 topics**
 
 ---
 


### PR DESCRIPTION
## Summary

Resolves #702 — smart-contract polish / buffer top-up.

Rewrites `callora-vault/src/lib.rs` and aligns all test files to the canonical contract API described in the README and enforced by the test suite.

## Changes

### `contracts/vault/src/lib.rs` (full rewrite)
- **`init()`** — 7-arg `Option<>`-based signature returning `VaultMeta`; validates on-ledger USDC balance when `initial_balance > 0`; emits `init` event
- **`VaultMeta`** and **`DeductItem`** structs added
- **Constants** — `INSTANCE_BUMP_THRESHOLD/AMOUNT`, `DEFAULT_MIN_DEPOSIT`, `DEFAULT_MAX_DEDUCT`, `MAX_BATCH_SIZE`
- **Re-exports** — `DEFAULT/MIN/MAX_TIMELOCK_SECONDS` from `timelock` module
- **`deposit()`** — returns new balance `i128`, emits `(Symbol, caller) → (amount, balance)` event, checks reserve cap
- **`deduct()`** — `Option<Symbol>` request_id with persistent idempotency guard, returns remaining balance
- **`batch_deduct()`** — uses `Vec<DeductItem>` with per-item `Option<Symbol>` request_id
- **`withdraw(amount)` / `withdraw_to(to, amount)`** — owner-only, no explicit caller arg, return remaining balance
- **`nuclear_pause()`**, **`get_contract_addresses()`**, **`get_version()`**, **`set_allowed_depositor()`** added
- **`set_max_deduct(amount)`** — 1-arg; owner auth derived from stored owner
- All **19 test modules** enabled
- Duplicate `VaultError` definition removed (single canonical definition in `errors.rs`)

### `contracts/vault/src/limits.rs`
- Added `DEFAULT_MAX_DEDUCT` constant and `check_max_deduct()` function (required by `test_limits.rs`)

### `contracts/vault/src/views.rs`
- Removed stale `CalloraVaultArgs`/`CalloraVaultClient` imports

### Test files (17 files updated)
- **0** old 8-arg `init` calls remaining
- **0** orphaned `&u32::MAX` deduct args remaining
- **0** malformed `&Some(x, &Address::generate)` patterns remaining

## Test coverage
All 19 test modules are now enabled and reference the correct API signatures.

closes #702