### PR TITLE
test: add invariant proptest for validators #691

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -295,11 +295,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "callora-validators"
+version = "0.0.1"
+dependencies = [
+ "proptest",
+ "soroban-sdk",
+]
+
+[[package]]
 name = "callora-vault"
 version = "0.0.1"
 dependencies = [
  "callora-revenue-pool",
  "callora-settlement",
+ "callora-validators",
  "rand 0.8.7",
  "soroban-sdk",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ members = [
     "contracts/settlement",
     "contracts/checkpoint",
     "contracts/helpers",
+    "contracts/validators",
     "contracts/revenue_pool/fuzz",
     "contracts/tests",
 ]
@@ -21,6 +22,7 @@ default-members = [
     "contracts/settlement",
     "contracts/checkpoint",
     "contracts/helpers",
+    "contracts/validators",
 ]
 
 

--- a/contracts/validators/Cargo.toml
+++ b/contracts/validators/Cargo.toml
@@ -1,19 +1,16 @@
 [package]
-name = "callora-vault"
+name = "callora-validators"
 version = "0.0.1"
 edition = "2021"
 publish = false
 
 [lib]
-crate-type = ["cdylib", "rlib"]
+crate-type = ["rlib"]
 doctest = false
 
 [dependencies]
 soroban-sdk = { workspace = true }
-callora-validators = { path = "../validators" }
 
 [dev-dependencies]
 soroban-sdk = { workspace = true, features = ["testutils"] }
-rand = "0.8"
-callora-settlement = { path = "../settlement" }
-callora-revenue-pool = { path = "../revenue_pool" }
+proptest = { version = "1", default-features = false, features = ["std"] }

--- a/contracts/validators/src/lib.rs
+++ b/contracts/validators/src/lib.rs
@@ -1,4 +1,5 @@
-//! Bounded string validators for user-supplied vault metadata.
+#![no_std]
+//! Bounded string validators for user-supplied contract metadata.
 //!
 //! Metadata is stored as contract state and later consumed by wallets,
 //! indexers, and off-chain services. Accepting arbitrary Unicode would allow
@@ -10,6 +11,13 @@
 //!
 //! The validator is O(n) over the input length, with `n` capped at the
 //! contract's existing 256-byte metadata limit.
+//!
+//! # Core invariant
+//! For every input string `s`:
+//! - `is_visible_ascii_metadata(s) == normalize_visible_ascii(s).is_ok()`
+//! - Acceptance iff `s` is non-empty, length ≤ [`MAX_VALIDATED_STRING_LEN`],
+//!   every byte is in `0x20..=0x7E`, and neither the first nor last byte is
+//!   ASCII space (`0x20`).
 
 use soroban_sdk::String;
 
@@ -22,6 +30,11 @@ pub const MAX_VALIDATED_STRING_LEN: u32 = 256;
 /// spaces. This rejects C0/DEL controls, zero-width and bidi controls, and
 /// Unicode confusables by construction. Because ASCII has no decomposed forms,
 /// the returned value is NFC-normalized and byte-stable.
+///
+/// # Errors
+/// Returns `Err(())` when the string is empty, exceeds
+/// [`MAX_VALIDATED_STRING_LEN`], contains a non-visible-ASCII byte, or has
+/// leading/trailing ASCII space.
 pub fn normalize_visible_ascii(s: &String) -> Result<[u8; MAX_VALIDATED_STRING_LEN as usize], ()> {
     let len = s.len();
     if len == 0 || len > MAX_VALIDATED_STRING_LEN {
@@ -48,4 +61,19 @@ pub fn normalize_visible_ascii(s: &String) -> Result<[u8; MAX_VALIDATED_STRING_L
 /// Return whether a bounded metadata string is accepted by the on-chain policy.
 pub fn is_visible_ascii_metadata(s: &String) -> bool {
     normalize_visible_ascii(s).is_ok()
+}
+
+/// Pure reference predicate mirroring [`normalize_visible_ascii`] over raw bytes.
+///
+/// Used by property tests to check the on-chain validator against an independent
+/// oracle that does not touch the Soroban host.
+pub fn bytes_are_visible_ascii(bytes: &[u8]) -> bool {
+    let len = bytes.len();
+    if len == 0 || len > MAX_VALIDATED_STRING_LEN as usize {
+        return false;
+    }
+    if bytes[0] == b' ' || bytes[len - 1] == b' ' {
+        return false;
+    }
+    bytes.iter().all(|b| (0x20..=0x7e).contains(b))
 }

--- a/contracts/validators/tests/proptest.rs
+++ b/contracts/validators/tests/proptest.rs
@@ -1,0 +1,277 @@
+//! Property tests for the validators crate core invariant.
+//!
+//! # Invariant
+//! Across arbitrary byte sequences (and sequences of independent checks):
+//!
+//! 1. `is_visible_ascii_metadata(s) == normalize_visible_ascii(s).is_ok()`
+//! 2. Acceptance matches the independent oracle [`bytes_are_visible_ascii`]
+//! 3. Accepted buffers are byte-identical to the input (NFC-stable for ASCII)
+//! 4. Rejection is stable under re-check (idempotent reject / accept)
+//!
+//! # Strategy
+//! - `proptest` drives random byte vectors plus focused edge cases
+//! - A deterministic LCG also runs 64 seeded action sequences of length ≥ 32
+//!   so CI has reproducible traces without relying solely on proptest shrinking
+//!
+//! Closes CalloraOrg/Callora-Contracts#691.
+
+extern crate std;
+
+use callora_validators::{
+    bytes_are_visible_ascii, is_visible_ascii_metadata, normalize_visible_ascii,
+    MAX_VALIDATED_STRING_LEN,
+};
+use proptest::prelude::*;
+use soroban_sdk::{Env, String};
+use std::string::String as StdString;
+
+/// Number of deterministic LCG traces (acceptance: ≥ 64).
+const SEED_COUNT: u64 = 64;
+/// Steps per LCG trace (acceptance: ≥ 32).
+const TRACE_LENGTH: u32 = 32;
+
+/// 64-bit LCG — deterministic, no `std` dependency in production paths.
+struct Prng {
+    state: u64,
+}
+
+impl Prng {
+    fn new(seed: u64) -> Self {
+        Self {
+            state: seed.wrapping_add(0x9E37_79B9_7F4A_7C15),
+        }
+    }
+
+    fn next_u64(&mut self) -> u64 {
+        self.state = self
+            .state
+            .wrapping_mul(6_364_136_223_846_793_005)
+            .wrapping_add(1);
+        self.state
+    }
+
+    fn gen_len(&mut self, max_inclusive: usize) -> usize {
+        (self.next_u64() as usize) % (max_inclusive + 1)
+    }
+
+    fn gen_byte(&mut self) -> u8 {
+        self.next_u64() as u8
+    }
+}
+
+fn sdk_string_from_ascii(env: &Env, bytes: &[u8]) -> String {
+    let s = StdString::from_utf8(bytes.to_vec()).expect("ASCII is valid UTF-8");
+    String::from_str(env, &s)
+}
+
+/// Assert all core invariants for one input.
+fn assert_invariants(env: &Env, bytes: &[u8], seed: Option<u64>, step: Option<u32>) {
+    let oracle = bytes_are_visible_ascii(bytes);
+
+    // Host path only for valid UTF-8 (Soroban String requirement).
+    if let Ok(text) = core::str::from_utf8(bytes) {
+        let s = String::from_str(env, text);
+        let accepted = is_visible_ascii_metadata(&s);
+        let normalized = normalize_visible_ascii(&s);
+
+        assert_eq!(
+            accepted,
+            normalized.is_ok(),
+            "seed={seed:?} step={step:?} predicate/normalize disagree for {bytes:?}"
+        );
+        assert_eq!(
+            accepted, oracle,
+            "seed={seed:?} step={step:?} host validator disagreed with byte oracle for {bytes:?}"
+        );
+
+        if let Ok(buf) = normalized {
+            let len = bytes.len();
+            assert_eq!(
+                &buf[..len],
+                bytes,
+                "seed={seed:?} step={step:?} accepted buffer must equal input bytes"
+            );
+            // Idempotence: re-checking the same string stays accepted.
+            assert!(
+                is_visible_ascii_metadata(&s),
+                "seed={seed:?} step={step:?} acceptance must be idempotent"
+            );
+        } else {
+            assert!(
+                !is_visible_ascii_metadata(&s),
+                "seed={seed:?} step={step:?} rejection must be idempotent"
+            );
+        }
+    } else {
+        // Non-UTF-8 can never be constructed as Soroban String; oracle must reject
+        // anything outside visible ASCII (which non-UTF-8 always is, since UTF-8
+        // multi-byte sequences use bytes > 0x7F).
+        assert!(
+            !oracle,
+            "seed={seed:?} step={step:?} non-UTF-8 bytes must fail the oracle"
+        );
+    }
+}
+
+/// Run one deterministic action sequence for `seed`.
+fn run_trace(seed: u64) {
+    let env = Env::default();
+    let mut rng = Prng::new(seed);
+
+    for step in 1..=TRACE_LENGTH {
+        let kind = rng.next_u64() % 6;
+        let bytes: std::vec::Vec<u8> = match kind {
+            // Uniform random bytes (may be non-UTF-8).
+            0 => {
+                let len = rng.gen_len(MAX_VALIDATED_STRING_LEN as usize + 8);
+                (0..len).map(|_| rng.gen_byte()).collect()
+            }
+            // Visible ASCII body, possibly with leading/trailing space.
+            1 => {
+                let len = rng.gen_len(MAX_VALIDATED_STRING_LEN as usize).max(1);
+                let mut v: std::vec::Vec<u8> = (0..len)
+                    .map(|_| 0x21 + (rng.gen_byte() % (0x7e - 0x21 + 1)))
+                    .collect();
+                if rng.next_u64() % 2 == 0 {
+                    v.insert(0, b' ');
+                }
+                if rng.next_u64() % 2 == 0 {
+                    v.push(b' ');
+                }
+                v
+            }
+            // Empty.
+            2 => std::vec::Vec::new(),
+            // Exact max-length valid ASCII.
+            3 => (0..MAX_VALIDATED_STRING_LEN as usize)
+                .map(|_| 0x41 + (rng.gen_byte() % 26))
+                .collect(),
+            // Over-long ASCII.
+            4 => (0..(MAX_VALIDATED_STRING_LEN as usize + 1 + (rng.gen_len(16))))
+                .map(|_| 0x61 + (rng.gen_byte() % 26))
+                .collect(),
+            // Control / DEL injection into otherwise-valid ASCII.
+            5 => {
+                let len = rng.gen_len(64).max(1);
+                let mut v: std::vec::Vec<u8> = (0..len)
+                    .map(|_| 0x41 + (rng.gen_byte() % 26))
+                    .collect();
+                let idx = (rng.next_u64() as usize) % v.len();
+                v[idx] = if rng.next_u64() % 2 == 0 {
+                    rng.gen_byte() % 0x20
+                } else {
+                    0x7f
+                };
+                v
+            }
+            _ => unreachable!(),
+        };
+
+        assert_invariants(&env, &bytes, Some(seed), Some(step));
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Deterministic seeded traces
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_validators_invariant_seeded_traces() {
+    for seed in 0..SEED_COUNT {
+        run_trace(seed);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Focused edge cases
+// ---------------------------------------------------------------------------
+
+#[test]
+fn empty_string_rejected() {
+    let env = Env::default();
+    assert_invariants(&env, b"", None, None);
+}
+
+#[test]
+fn single_space_rejected() {
+    let env = Env::default();
+    assert_invariants(&env, b" ", None, None);
+}
+
+#[test]
+fn leading_and_trailing_space_rejected() {
+    let env = Env::default();
+    assert_invariants(&env, b" hello", None, None);
+    assert_invariants(&env, b"hello ", None, None);
+    assert_invariants(&env, b" hello ", None, None);
+}
+
+#[test]
+fn control_and_del_rejected() {
+    let env = Env::default();
+    assert_invariants(&env, b"a\x00b", None, None);
+    assert_invariants(&env, b"a\x1fb", None, None);
+    assert_invariants(&env, b"a\x7fb", None, None);
+}
+
+#[test]
+fn valid_visible_ascii_accepted() {
+    let env = Env::default();
+    for sample in [b"ipfs://cid".as_slice(), b"A", b"~!@#"] {
+        let s = sdk_string_from_ascii(&env, sample);
+        assert!(is_visible_ascii_metadata(&s));
+        assert_invariants(&env, sample, None, None);
+    }
+}
+
+#[test]
+fn exact_max_length_accepted_overlong_rejected() {
+    let env = Env::default();
+    let ok = vec![b'x'; MAX_VALIDATED_STRING_LEN as usize];
+    let over = vec![b'x'; MAX_VALIDATED_STRING_LEN as usize + 1];
+    assert_invariants(&env, &ok, None, None);
+    assert_invariants(&env, &over, None, None);
+}
+
+#[test]
+fn unicode_multibyte_rejected_by_oracle_and_host() {
+    let env = Env::default();
+    // Cyrillic lookalike / combining accent — multi-byte UTF-8, not visible ASCII.
+    assert_invariants(&env, "раypal".as_bytes(), None, None);
+    assert_invariants(&env, "cafe\u{0301}".as_bytes(), None, None);
+    assert_invariants(&env, "meta\u{200b}data".as_bytes(), None, None);
+}
+
+// ---------------------------------------------------------------------------
+// proptest-driven random inputs
+// ---------------------------------------------------------------------------
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(256))]
+
+    /// Random byte vectors preserve the validator ↔ oracle invariant.
+    #[test]
+    fn prop_random_bytes_match_oracle(bytes in prop::collection::vec(any::<u8>(), 0..=280)) {
+        let env = Env::default();
+        assert_invariants(&env, &bytes, None, None);
+    }
+
+    /// Random visible-ASCII bodies (with optional edge padding) stay consistent.
+    #[test]
+    fn prop_ascii_bodies(
+        body in prop::collection::vec(0x21u8..=0x7eu8, 0..=260),
+        lead_space in any::<bool>(),
+        trail_space in any::<bool>(),
+    ) {
+        let env = Env::default();
+        let mut bytes = std::vec::Vec::new();
+        if lead_space {
+            bytes.push(b' ');
+        }
+        bytes.extend_from_slice(&body);
+        if trail_space {
+            bytes.push(b' ');
+        }
+        assert_invariants(&env, &bytes, None, None);
+    }
+}

--- a/contracts/vault/src/lib.rs
+++ b/contracts/vault/src/lib.rs
@@ -54,6 +54,9 @@ use soroban_sdk::{
 
 pub mod views;
 
+/// Bounded visible-ASCII metadata validators (shared `callora-validators` crate).
+pub use callora_validators as validators;
+
 mod errors;
 pub use errors::VaultError;
 


### PR DESCRIPTION
## Overview

This PR adds an invariant **proptest** suite for the validators component. It extracts bounded visible-ASCII metadata validation into a dedicated `callora-validators` crate and asserts the core accept/reject invariant across arbitrary byte sequences and deterministic action traces.

## Related Issue

Closes #691

## Changes

### 🧪 Validators Invariant Proptest

* **[ADD]** `contracts/validators/` (`callora-validators`)
  * Moved visible-ASCII metadata validators into a standalone `no_std` crate.
  * Documents the core invariant: `is_visible_ascii_metadata(s) == normalize_visible_ascii(s).is_ok()`, with acceptance iff non-empty, length ≤ 256, bytes in `0x20..=0x7E`, and no leading/trailing space.
  * Adds `bytes_are_visible_ascii` as an independent byte-oracle for property tests.

* **[ADD]** `contracts/validators/tests/proptest.rs`
  * 64 deterministic LCG-seeded traces × 32 steps each.
  * `proptest!` random-byte and ASCII-body strategies (256 cases).
  * Focused edge cases: empty, spaces, controls/DEL, max length, Unicode/confusables.
  * After every input, asserts host validator ↔ oracle agreement, buffer identity on accept, and idempotent accept/reject.

### 📦 Workspace / Vault Wiring

* **[MODIFY]** `Cargo.toml` / `Cargo.lock`
  * Registers `contracts/validators` as a workspace member.

* **[MODIFY]** `contracts/vault/Cargo.toml`, `contracts/vault/src/lib.rs`
  * Vault depends on `callora-validators` and re-exports it as `validators`.

## Verification Results

```
cargo test -p callora-validators --test proptest
✅ 10/10 passed

running 10 tests
test empty_string_rejected ... ok
test single_space_rejected ... ok
test leading_and_trailing_space_rejected ... ok
test control_and_del_rejected ... ok
test valid_visible_ascii_accepted ... ok
test exact_max_length_accepted_overlong_rejected ... ok
test unicode_multibyte_rejected_by_oracle_and_host ... ok
test test_validators_invariant_seeded_traces ... ok
test prop_random_bytes_match_oracle ... ok
test prop_ascii_bodies ... ok
```

| Acceptance Criteria | Status |
| --- | --- |
| Property test asserts validators core invariant across arbitrary sequences | ✅ LCG traces + proptest random inputs |
| `contracts/validators/tests/proptest.rs` added | ✅ |
| Focused edge-case coverage | ✅ empty / spaces / controls / max-len / Unicode |
| Tests passing | ✅ `cargo test -p callora-validators --test proptest` 10/10 |