### PR TITLE
fix: min-amount enforcement — reject sub-unit transfers on propose_sweep

### DIFF
--- a/contracts/vault/STORAGE.md
+++ b/contracts/vault/STORAGE.md
@@ -132,7 +132,7 @@ pub struct VaultMeta {
 - `owner`: `Address` - The vault owner; immutable except via `transfer_ownership()`; always permitted to deposit; can set allowed depositors and manage metadata
 - `balance`: `i128` - Current vault balance in smallest USDC units; incremented by deposits, decremented by deducts/withdrawals
 - `authorized_caller`: `Option<Address>` - Optional address permitted to trigger `deduct()` and `batch_deduct()` operations; can be set via `set_authorized_caller()`
-- `min_deposit`: `i128` - Minimum required per deposit; configured at initialization; prevents dust deposits and rejects zero or sub-unit transfer requests on the deposit path
+- `min_deposit`: `i128` - Minimum required per deposit; configured at initialization; prevents dust deposits and rejects zero or sub-unit transfer requests on the deposit path. The same floor is reused as the per-call minimum for `deduct`/`batch_deduct` items and for `propose_sweep`, so every entrypoint that moves USDC out of or into the vault rejects sub-unit/dust amounts consistently (`propose_sweep` returns `VaultError::BelowMinTransferAmount` when `amount` is below this floor)
 
 ### DeductItem
 
@@ -379,6 +379,7 @@ Monitor storage-related events:
 | 1.1 | Renamed `StorageKey` → `DataKey`; added doc comments to all variants; removed stale `// Replaced by StorageKey enum variants` comment; updated STORAGE.md |
 | 1.2 | Added `StorageKey::ProcessedRequest(Symbol)` in **persistent storage** for `request_id` idempotency in `deduct` and `batch_deduct`. Added `VaultError::DuplicateRequestId` (code 28). Added `is_request_processed(request_id)` view. TTL: threshold ~7 days, bump to ~30 days. |
 | 1.3 | Added `StorageKey::LifetimeDeposit(Address)` (persistent, TTL ~1 year) and `StorageKey::LifetimeDepositorIndex` (instance) for per-depositor cumulative deposit tracking. Added `get_lifetime_deposit(addr)` and `list_lifetime_deposits(cursor, limit)` view functions. Page cap: 100. Overflow-protected via `checked_add`. |
+| 1.4 | `propose_sweep` now rejects sub-unit/dust amounts: `amount` must be `>= min_deposit`, in addition to the existing `amount > 0` check. Added `VaultError::BelowMinTransferAmount` (code 48). |
 
 ## Canonical Storage Keys
 

--- a/contracts/vault/src/errors.rs
+++ b/contracts/vault/src/errors.rs
@@ -45,6 +45,17 @@ use soroban_sdk::contracterror;
 /// | 35   | Slippage                       | Fee basis points exceeds caller limit                    |
 /// | 36   | RateLimited                    | Developer rate limit has been exceeded                   |
 /// | 37   | PausedState                    | Operation is rejected because the vault is paused        |
+/// | 38   | InvalidHotBps                  | Hot BPS must be between 1 and 10000                       |
+/// | 39   | InvalidRebalanceThreshold      | Rebalance threshold must be between 1 and 10000          |
+/// | 40   | ColdSignersEmpty               | Cold signer set cannot be empty                          |
+/// | 41   | InvalidColdThreshold           | Cold threshold must be between 1 and signer count        |
+/// | 42   | DuplicateColdSigner            | Duplicate address found in cold signer set               |
+/// | 43   | ExceedsReserveCap              | Deposit would exceed the configured reserve cap          |
+/// | 44   | ProposalNotFound               | No pending timelock proposal for the requested action    |
+/// | 45   | TimelockNotExpired             | Action attempted before the timelock window has elapsed  |
+/// | 46   | TimelockOverflow               | `proposed_at + window` overflowed `u64`                  |
+/// | 47   | InvalidTimelockWindow          | Proposed timelock window is outside the allowed bounds   |
+/// | 48   | BelowMinTransferAmount         | Amount is below the configured minimum transfer unit (rejects sub-unit/dust transfers) |
 #[contracterror]
 #[repr(u32)]
 #[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
@@ -135,4 +146,15 @@ pub enum VaultError {
     DuplicateColdSigner = 42,
     /// Deposit would exceed the configured reserve cap (code 43).
     ExceedsReserveCap = 43,
+    /// No pending timelock proposal for the requested action (code 44).
+    ProposalNotFound = 44,
+    /// Action attempted before the timelock window has elapsed (code 45).
+    TimelockNotExpired = 45,
+    /// `proposed_at + window` overflowed `u64` (code 46).
+    TimelockOverflow = 46,
+    /// Proposed timelock window is outside the allowed `MIN..=MAX` bounds (code 47).
+    InvalidTimelockWindow = 47,
+    /// Amount is below the vault's configured minimum transfer unit; rejects
+    /// sub-unit/dust transfers (code 48).
+    BelowMinTransferAmount = 48,
 }

--- a/contracts/vault/src/lib.rs
+++ b/contracts/vault/src/lib.rs
@@ -47,105 +47,18 @@
 /// for triggering a bump is `REQUEST_ID_BUMP_THRESHOLD`. Because they are now
 /// persistent, they do not silently archive. To prevent state bloat, an owner
 /// can explicitly prune old markers using `prune_processed_requests`.
-use soroban_sdk::{
-    contract, contractclient, contractimpl, contracttype, token, Address, BytesN, Env, String,
-    Symbol, Vec,
-};
+use soroban_sdk::{contract, contractimpl, contracttype, Address, BytesN, Env, Symbol, Vec};
 
 pub mod views;
 
 mod errors;
 pub use errors::VaultError;
 
-/// Typed error codes for the Callora Vault contract.
-///
-/// These error codes are returned instead of string panics to enable
-/// machine-readable error handling by integrators using @stellar/stellar-sdk.
-#[contracterror]
-#[repr(u32)]
-#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
-pub enum VaultError {
-    /// Vault has not been initialized yet (code 1).
-    NotInitialized = 1,
-    /// Vault has already been initialized (code 2).
-    AlreadyInitialized = 2,
-    /// Caller is not authorized for this operation (code 3).
-    Unauthorized = 3,
-    /// Vault is currently paused (code 4).
-    Paused = 4,
-    /// Insufficient balance for the requested operation (code 5).
-    InsufficientBalance = 5,
-    /// Amount must be positive (code 6).
-    AmountNotPositive = 6,
-    /// Deduct amount exceeds the configured maximum (code 7).
-    ExceedsMaxDeduct = 7,
-    /// Deposit amount is below the configured minimum (code 8).
-    BelowMinDeposit = 8,
-    /// Arithmetic overflow detected (code 9).
-    Overflow = 9,
-    /// Initial balance must be non-negative (code 10).
-    InitialBalanceNegative = 10,
-    /// Min deposit must be positive (code 11).
-    MinDepositNotPositive = 11,
-    /// Max deduct must be positive (code 12).
-    MaxDeductNotPositive = 12,
-    /// Min deposit cannot exceed max deduct (code 13).
-    MinDepositExceedsMaxDeduct = 13,
-    /// USDC token address cannot be the vault address (code 14).
-    UsdcTokenCannotBeVault = 14,
-    /// Revenue pool address cannot be the vault address (code 15).
-    RevenuePoolCannotBeVault = 15,
-    /// Authorized caller address cannot be the vault address (code 16).
-    AuthorizedCallerCannotBeVault = 16,
-    /// Initial balance exceeds on-ledger USDC balance (code 17).
-    InitialBalanceExceedsOnLedger = 17,
-    /// Vault is already paused (code 18).
-    AlreadyPaused = 18,
-    /// Vault is not paused (code 19).
-    NotPaused = 19,
-    /// Settlement address has not been configured (code 20).
-    SettlementNotSet = 20,
-    /// Batch deduct requires at least one item (code 21).
-    BatchEmpty = 21,
-    /// Batch size exceeds maximum allowed (code 22).
-    BatchTooLarge = 22,
-    /// New owner must be different from current owner (code 23).
-    NewOwnerSameAsCurrent = 23,
-    /// No ownership transfer is pending (code 24).
-    NoOwnershipTransferPending = 24,
-    /// No admin transfer is pending (code 25).
-    NoAdminTransferPending = 25,
-    /// Offering ID exceeds maximum length (code 26).
-    OfferingIdTooLong = 26,
-    /// Metadata exceeds maximum length (code 27).
-    MetadataTooLong = 27,
-    /// Price parsing error or non‑positive price (code 28).
-    PriceParseError = 28,
-    /// Duplicate request ID detected (code 29).
-    DuplicateRequestId = 29,
-    /// Offering ID is empty or contains invalid characters (code 30).
-    OfferingIdInvalid = 30,
-    /// Metadata string is empty or contains invalid characters (code 31).
-    MetadataInvalid = 31,
-    /// Supplied nonce does not match the stored authorized-caller rotation nonce (code 30).
-    StaleNonce = 32,
-    /// New revenue pool must be different from current revenue pool (code 33).
-    NewRevenuePoolSameAsCurrent = 33,
-    /// No revenue pool transfer is pending (code 34).
-    NoRevenuePoolTransferPending = 34,
-    /// Calculated fee in basis points exceeds the caller-supplied `max_fee_bps` limit (code 35).
-    Slippage = 35,
-    /// Rate limit exceeded for the developer (code 36).
-    RateLimited = 36,
-    /// No pending timelock proposal for the requested action (code 37).
-    ProposalNotFound = 37,
-    /// Action attempted before the timelock window has elapsed (code 38).
-    TimelockNotExpired = 38,
-    /// `proposed_at + window` overflowed `u64` (code 39).
-    TimelockOverflow = 39,
-    /// Proposed timelock window is outside the allowed `MIN..=MAX` bounds (code 40).
-    InvalidTimelockWindow = 40,
-}
+/// Threshold (in ledgers) at which instance-storage TTL is bumped; ~30 days
+/// assuming a 5-second Stellar mainnet ledger close time (17 280 ledgers/day).
+pub const INSTANCE_BUMP_THRESHOLD: u32 = 17_280 * 30;
+/// Amount (in ledgers) instance-storage TTL is extended to on bump; ~60 days.
+pub const INSTANCE_BUMP_AMOUNT: u32 = 17_280 * 60;
 
 #[contracttype]
 #[derive(Clone)]
@@ -881,8 +794,10 @@ impl CalloraVault {
         }
         env.storage().instance().set(&DataKey::Paused, &true);
         timelock::clear_pending_pause(&env);
-        env.events()
-            .publish((events::event_pause_executed(&env), caller), env.ledger().timestamp());
+        env.events().publish(
+            (events::event_pause_executed(&env), caller.clone()),
+            env.ledger().timestamp(),
+        );
         env.events()
             .publish((events::event_vault_paused(&env), caller), ());
         Ok(())
@@ -906,7 +821,7 @@ impl CalloraVault {
                 events::event_pause_cancelled(&env),
                 caller.clone(),
             ),
-            (existing.is_some()),
+            existing.is_some(),
         );
         Ok(())
     }
@@ -991,7 +906,7 @@ impl CalloraVault {
                 events::event_upgrade_cancelled(&env),
                 caller.clone(),
             ),
-            (existing.is_some()),
+            existing.is_some(),
         );
         Ok(())
     }
@@ -1002,9 +917,17 @@ impl CalloraVault {
     /// funds and emits the standard `distribute` event. Re-proposing
     /// replaces the recipient+amount **and restarts the timer**.
     ///
+    /// `amount` is checked against the vault's configured `min_deposit` floor,
+    /// the same per-call minimum enforced on `deposit`/`deduct`/`batch_deduct`.
+    /// This closes the one remaining value-moving path that previously had no
+    /// floor, so sub-unit/dust sweeps are rejected consistently everywhere the
+    /// vault moves USDC.
+    ///
     /// # Errors
     /// - `VaultError::Unauthorized` if caller is not admin.
     /// - `VaultError::AmountNotPositive` if `amount <= 0`.
+    /// - `VaultError::BelowMinTransferAmount` if `amount` is below the vault's
+    ///   configured minimum transfer unit (`min_deposit`).
     /// - `VaultError::TimelockOverflow` if `proposed_at + window` overflows.
     pub fn propose_sweep(
         env: Env,
@@ -1015,6 +938,14 @@ impl CalloraVault {
         Self::require_admin(&env, &caller)?;
         if amount <= 0 {
             return Err(VaultError::AmountNotPositive);
+        }
+        let min_amount: i128 = env
+            .storage()
+            .instance()
+            .get(&DataKey::MinDeposit)
+            .ok_or(VaultError::NotInitialized)?;
+        if amount < min_amount {
+            return Err(VaultError::BelowMinTransferAmount);
         }
         let proposed_at = env.ledger().timestamp();
         let window = timelock::get_timelock_window(&env);
@@ -1099,7 +1030,7 @@ impl CalloraVault {
                 events::event_sweep_cancelled(&env),
                 caller.clone(),
             ),
-            (existing.is_some()),
+            existing.is_some(),
         );
         Ok(())
     }
@@ -1184,6 +1115,7 @@ mod cold_storage;
 mod events;
 pub mod limits;
 pub mod rate_limit;
+pub mod timelock;
 
 // #[cfg(test)]
 // #[path = "../proofs/deduct.rs"]
@@ -1221,6 +1153,9 @@ mod test_sweep_idle_balance;
 
 #[cfg(test)]
 mod test_access_control_matrix;
+
+#[cfg(test)]
+mod test_min_amount;
 
 // #[cfg(test)]
 // mod test_gas_budget;

--- a/contracts/vault/src/test_min_amount.rs
+++ b/contracts/vault/src/test_min_amount.rs
@@ -1,0 +1,124 @@
+//! Focused tests for per-call minimum-amount enforcement on `propose_sweep`.
+//!
+//! `deposit`, `deduct`, and `batch_deduct` already reject amounts below the
+//! vault's configured `min_deposit` floor. `propose_sweep` previously only
+//! rejected non-positive amounts, leaving it as the one value-moving
+//! entrypoint that could still move a sub-unit/dust amount out of the vault.
+//! These tests cover the new `VaultError::BelowMinTransferAmount` guard and
+//! confirm it does not disturb the existing positive-amount check or the
+//! normal propose/execute sweep flow.
+
+#![cfg(test)]
+
+use soroban_sdk::testutils::{Address as _, Ledger as _};
+use soroban_sdk::{token, Address, Env};
+
+use super::*;
+use crate::timelock::DEFAULT_TIMELOCK_SECONDS;
+
+fn create_usdc<'a>(env: &'a Env, admin: &Address) -> (Address, token::StellarAssetClient<'a>) {
+    let ca = env.register_stellar_asset_contract_v2(admin.clone());
+    let addr = ca.address();
+    (addr.clone(), token::StellarAssetClient::new(env, &addr))
+}
+
+/// Registers a vault with a custom `min_deposit` so boundary values are easy
+/// to reason about, and mocks all auths so tests can focus on amount checks.
+fn setup(env: &Env, min_deposit: i128) -> (Address, CalloraVaultClient<'_>, Address, Address) {
+    env.ledger().set_timestamp(1_700_000_000);
+    let owner = Address::generate(env);
+    let vault_addr = env.register(CalloraVault, ());
+    let client = CalloraVaultClient::new(env, &vault_addr);
+    let (usdc, _) = create_usdc(env, &owner);
+    env.mock_all_auths();
+    client.init(
+        &owner,
+        &usdc,
+        &0,
+        &owner,
+        &min_deposit,
+        &None,
+        &1_000_000,
+        &Address::generate(env),
+    );
+    (owner, client, usdc, vault_addr)
+}
+
+#[test]
+fn propose_sweep_rejects_amount_below_min_deposit() {
+    let env = Env::default();
+    let (owner, client, _usdc, _vault_addr) = setup(&env, 100);
+    let recipient = Address::generate(&env);
+
+    let res = client.try_propose_sweep(&owner, &recipient, &99);
+    assert_eq!(
+        res.unwrap_err().unwrap(),
+        VaultError::BelowMinTransferAmount
+    );
+    assert!(client.get_pending_sweep().is_none());
+}
+
+#[test]
+fn propose_sweep_accepts_amount_at_min_deposit_boundary() {
+    let env = Env::default();
+    let (owner, client, _usdc, _vault_addr) = setup(&env, 100);
+    let recipient = Address::generate(&env);
+
+    client.propose_sweep(&owner, &recipient, &100);
+    let pending = client.get_pending_sweep().expect("proposal recorded");
+    assert_eq!(pending.amount, 100);
+}
+
+#[test]
+fn propose_sweep_rejects_zero_amount_before_min_check() {
+    let env = Env::default();
+    let (owner, client, _usdc, _vault_addr) = setup(&env, 100);
+    let recipient = Address::generate(&env);
+
+    // Zero must fail with AmountNotPositive, not BelowMinTransferAmount —
+    // the positive check runs first regardless of the configured minimum.
+    let res = client.try_propose_sweep(&owner, &recipient, &0);
+    assert_eq!(res.unwrap_err().unwrap(), VaultError::AmountNotPositive);
+}
+
+#[test]
+fn propose_sweep_rejects_negative_amount() {
+    let env = Env::default();
+    let (owner, client, _usdc, _vault_addr) = setup(&env, 100);
+    let recipient = Address::generate(&env);
+
+    let res = client.try_propose_sweep(&owner, &recipient, &-5);
+    assert_eq!(res.unwrap_err().unwrap(), VaultError::AmountNotPositive);
+}
+
+#[test]
+fn propose_sweep_with_default_min_deposit_still_rejects_sub_unit_amount() {
+    // min_deposit = 5 means "1" is a sub-unit (dust) amount relative to it.
+    let env = Env::default();
+    let (owner, client, _usdc, _vault_addr) = setup(&env, 5);
+    let recipient = Address::generate(&env);
+
+    let res = client.try_propose_sweep(&owner, &recipient, &1);
+    assert_eq!(
+        res.unwrap_err().unwrap(),
+        VaultError::BelowMinTransferAmount
+    );
+}
+
+#[test]
+fn execute_sweep_still_moves_funds_for_amount_at_or_above_minimum() {
+    let env = Env::default();
+    let (owner, client, usdc_addr, vault_addr) = setup(&env, 100);
+    let recipient = Address::generate(&env);
+    let usdc_asset = token::StellarAssetClient::new(&env, &usdc_addr);
+    usdc_asset.mint(&vault_addr, &1_000);
+
+    client.propose_sweep(&owner, &recipient, &500);
+    env.ledger()
+        .set_timestamp(env.ledger().timestamp() + DEFAULT_TIMELOCK_SECONDS + 1);
+    client.execute_sweep(&owner);
+
+    let usdc = token::Client::new(&env, &usdc_addr);
+    assert_eq!(usdc.balance(&recipient), 500);
+    assert!(client.get_pending_sweep().is_none());
+}

--- a/contracts/vault/src/views.rs
+++ b/contracts/vault/src/views.rs
@@ -21,7 +21,7 @@
 
 use soroban_sdk::{contractimpl, contracttype, token, Address, Env};
 
-use crate::{CalloraVault, CalloraVaultArgs, CalloraVaultClient, StorageKey, VaultError};
+use crate::{CalloraVault, CalloraVaultArgs, CalloraVaultClient, VaultError};
 
 /// Structured result of [`CalloraVault::dry_run_sweep_idle_balance`].
 ///

--- a/docs/ERROR_CODES.md
+++ b/docs/ERROR_CODES.md
@@ -51,7 +51,18 @@ must not be reassigned once released.
 | 34 | `NoRevenuePoolTransferPending` | Vault | No revenue-pool transfer is pending |
 | 35 | `Slippage` | Vault | Calculated fee in basis points exceeds the caller-supplied `max_fee_bps` limit |
 | 36 | `RateLimited` | Vault | Developer exceeded the configured rate limit |
-| 37 | `ExceedsReserveCap` | Vault | Deposit would exceed the configured per-token reserve cap |
+| 37 | `PausedState` | Vault | Operation is rejected because the vault is paused |
+| 38 | `InvalidHotBps` | Vault | Hot BPS must be between 1 and 10000 |
+| 39 | `InvalidRebalanceThreshold` | Vault | Rebalance threshold must be between 1 and 10000 |
+| 40 | `ColdSignersEmpty` | Vault | Cold signer set cannot be empty |
+| 41 | `InvalidColdThreshold` | Vault | Cold threshold must be between 1 and signer count |
+| 42 | `DuplicateColdSigner` | Vault | Duplicate address found in cold signer set |
+| 43 | `ExceedsReserveCap` | Vault | Deposit would exceed the configured per-token reserve cap |
+| 44 | `ProposalNotFound` | Vault | No pending timelock proposal for the requested action |
+| 45 | `TimelockNotExpired` | Vault | Action attempted before the timelock window has elapsed |
+| 46 | `TimelockOverflow` | Vault | `proposed_at + window` overflowed `u64` |
+| 47 | `InvalidTimelockWindow` | Vault | Proposed timelock window is outside the allowed `MIN..=MAX` bounds |
+| 48 | `BelowMinTransferAmount` | Vault | Amount is below the vault's configured minimum transfer unit (rejects sub-unit/dust transfers); currently enforced on `propose_sweep` |
 
 ## Settlement
 


### PR DESCRIPTION
Closes #634

## Summary
- `deposit`/`deduct`/`batch_deduct` already reject amounts below the vault's configured `min_deposit` floor. `propose_sweep` only rejected `amount <= 0`, leaving it as the one value-moving entrypoint with no minimum — a sub-unit/dust amount could still be swept out of the vault. Added the same `min_deposit` floor check to `propose_sweep`, returning a new `VaultError::BelowMinTransferAmount` (code 48).
- Along the way, discovered `contracts/vault/src/lib.rs` did not compile on `main`: a duplicate `VaultError` enum (one in `errors.rs`, one pasted directly into `lib.rs`) shadowed each other and dropped the escape-hatch timelock variants; `mod timelock;` was never declared despite `timelock.rs` existing; `token` was imported both via `soroban_sdk` and as a local module; and `execute_pause` moved `caller` before reusing it. Merged the timelock error variants into the canonical `errors.rs` enum at new, previously-unused codes (44-47) and fixed the rest so the crate — and `cargo test -p callora-vault` — actually builds and runs.

## Changes
- `contracts/vault/src/lib.rs`: min-amount check in `propose_sweep`; compile fixes (module wiring, duplicate imports/enum, moved-value bug).
- `contracts/vault/src/errors.rs`: merged timelock variants (`ProposalNotFound`, `TimelockNotExpired`, `TimelockOverflow`, `InvalidTimelockWindow`) and added `BelowMinTransferAmount`, at new stable codes 44-48.
- `contracts/vault/src/views.rs`: dropped an unused import surfaced once the crate compiled.
- `contracts/vault/src/test_min_amount.rs` (new): focused tests — below-minimum rejection, exact-boundary acceptance, zero/negative still hit `AmountNotPositive` first, a low-`min_deposit` case, and a full propose→wait→execute happy path.
- `contracts/vault/STORAGE.md`, `docs/ERROR_CODES.md`: documented the new behavior/error code and the previously-undocumented codes 38-43.

## Test plan
- [x] `cargo test -p callora-vault` — 59 passed, 0 failed (including 6 new tests)
- [x] `cargo check -p callora-vault` — clean
- [x] Verified none of the pre-existing `cargo fmt`/`cargo clippy -D warnings` failures elsewhere in the vault crate (dead `event_*` fns, a couple of unrelated lints) or in other crates (`contracts/tests`, `contracts/settlement`) were introduced by this change — confirmed via `git status`/diff scoping and by checking each failure traces to code this PR does not touch.

Note for reviewers: `main` currently fails CI (`cargo test --workspace`, `cargo fmt --check`, `cargo clippy -- -D warnings`) independent of this PR, both in the vault crate (now fixed here for compilation) and in other crates (e.g. `contracts/tests/src/grant_fox_fwc26_auth_matrix.rs` has unrelated compile errors, `contracts/settlement` has unrelated clippy warnings). Those are out of scope for this issue and left untouched.