### PR TITLE
feat: add admin cooldown for hot critical actions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -270,6 +270,13 @@ name = "callora-helpers"
 version = "0.1.0"
 
 [[package]]
+name = "callora-hot"
+version = "0.1.0"
+dependencies = [
+ "soroban-sdk",
+]
+
+[[package]]
 name = "callora-revenue-pool"
 version = "0.0.1"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ members = [
     "contracts/settlement",
     "contracts/checkpoint",
     "contracts/helpers",
+    "contracts/hot",
     "contracts/revenue_pool/fuzz",
     "contracts/tests",
 ]
@@ -21,6 +22,7 @@ default-members = [
     "contracts/settlement",
     "contracts/checkpoint",
     "contracts/helpers",
+    "contracts/hot",
 ]
 
 

--- a/contracts/hot/Cargo.toml
+++ b/contracts/hot/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "callora-hot"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+doctest = false
+
+[dependencies]
+soroban-sdk = { workspace = true }
+
+[dev-dependencies]
+soroban-sdk = { workspace = true, features = ["testutils"] }

--- a/contracts/hot/src/admin.rs
+++ b/contracts/hot/src/admin.rs
@@ -1,0 +1,137 @@
+//! Admin cool-off (cooldown) module for the `hot` contract.
+//!
+//! # Purpose
+//!
+//! The `hot` contract exposes a set of *critical* admin actions (pausing,
+//! rotating keys, upgrading, sweeping funds, …). Left unguarded, a compromised
+//! or careless admin key could fire these actions back-to-back and inflict
+//! damage far faster than an off-chain monitor could react.
+//!
+//! This module enforces a per-action **cool-off window**: after a critical
+//! action of a given kind runs, another action of the *same kind* is rejected
+//! with [`HotError::CooldownActive`] until the window elapses. The window is
+//! measured against the ledger timestamp (wall-clock seconds), so it is
+//! independent of block cadence.
+//!
+//! # Design
+//!
+//! * **Per-action tracking.** Each critical action is identified by a short
+//!   [`Symbol`] tag (e.g. `"pause"`, `"upgrade"`). The last-execution timestamp
+//!   is stored per tag under [`StorageKey::LastAction`], so cooling one action
+//!   never blocks an unrelated one.
+//! * **Configurable window.** A single global cooldown (in seconds) is held in
+//!   instance storage and bounded by [`MIN_COOLDOWN_SECS`]..=[`MAX_COOLDOWN_SECS`].
+//! * **Overflow-safe.** All arithmetic uses checked/saturating operations; there
+//!   are no `unwrap()` calls on production paths.
+//! * **No auth here.** Authentication (`require_auth`) and authorization
+//!   (admin check) live in the contract entrypoints in `lib.rs`. This module is
+//!   pure cool-off bookkeeping so it can be unit-tested in isolation and reused.
+
+use crate::errors::HotError;
+use crate::StorageKey;
+use soroban_sdk::{Env, Symbol};
+
+// ---------------------------------------------------------------------------
+// Cooldown bounds
+// ---------------------------------------------------------------------------
+
+/// Minimum accepted cooldown window, in seconds (1 second).
+///
+/// A zero window would defeat the purpose of the guard, so the smallest
+/// meaningful value is one second.
+pub const MIN_COOLDOWN_SECS: u64 = 1;
+
+/// Maximum accepted cooldown window, in seconds (30 days).
+///
+/// Caps the window so a mistaken configuration cannot lock critical actions
+/// out for an unreasonable length of time.
+pub const MAX_COOLDOWN_SECS: u64 = 30 * 24 * 60 * 60;
+
+/// Default cooldown window applied at `init`, in seconds (1 hour).
+pub const DEFAULT_COOLDOWN_SECS: u64 = 60 * 60;
+
+// ---------------------------------------------------------------------------
+// Cooldown configuration
+// ---------------------------------------------------------------------------
+
+/// Read the currently-configured cool-off window, in seconds.
+///
+/// Falls back to [`DEFAULT_COOLDOWN_SECS`] when the contract has been
+/// initialized but no explicit value was ever written (defensive default).
+pub fn get_cooldown(env: &Env) -> u64 {
+    env.storage()
+        .instance()
+        .get(&StorageKey::Cooldown)
+        .unwrap_or(DEFAULT_COOLDOWN_SECS)
+}
+
+/// Validate and persist a new cool-off window.
+///
+/// # Errors
+/// * [`HotError::InvalidCooldown`] -- `secs` is outside
+///   [`MIN_COOLDOWN_SECS`]..=[`MAX_COOLDOWN_SECS`].
+pub fn set_cooldown(env: &Env, secs: u64) -> Result<(), HotError> {
+    if !(MIN_COOLDOWN_SECS..=MAX_COOLDOWN_SECS).contains(&secs) {
+        return Err(HotError::InvalidCooldown);
+    }
+    env.storage().instance().set(&StorageKey::Cooldown, &secs);
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Per-action cool-off bookkeeping
+// ---------------------------------------------------------------------------
+
+/// Return the ledger timestamp (seconds) at which the action tagged `action`
+/// last ran, or `None` if it has never run.
+pub fn last_action_ts(env: &Env, action: &Symbol) -> Option<u64> {
+    env.storage()
+        .instance()
+        .get(&StorageKey::LastAction(action.clone()))
+}
+
+/// Return the earliest ledger timestamp at which the action tagged `action`
+/// may next run.
+///
+/// This is `last_run + cooldown`, computed with saturating arithmetic so a
+/// pathological configuration can never wrap. Returns `0` when the action has
+/// never run (i.e. it is immediately available).
+pub fn ready_at(env: &Env, action: &Symbol) -> u64 {
+    match last_action_ts(env, action) {
+        Some(last) => last.saturating_add(get_cooldown(env)),
+        None => 0,
+    }
+}
+
+/// Return the number of seconds remaining before the action tagged `action`
+/// may run again. Returns `0` when the action is available now.
+pub fn remaining(env: &Env, action: &Symbol) -> u64 {
+    let now = env.ledger().timestamp();
+    ready_at(env, action).saturating_sub(now)
+}
+
+/// Return `true` when the action tagged `action` is currently outside its
+/// cool-off window (i.e. it may run now).
+pub fn is_ready(env: &Env, action: &Symbol) -> bool {
+    remaining(env, action) == 0
+}
+
+/// Enforce and then arm the cool-off window for a critical action.
+///
+/// On success the action's last-execution timestamp is set to the current
+/// ledger timestamp, starting a fresh window. Call this exactly once, at the
+/// top of every guarded critical entrypoint, *after* the admin check.
+///
+/// # Errors
+/// * [`HotError::CooldownActive`] -- the previous invocation of this action is
+///   still inside its cool-off window.
+pub fn guard(env: &Env, action: &Symbol) -> Result<(), HotError> {
+    if !is_ready(env, action) {
+        return Err(HotError::CooldownActive);
+    }
+    let now = env.ledger().timestamp();
+    env.storage()
+        .instance()
+        .set(&StorageKey::LastAction(action.clone()), &now);
+    Ok(())
+}

--- a/contracts/hot/src/errors.rs
+++ b/contracts/hot/src/errors.rs
@@ -1,0 +1,36 @@
+use soroban_sdk::contracterror;
+
+/// Stable, machine-readable error codes for the Hot contract.
+///
+/// The numeric discriminants in this enum are part of the contract interface and
+/// must remain stable over time. Callers and indexers may branch on these `u32`
+/// codes instead of parsing panic strings.
+///
+/// | Code | Variant             | Meaning                                                      |
+/// |------|---------------------|--------------------------------------------------------------|
+/// | 1    | NotInitialized      | Contract has not been initialized yet                        |
+/// | 2    | AlreadyInitialized  | `init` was called more than once                             |
+/// | 3    | Unauthorized        | Caller is not authorized for this operation                  |
+/// | 4    | CooldownActive      | A critical action is still inside its cool-off window        |
+/// | 5    | InvalidCooldown     | Proposed cooldown value is outside the accepted range        |
+/// | 6    | NoPendingAdmin      | No admin transfer is currently pending                       |
+/// | 7    | Overflow            | Arithmetic overflow detected                                 |
+#[contracterror]
+#[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u32)]
+pub enum HotError {
+    /// Contract has not been initialized yet (code 1).
+    NotInitialized = 1,
+    /// `init` was called more than once (code 2).
+    AlreadyInitialized = 2,
+    /// Caller is not authorized for this operation (code 3).
+    Unauthorized = 3,
+    /// A critical action is still inside its cool-off window (code 4).
+    CooldownActive = 4,
+    /// Proposed cooldown value is outside the accepted range (code 5).
+    InvalidCooldown = 5,
+    /// No admin transfer is currently pending (code 6).
+    NoPendingAdmin = 6,
+    /// Arithmetic overflow detected (code 7).
+    Overflow = 7,
+}

--- a/contracts/hot/src/events.rs
+++ b/contracts/hot/src/events.rs
@@ -1,0 +1,95 @@
+//! Event topic Symbol constructors for the Callora Hot contract.
+//!
+//! This module centralizes all event topic strings into dedicated functions,
+//! ensuring byte-identity is preserved and preventing accidental topic name
+//! drift across call sites.
+
+use soroban_sdk::{Env, Symbol};
+
+/// Returns the Symbol for the `"init"` event topic.
+///
+/// Emitted when the hot contract is first initialized with an admin address
+/// and a default cooldown window.
+pub fn event_init(env: &Env) -> Symbol {
+    Symbol::new(env, "init")
+}
+
+/// Returns the Symbol for the `"cooldown_set"` event topic.
+///
+/// Emitted when the admin updates the global cool-off window via
+/// [`crate::CalloraHot::set_cooldown`].
+pub fn event_cooldown_set(env: &Env) -> Symbol {
+    Symbol::new(env, "cooldown_set")
+}
+
+/// Returns the Symbol for the `"action"` event topic.
+///
+/// Emitted every time a guarded critical action is successfully executed,
+/// recording the action tag so indexers can reconstruct the cool-off timeline.
+pub fn event_action(env: &Env) -> Symbol {
+    Symbol::new(env, "action")
+}
+
+/// Returns the Symbol for the `"admin_nominated"` event topic.
+///
+/// Emitted when the current admin nominates a new admin via
+/// [`crate::CalloraHot::set_admin`]. The nominated admin must call
+/// [`crate::CalloraHot::accept_admin`] to complete the transfer.
+pub fn event_admin_nominated(env: &Env) -> Symbol {
+    Symbol::new(env, "admin_nominated")
+}
+
+/// Returns the Symbol for the `"admin_accepted"` event topic.
+///
+/// Emitted when the pending admin accepts the role via
+/// [`crate::CalloraHot::accept_admin`], completing the two-step handover.
+pub fn event_admin_accepted(env: &Env) -> Symbol {
+    Symbol::new(env, "admin_accepted")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use soroban_sdk::Env;
+
+    /// Snapshot: proves event_init still maps to exactly the bytes for "init".
+    #[test]
+    fn test_event_init_bytes() {
+        let env = Env::default();
+        assert_eq!(event_init(&env), Symbol::new(&env, "init"));
+    }
+
+    /// Snapshot: proves event_cooldown_set still maps to exactly the bytes for "cooldown_set".
+    #[test]
+    fn test_event_cooldown_set_bytes() {
+        let env = Env::default();
+        assert_eq!(event_cooldown_set(&env), Symbol::new(&env, "cooldown_set"));
+    }
+
+    /// Snapshot: proves event_action still maps to exactly the bytes for "action".
+    #[test]
+    fn test_event_action_bytes() {
+        let env = Env::default();
+        assert_eq!(event_action(&env), Symbol::new(&env, "action"));
+    }
+
+    /// Snapshot: proves event_admin_nominated still maps to exactly the bytes for "admin_nominated".
+    #[test]
+    fn test_event_admin_nominated_bytes() {
+        let env = Env::default();
+        assert_eq!(
+            event_admin_nominated(&env),
+            Symbol::new(&env, "admin_nominated")
+        );
+    }
+
+    /// Snapshot: proves event_admin_accepted still maps to exactly the bytes for "admin_accepted".
+    #[test]
+    fn test_event_admin_accepted_bytes() {
+        let env = Env::default();
+        assert_eq!(
+            event_admin_accepted(&env),
+            Symbol::new(&env, "admin_accepted")
+        );
+    }
+}

--- a/contracts/hot/src/lib.rs
+++ b/contracts/hot/src/lib.rs
@@ -1,0 +1,429 @@
+#![no_std]
+
+//! # Callora Hot contract
+//!
+//! The `hot` contract is the operational "hot" control surface for the Callora
+//! marketplace: the place where privileged admin keys perform time-sensitive,
+//! high-impact operations. Because those keys are, by definition, kept online
+//! ("hot"), they are the most exposed to compromise.
+//!
+//! This contract's defining feature is an **admin cool-off window**: every
+//! critical action is rate-limited so that two invocations of the *same* action
+//! cannot fire within the configured window. See [`admin`] for the cool-off
+//! engine and [issue #743](https://github.com/CalloraOrg/Callora-Contracts/issues/743).
+
+#[cfg(test)]
+extern crate std;
+
+pub mod admin;
+pub mod errors;
+pub mod events;
+
+use errors::HotError;
+use soroban_sdk::{contract, contractimpl, contracttype, Address, Env, Symbol};
+
+// ---------------------------------------------------------------------------
+// Action tags
+// ---------------------------------------------------------------------------
+
+/// Cool-off tag for the `pause` critical action.
+pub const ACTION_PAUSE: &str = "pause";
+
+/// Cool-off tag for the `unpause` critical action.
+pub const ACTION_UNPAUSE: &str = "unpause";
+
+/// Cool-off tag for the `rotate_signer` critical action.
+pub const ACTION_ROTATE: &str = "rotate";
+
+// ---------------------------------------------------------------------------
+// Storage keys
+// ---------------------------------------------------------------------------
+
+/// Instance storage keys for the hot contract.
+///
+/// Each variant maps a logical key name to the underlying Soroban storage key,
+/// avoiding accidental key collisions with raw strings.
+#[contracttype]
+#[derive(Clone, Debug, PartialEq)]
+pub enum StorageKey {
+    /// Instance: current admin [`Address`].
+    Admin,
+    /// Instance: pending admin [`Address`] for two-step rotation.
+    PendingAdmin,
+    /// Instance: global cool-off window in seconds (`u64`).
+    Cooldown,
+    /// Instance: last-execution ledger timestamp for the action with the given
+    /// [`Symbol`] tag (`u64`).
+    LastAction(Symbol),
+    /// Instance: paused flag (`bool`) toggled by the guarded pause actions.
+    Paused,
+    /// Instance: the currently-authorized hot signer [`Address`].
+    Signer,
+}
+
+// ---------------------------------------------------------------------------
+// Contract
+// ---------------------------------------------------------------------------
+
+#[contract]
+pub struct CalloraHot;
+
+#[contractimpl]
+impl CalloraHot {
+    // -----------------------------------------------------------------------
+    // Initialisation
+    // -----------------------------------------------------------------------
+
+    /// Initialize the hot contract.
+    ///
+    /// Can only be called once. Sets the admin, the initial hot signer, and the
+    /// cool-off window. Pass `None` for `cooldown_secs` to adopt
+    /// [`admin::DEFAULT_COOLDOWN_SECS`].
+    ///
+    /// # Parameters
+    /// * `admin` -- Address permitted to call admin-only entrypoints; must authorize.
+    /// * `signer` -- The initial hot signer address.
+    /// * `cooldown_secs` -- Optional cool-off window in seconds.
+    ///
+    /// # Errors
+    /// * [`HotError::AlreadyInitialized`] -- `init` was called more than once.
+    /// * [`HotError::InvalidCooldown`] -- explicit `cooldown_secs` is out of range.
+    ///
+    /// # Events
+    /// Emits `init` with `admin` as topic and the cooldown window as data.
+    pub fn init(
+        env: Env,
+        admin: Address,
+        signer: Address,
+        cooldown_secs: Option<u64>,
+    ) -> Result<(), HotError> {
+        admin.require_auth();
+        if env.storage().instance().has(&StorageKey::Admin) {
+            return Err(HotError::AlreadyInitialized);
+        }
+
+        let cooldown = cooldown_secs.unwrap_or(admin::DEFAULT_COOLDOWN_SECS);
+
+        // Validate and persist the cooldown through the module's checked setter
+        // *before* writing any other state, so a bad value leaves storage clean.
+        admin::set_cooldown(&env, cooldown)?;
+
+        let inst = env.storage().instance();
+        inst.set(&StorageKey::Admin, &admin);
+        inst.set(&StorageKey::Signer, &signer);
+        inst.set(&StorageKey::Paused, &false);
+
+        env.events()
+            .publish((events::event_init(&env), admin), cooldown);
+
+        Ok(())
+    }
+
+    // -----------------------------------------------------------------------
+    // Admin helpers (internal)
+    // -----------------------------------------------------------------------
+
+    /// Read the current admin address from instance storage.
+    ///
+    /// Returns [`HotError::NotInitialized`] when no admin has been set.
+    fn admin(env: &Env) -> Result<Address, HotError> {
+        env.storage()
+            .instance()
+            .get(&StorageKey::Admin)
+            .ok_or(HotError::NotInitialized)
+    }
+
+    /// Verify that `caller` is the current admin.
+    ///
+    /// Consumes the caller's auth via `require_auth`, then checks instance
+    /// storage for the admin address. Returns [`HotError::Unauthorized`] when
+    /// the caller does not match.
+    fn require_admin(env: &Env, caller: &Address) -> Result<(), HotError> {
+        caller.require_auth();
+        let admin = Self::admin(env)?;
+        if caller != &admin {
+            return Err(HotError::Unauthorized);
+        }
+        Ok(())
+    }
+
+    // -----------------------------------------------------------------------
+    // Cooldown administration
+    // -----------------------------------------------------------------------
+
+    /// Return the currently-configured cool-off window, in seconds.
+    ///
+    /// # Errors
+    /// * [`HotError::NotInitialized`] -- contract was never initialized.
+    pub fn get_cooldown(env: Env) -> Result<u64, HotError> {
+        Self::admin(&env)?;
+        Ok(admin::get_cooldown(&env))
+    }
+
+    /// Update the global cool-off window. Only the current admin may call.
+    ///
+    /// # Parameters
+    /// * `caller` -- Must be the current admin; must authorize.
+    /// * `secs` -- New window in seconds, within
+    ///   [`admin::MIN_COOLDOWN_SECS`]..=[`admin::MAX_COOLDOWN_SECS`].
+    ///
+    /// # Errors
+    /// * [`HotError::Unauthorized`] -- caller is not the current admin.
+    /// * [`HotError::NotInitialized`] -- contract not initialized.
+    /// * [`HotError::InvalidCooldown`] -- `secs` is out of range.
+    ///
+    /// # Events
+    /// Emits `cooldown_set` with `caller` as topic and the new window as data.
+    pub fn set_cooldown(env: Env, caller: Address, secs: u64) -> Result<(), HotError> {
+        Self::require_admin(&env, &caller)?;
+        admin::set_cooldown(&env, secs)?;
+
+        env.events()
+            .publish((events::event_cooldown_set(&env), caller), secs);
+
+        Ok(())
+    }
+
+    /// Return the number of seconds remaining before the action tagged
+    /// `action` may run again, or `0` if it is available now.
+    ///
+    /// This is a read-only view and does not require initialization.
+    pub fn cooldown_remaining(env: Env, action: Symbol) -> u64 {
+        admin::remaining(&env, &action)
+    }
+
+    /// Return `true` when the action tagged `action` may run now.
+    pub fn is_ready(env: Env, action: Symbol) -> bool {
+        admin::is_ready(&env, &action)
+    }
+
+    // -----------------------------------------------------------------------
+    // Views
+    // -----------------------------------------------------------------------
+
+    /// Return the current admin address.
+    ///
+    /// # Errors
+    /// * [`HotError::NotInitialized`] -- contract was never initialized.
+    pub fn get_admin(env: Env) -> Result<Address, HotError> {
+        Self::admin(&env)
+    }
+
+    /// Return the pending admin for a two-step rotation, or `None`.
+    pub fn get_pending_admin(env: Env) -> Option<Address> {
+        env.storage().instance().get(&StorageKey::PendingAdmin)
+    }
+
+    /// Return the current hot signer address.
+    ///
+    /// # Errors
+    /// * [`HotError::NotInitialized`] -- contract was never initialized.
+    pub fn get_signer(env: Env) -> Result<Address, HotError> {
+        env.storage()
+            .instance()
+            .get(&StorageKey::Signer)
+            .ok_or(HotError::NotInitialized)
+    }
+
+    /// Return whether the contract is currently paused.
+    pub fn is_paused(env: Env) -> bool {
+        env.storage()
+            .instance()
+            .get(&StorageKey::Paused)
+            .unwrap_or(false)
+    }
+
+    // -----------------------------------------------------------------------
+    // Guarded critical actions
+    // -----------------------------------------------------------------------
+
+    /// Pause the contract. Cool-off-guarded critical action (tag `"pause"`).
+    ///
+    /// # Parameters
+    /// * `caller` -- Must be the current admin; must authorize.
+    ///
+    /// # Errors
+    /// * [`HotError::Unauthorized`] -- caller is not the current admin.
+    /// * [`HotError::NotInitialized`] -- contract not initialized.
+    /// * [`HotError::CooldownActive`] -- a `pause` ran within the cool-off window.
+    ///
+    /// # Events
+    /// Emits `action` with `caller` as topic and the `"pause"` tag as data.
+    pub fn pause(env: Env, caller: Address) -> Result<(), HotError> {
+        Self::require_admin(&env, &caller)?;
+        let action = Symbol::new(&env, ACTION_PAUSE);
+        admin::guard(&env, &action)?;
+
+        env.storage().instance().set(&StorageKey::Paused, &true);
+
+        env.events()
+            .publish((events::event_action(&env), caller), action);
+
+        Ok(())
+    }
+
+    /// Unpause the contract. Cool-off-guarded critical action (tag `"unpause"`).
+    ///
+    /// # Parameters
+    /// * `caller` -- Must be the current admin; must authorize.
+    ///
+    /// # Errors
+    /// * [`HotError::Unauthorized`] -- caller is not the current admin.
+    /// * [`HotError::NotInitialized`] -- contract not initialized.
+    /// * [`HotError::CooldownActive`] -- an `unpause` ran within the cool-off window.
+    ///
+    /// # Events
+    /// Emits `action` with `caller` as topic and the `"unpause"` tag as data.
+    pub fn unpause(env: Env, caller: Address) -> Result<(), HotError> {
+        Self::require_admin(&env, &caller)?;
+        let action = Symbol::new(&env, ACTION_UNPAUSE);
+        admin::guard(&env, &action)?;
+
+        env.storage().instance().set(&StorageKey::Paused, &false);
+
+        env.events()
+            .publish((events::event_action(&env), caller), action);
+
+        Ok(())
+    }
+
+    /// Rotate the hot signer. Cool-off-guarded critical action (tag `"rotate"`).
+    ///
+    /// # Parameters
+    /// * `caller` -- Must be the current admin; must authorize.
+    /// * `new_signer` -- The replacement hot signer address.
+    ///
+    /// # Errors
+    /// * [`HotError::Unauthorized`] -- caller is not the current admin.
+    /// * [`HotError::NotInitialized`] -- contract not initialized.
+    /// * [`HotError::CooldownActive`] -- a `rotate` ran within the cool-off window.
+    ///
+    /// # Events
+    /// Emits `action` with `caller` as topic and the `"rotate"` tag as data.
+    pub fn rotate_signer(env: Env, caller: Address, new_signer: Address) -> Result<(), HotError> {
+        Self::require_admin(&env, &caller)?;
+        let action = Symbol::new(&env, ACTION_ROTATE);
+        admin::guard(&env, &action)?;
+
+        env.storage()
+            .instance()
+            .set(&StorageKey::Signer, &new_signer);
+
+        env.events()
+            .publish((events::event_action(&env), caller), action);
+
+        Ok(())
+    }
+
+    // -----------------------------------------------------------------------
+    // Two-step admin rotation
+    // -----------------------------------------------------------------------
+
+    /// Nominate a new admin. Only the current admin may call.
+    ///
+    /// The nominee must call [`CalloraHot::accept_admin`] to complete the
+    /// transfer. Until then the current admin retains full authority.
+    ///
+    /// # Parameters
+    /// * `caller` -- Must be the current admin; must authorize.
+    /// * `new_admin` -- Address of the proposed new admin.
+    ///
+    /// # Errors
+    /// * [`HotError::Unauthorized`] -- caller is not the current admin.
+    /// * [`HotError::NotInitialized`] -- contract not initialized.
+    ///
+    /// # Events
+    /// Emits `admin_nominated` with `(caller)` as topic and `new_admin` as data.
+    pub fn set_admin(env: Env, caller: Address, new_admin: Address) -> Result<(), HotError> {
+        Self::require_admin(&env, &caller)?;
+
+        env.storage()
+            .instance()
+            .set(&StorageKey::PendingAdmin, &new_admin);
+
+        env.events()
+            .publish((events::event_admin_nominated(&env), caller), new_admin);
+
+        Ok(())
+    }
+
+    /// Complete a pending admin transfer. Must be called by the nominated admin.
+    ///
+    /// # Parameters
+    /// * `caller` -- Must be the pending admin; must authorize.
+    ///
+    /// # Errors
+    /// * [`HotError::NotInitialized`] -- contract not initialized.
+    /// * [`HotError::NoPendingAdmin`] -- no nomination is in progress.
+    /// * [`HotError::Unauthorized`] -- caller is not the pending admin.
+    ///
+    /// # Events
+    /// Emits `admin_accepted` with `(old_admin)` as topic and `new_admin` as data.
+    pub fn accept_admin(env: Env, caller: Address) -> Result<(), HotError> {
+        caller.require_auth();
+
+        let pending: Address = env
+            .storage()
+            .instance()
+            .get(&StorageKey::PendingAdmin)
+            .ok_or(HotError::NoPendingAdmin)?;
+
+        if caller != pending {
+            return Err(HotError::Unauthorized);
+        }
+
+        let old_admin = Self::admin(&env)?;
+        let inst = env.storage().instance();
+        inst.set(&StorageKey::Admin, &pending);
+        inst.remove(&StorageKey::PendingAdmin);
+
+        env.events()
+            .publish((events::event_admin_accepted(&env), old_admin), pending);
+
+        Ok(())
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Test modules
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod test;
+
+#[cfg(test)]
+mod rustdoc_tests {
+    #[test]
+    fn every_public_fn_in_lib_has_rustdoc() {
+        let source = include_str!("lib.rs")
+            .split("// ---------------------------------------------------------------------------\n// Test modules")
+            .next()
+            .expect("lib.rs contains test module marker");
+        let lines: std::vec::Vec<&str> = source.lines().collect();
+
+        for (idx, line) in lines.iter().enumerate() {
+            let trimmed = line.trim_start();
+            if !(trimmed.starts_with("pub fn ")
+                || trimmed.starts_with("pub(crate) fn ")
+                || trimmed.starts_with("pub(super) fn "))
+            {
+                continue;
+            }
+
+            let has_rustdoc = lines[..idx]
+                .iter()
+                .rev()
+                .map(|candidate| candidate.trim_start())
+                .find(|candidate| !candidate.is_empty())
+                .map(|candidate| candidate.starts_with("///"))
+                .unwrap_or(false);
+
+            assert!(
+                has_rustdoc,
+                "public function on line {} is missing /// rustdoc: {}",
+                idx + 1,
+                trimmed
+            );
+        }
+    }
+}

--- a/contracts/hot/src/test.rs
+++ b/contracts/hot/src/test.rs
@@ -1,0 +1,280 @@
+//! Focused tests for the `hot` contract's admin cool-off feature (issue #743).
+//!
+//! Coverage targets: cooldown configuration bounds, per-action isolation,
+//! window enforcement across ledger time, auth/authorization gating, the
+//! two-step admin rotation, and the read-only views.
+
+use crate::admin::{DEFAULT_COOLDOWN_SECS, MAX_COOLDOWN_SECS, MIN_COOLDOWN_SECS};
+use crate::{CalloraHot, CalloraHotClient, HotError, ACTION_PAUSE, ACTION_ROTATE};
+use soroban_sdk::testutils::{Address as _, Ledger as _};
+use soroban_sdk::{Address, Env, Symbol};
+
+/// Helper: register a fresh hot contract initialized with `cooldown_secs` and
+/// return `(env, admin, signer, client)`. Auth is mocked for convenience.
+fn setup(cooldown_secs: Option<u64>) -> (Env, Address, Address, CalloraHotClient<'static>) {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let signer = Address::generate(&env);
+    let contract_id = env.register(CalloraHot, ());
+    let client = CalloraHotClient::new(&env, &contract_id);
+    client.init(&admin, &signer, &cooldown_secs);
+    (env, admin, signer, client)
+}
+
+/// Advance the ledger timestamp by `secs` seconds.
+fn advance(env: &Env, secs: u64) {
+    let now = env.ledger().timestamp();
+    env.ledger().set_timestamp(now + secs);
+}
+
+// ===========================================================================
+// Initialisation
+// ===========================================================================
+
+#[test]
+fn test_init_defaults_cooldown() {
+    let (_env, admin, signer, client) = setup(None);
+    assert_eq!(client.get_admin(), admin);
+    assert_eq!(client.get_signer(), signer);
+    assert_eq!(client.get_cooldown(), DEFAULT_COOLDOWN_SECS);
+    assert!(!client.is_paused());
+}
+
+#[test]
+fn test_init_custom_cooldown() {
+    let (_env, _admin, _signer, client) = setup(Some(120));
+    assert_eq!(client.get_cooldown(), 120);
+}
+
+#[test]
+fn test_init_twice_fails() {
+    let (env, _admin, _signer, client) = setup(Some(60));
+    let other = Address::generate(&env);
+    let res = client.try_init(&other, &other, &None);
+    assert_eq!(res, Err(Ok(HotError::AlreadyInitialized)));
+}
+
+#[test]
+fn test_init_rejects_out_of_range_cooldown() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let signer = Address::generate(&env);
+    let contract_id = env.register(CalloraHot, ());
+    let client = CalloraHotClient::new(&env, &contract_id);
+
+    let res = client.try_init(&admin, &signer, &Some(MAX_COOLDOWN_SECS + 1));
+    assert_eq!(res, Err(Ok(HotError::InvalidCooldown)));
+}
+
+#[test]
+fn test_views_before_init_return_not_initialized() {
+    let env = Env::default();
+    let contract_id = env.register(CalloraHot, ());
+    let client = CalloraHotClient::new(&env, &contract_id);
+    assert_eq!(client.try_get_admin(), Err(Ok(HotError::NotInitialized)));
+    assert_eq!(client.try_get_signer(), Err(Ok(HotError::NotInitialized)));
+    assert_eq!(client.try_get_cooldown(), Err(Ok(HotError::NotInitialized)));
+    // is_paused / views without init default gracefully.
+    assert!(!client.is_paused());
+    assert_eq!(client.get_pending_admin(), None);
+}
+
+// ===========================================================================
+// Cooldown configuration
+// ===========================================================================
+
+#[test]
+fn test_set_cooldown_updates_value() {
+    let (_env, admin, _signer, client) = setup(Some(60));
+    client.set_cooldown(&admin, &900);
+    assert_eq!(client.get_cooldown(), 900);
+}
+
+#[test]
+fn test_set_cooldown_boundaries_accepted() {
+    let (_env, admin, _signer, client) = setup(Some(60));
+    client.set_cooldown(&admin, &MIN_COOLDOWN_SECS);
+    assert_eq!(client.get_cooldown(), MIN_COOLDOWN_SECS);
+    client.set_cooldown(&admin, &MAX_COOLDOWN_SECS);
+    assert_eq!(client.get_cooldown(), MAX_COOLDOWN_SECS);
+}
+
+#[test]
+fn test_set_cooldown_zero_rejected() {
+    let (_env, admin, _signer, client) = setup(Some(60));
+    let res = client.try_set_cooldown(&admin, &0);
+    assert_eq!(res, Err(Ok(HotError::InvalidCooldown)));
+}
+
+#[test]
+fn test_set_cooldown_too_large_rejected() {
+    let (_env, admin, _signer, client) = setup(Some(60));
+    let res = client.try_set_cooldown(&admin, &(MAX_COOLDOWN_SECS + 1));
+    assert_eq!(res, Err(Ok(HotError::InvalidCooldown)));
+}
+
+#[test]
+fn test_set_cooldown_non_admin_rejected() {
+    let (env, _admin, _signer, client) = setup(Some(60));
+    let intruder = Address::generate(&env);
+    let res = client.try_set_cooldown(&intruder, &120);
+    assert_eq!(res, Err(Ok(HotError::Unauthorized)));
+}
+
+// ===========================================================================
+// Cool-off enforcement
+// ===========================================================================
+
+#[test]
+fn test_action_available_immediately_after_init() {
+    let (env, _admin, _signer, client) = setup(Some(60));
+    let pause = Symbol::new(&env, ACTION_PAUSE);
+    assert!(client.is_ready(&pause));
+    assert_eq!(client.cooldown_remaining(&pause), 0);
+}
+
+#[test]
+fn test_second_action_within_window_rejected() {
+    let (_env, admin, _signer, client) = setup(Some(300));
+    client.pause(&admin);
+    assert!(client.is_paused());
+
+    // Immediately unpausing is a different action tag → allowed.
+    client.unpause(&admin);
+    assert!(!client.is_paused());
+
+    // A second pause within the window is rejected.
+    let res = client.try_pause(&admin);
+    assert_eq!(res, Err(Ok(HotError::CooldownActive)));
+}
+
+#[test]
+fn test_action_allowed_after_window_elapses() {
+    let (env, admin, _signer, client) = setup(Some(300));
+    client.pause(&admin);
+    let res = client.try_pause(&admin);
+    assert_eq!(res, Err(Ok(HotError::CooldownActive)));
+
+    // Just before the window closes it is still blocked.
+    advance(&env, 299);
+    let pause = Symbol::new(&env, ACTION_PAUSE);
+    assert_eq!(client.cooldown_remaining(&pause), 1);
+    assert_eq!(client.try_pause(&admin), Err(Ok(HotError::CooldownActive)));
+
+    // At the boundary it becomes available again.
+    advance(&env, 1);
+    assert!(client.is_ready(&pause));
+    client.pause(&admin);
+}
+
+#[test]
+fn test_per_action_isolation() {
+    let (env, admin, _signer, client) = setup(Some(1000));
+    let new_signer = Address::generate(&env);
+
+    client.pause(&admin);
+    // rotate is a distinct action; not blocked by pause's window.
+    client.rotate_signer(&admin, &new_signer);
+    assert_eq!(client.get_signer(), new_signer);
+
+    // But a second rotate is now blocked.
+    let another = Address::generate(&env);
+    let res = client.try_rotate_signer(&admin, &another);
+    assert_eq!(res, Err(Ok(HotError::CooldownActive)));
+
+    let rotate = Symbol::new(&env, ACTION_ROTATE);
+    assert_eq!(client.cooldown_remaining(&rotate), 1000);
+}
+
+#[test]
+fn test_shorter_cooldown_takes_effect_for_next_check() {
+    let (env, admin, _signer, client) = setup(Some(1000));
+    client.pause(&admin);
+
+    // Shorten the window; the pending pause becomes available sooner.
+    client.set_cooldown(&admin, &10);
+    advance(&env, 10);
+    let pause = Symbol::new(&env, ACTION_PAUSE);
+    assert!(client.is_ready(&pause));
+    client.pause(&admin);
+}
+
+#[test]
+fn test_guarded_actions_require_admin() {
+    let (env, _admin, _signer, client) = setup(Some(60));
+    let intruder = Address::generate(&env);
+    let target = Address::generate(&env);
+    assert_eq!(client.try_pause(&intruder), Err(Ok(HotError::Unauthorized)));
+    assert_eq!(
+        client.try_unpause(&intruder),
+        Err(Ok(HotError::Unauthorized))
+    );
+    assert_eq!(
+        client.try_rotate_signer(&intruder, &target),
+        Err(Ok(HotError::Unauthorized))
+    );
+}
+
+// ===========================================================================
+// Two-step admin rotation
+// ===========================================================================
+
+#[test]
+fn test_admin_rotation_happy_path() {
+    let (env, admin, _signer, client) = setup(Some(60));
+    let new_admin = Address::generate(&env);
+
+    client.set_admin(&admin, &new_admin);
+    assert_eq!(client.get_pending_admin(), Some(new_admin.clone()));
+    // Current admin unchanged until accepted.
+    assert_eq!(client.get_admin(), admin);
+
+    client.accept_admin(&new_admin);
+    assert_eq!(client.get_admin(), new_admin);
+    assert_eq!(client.get_pending_admin(), None);
+}
+
+#[test]
+fn test_set_admin_non_admin_rejected() {
+    let (env, _admin, _signer, client) = setup(Some(60));
+    let intruder = Address::generate(&env);
+    let res = client.try_set_admin(&intruder, &intruder);
+    assert_eq!(res, Err(Ok(HotError::Unauthorized)));
+}
+
+#[test]
+fn test_accept_admin_without_pending_rejected() {
+    let (env, _admin, _signer, client) = setup(Some(60));
+    let stranger = Address::generate(&env);
+    let res = client.try_accept_admin(&stranger);
+    assert_eq!(res, Err(Ok(HotError::NoPendingAdmin)));
+}
+
+#[test]
+fn test_accept_admin_wrong_caller_rejected() {
+    let (env, admin, _signer, client) = setup(Some(60));
+    let new_admin = Address::generate(&env);
+    let wrong = Address::generate(&env);
+    client.set_admin(&admin, &new_admin);
+    let res = client.try_accept_admin(&wrong);
+    assert_eq!(res, Err(Ok(HotError::Unauthorized)));
+}
+
+#[test]
+fn test_new_admin_controls_cooldown_after_rotation() {
+    let (env, admin, _signer, client) = setup(Some(60));
+    let new_admin = Address::generate(&env);
+    client.set_admin(&admin, &new_admin);
+    client.accept_admin(&new_admin);
+
+    // Old admin can no longer configure cooldown.
+    assert_eq!(
+        client.try_set_cooldown(&admin, &120),
+        Err(Ok(HotError::Unauthorized))
+    );
+    // New admin can.
+    client.set_cooldown(&new_admin, &120);
+    assert_eq!(client.get_cooldown(), 120);
+}

--- a/docs/HOT_ADMIN_COOLDOWN.md
+++ b/docs/HOT_ADMIN_COOLDOWN.md
@@ -1,0 +1,104 @@
+# Hot Contract — Admin Cool-off (Cooldown) for Critical Actions
+
+Implements [issue #743](https://github.com/CalloraOrg/Callora-Contracts/issues/743):
+a cool-off window between admin actions on the `hot` contract to prevent rapid
+abuse of an online ("hot") admin key.
+
+## Overview
+
+The `hot` contract is the operational control surface where privileged keys
+perform time-sensitive, high-impact operations. Because those keys are kept
+online, they are the most exposed to compromise. To bound the blast radius of a
+leaked or misused key, every **critical action** is rate-limited by a
+per-action **cool-off window**: after an action runs, another invocation of the
+*same* action is rejected until the window elapses.
+
+The window is measured against the ledger **timestamp** (wall-clock seconds), so
+it is independent of block cadence.
+
+## Design
+
+- **Per-action tracking.** Each critical action is identified by a short
+  `Symbol` tag (`"pause"`, `"unpause"`, `"rotate"`). The last-execution
+  timestamp is stored per tag, so cooling one action never blocks an unrelated
+  one.
+- **Configurable window.** A single global cooldown (seconds) is held in
+  instance storage and bounded by `MIN_COOLDOWN_SECS`..=`MAX_COOLDOWN_SECS`
+  (1 second .. 30 days). The default at `init` is `DEFAULT_COOLDOWN_SECS`
+  (1 hour).
+- **Overflow-safe.** All arithmetic uses checked/saturating operations. There
+  are no `unwrap()` calls on production paths.
+- **Auth at the edge.** `require_auth` and the admin check run in the contract
+  entrypoints; `admin.rs` is pure cool-off bookkeeping and is unit-tested in
+  isolation.
+
+## Entrypoints (API)
+
+| Function | Auth | Cool-off tag | Description |
+|----------|------|--------------|-------------|
+| `init(admin, signer, cooldown_secs: Option<u64>)` | `admin` | — | One-time setup. `None` adopts the 1-hour default. |
+| `set_cooldown(caller, secs)` | admin | — | Update the global window (validated). |
+| `get_cooldown() -> u64` | — (view) | — | Current window in seconds. |
+| `cooldown_remaining(action) -> u64` | — (view) | — | Seconds until `action` is available (0 = now). |
+| `is_ready(action) -> bool` | — (view) | — | Whether `action` may run now. |
+| `pause(caller)` | admin | `"pause"` | Pause the contract. |
+| `unpause(caller)` | admin | `"unpause"` | Unpause the contract. |
+| `rotate_signer(caller, new_signer)` | admin | `"rotate"` | Replace the hot signer. |
+| `set_admin(caller, new_admin)` | admin | — | Nominate a new admin (two-step). |
+| `accept_admin(caller)` | pending admin | — | Complete the two-step transfer. |
+| `get_admin() -> Address` | — (view) | — | Current admin. |
+| `get_pending_admin() -> Option<Address>` | — (view) | — | Pending nominee, if any. |
+| `get_signer() -> Address` | — (view) | — | Current hot signer. |
+| `is_paused() -> bool` | — (view) | — | Current pause state. |
+
+Every state-changing entrypoint calls `require_auth` on its `caller`.
+
+## Cool-off semantics
+
+For a given action tag:
+
+```
+ready_at   = last_run_ts + cooldown           (saturating; 0 if never run)
+remaining  = max(0, ready_at - now)
+is_ready   = remaining == 0
+```
+
+`guard()` enforces `is_ready` and, on success, stamps `last_run_ts = now`,
+arming a fresh window. A blocked call returns `HotError::CooldownActive` and
+makes **no** state change.
+
+Reducing the window via `set_cooldown` takes effect immediately for the *next*
+readiness check (it is recomputed from the stored `last_run_ts`), allowing an
+admin to safely shorten the cool-off in a genuine emergency.
+
+## Error codes
+
+| Code | Variant | Meaning |
+|------|---------|---------|
+| 1 | `NotInitialized` | Contract not initialized |
+| 2 | `AlreadyInitialized` | `init` called twice |
+| 3 | `Unauthorized` | Caller is not the required admin/pending admin |
+| 4 | `CooldownActive` | Action is still inside its cool-off window |
+| 5 | `InvalidCooldown` | Proposed window outside `[1s, 30d]` |
+| 6 | `NoPendingAdmin` | No admin transfer pending |
+| 7 | `Overflow` | Arithmetic overflow detected |
+
+## Events
+
+| Topic | Data | When |
+|-------|------|------|
+| `init` | `cooldown: u64` | On initialization (topic includes `admin`). |
+| `cooldown_set` | `secs: u64` | On `set_cooldown` (topic includes `caller`). |
+| `action` | `tag: Symbol` | On each successful guarded action (topic includes `caller`). |
+| `admin_nominated` | `new_admin: Address` | On `set_admin`. |
+| `admin_accepted` | `new_admin: Address` | On `accept_admin`. |
+
+## Security notes
+
+- The cool-off caps the *rate* of critical actions; it is a defense-in-depth
+  layer complementing the two-step admin rotation, not a replacement for key
+  hygiene.
+- Distinct action tags are independently cooled so that an emergency `pause` is
+  never blocked by a recent `rotate`, and vice versa.
+- All windows are bounded, so a configuration mistake cannot brick critical
+  actions for longer than `MAX_COOLDOWN_SECS` (30 days).


### PR DESCRIPTION
Closes #743

## Summary

Adds an **admin cool-off (cooldown) window** for critical actions on the `hot` contract, so two invocations of the same critical action cannot fire back-to-back. This bounds the blast radius of a compromised or careless online ("hot") admin key by rate-limiting high-impact operations.

Implemented as directed by the issue in `contracts/hot/src/admin.rs`, with the guarded entrypoints wired in `contracts/hot/src/lib.rs`.

## What's included

- **`contracts/hot/src/admin.rs`** — the cool-off engine:
  - Per-action tracking keyed by a short `Symbol` tag, so cooling one action never blocks an unrelated one.
  - Configurable global window, bounded to `[1s, 30 days]`, default `1 hour`.
  - Overflow-safe: all arithmetic uses checked/saturating operations; **no `unwrap()` on production paths**.
  - `guard()` enforces the window and arms a fresh one atomically; a blocked call makes no state change.
- **`contracts/hot/src/lib.rs`** — guarded critical entrypoints (`pause`, `unpause`, `rotate_signer`) plus two-step admin rotation (`set_admin` / `accept_admin`) and read-only views (`get_cooldown`, `cooldown_remaining`, `is_ready`, …).
- **`errors.rs` / `events.rs`** — stable `u32` error codes and centralized event topic constructors, matching the checkpoint/revenue_pool conventions.
- **`contracts/hot/src/test.rs`** — focused tests: cooldown bounds & validation, per-action isolation, window enforcement across ledger time (boundary cases), auth/authorization gating on every state-changing entrypoint, and the two-step admin rotation.
- **`docs/HOT_ADMIN_COOLDOWN.md`** — API surface, cool-off semantics, error codes, events, and security notes.
- Workspace registration in the root `Cargo.toml` / `Cargo.lock`.

## Adherence to issue guidelines

- ✅ `require_auth` on every state-changing entrypoint.
- ✅ Overflow-safe math; no `unwrap()` in production paths.
- ✅ Clear `///` rustdoc on all public items (enforced by an in-crate `rustdoc_tests` guard, mirroring `checkpoint`).
- ✅ Focused tests for the change.
- ✅ API/visible changes documented.
- ✅ Formatted with `rustfmt` to match repo style.

## Cool-off semantics

For a given action tag:

```
ready_at  = last_run_ts + cooldown        (saturating; 0 if never run)
remaining = max(0, ready_at - now)
is_ready  = remaining == 0
```

Reducing the window via `set_cooldown` takes effect immediately for the next readiness check, so an admin can safely shorten the cool-off in a genuine emergency.