### PR TITLE
feat: add read-only capabilities() view for cold #714

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -245,6 +245,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "callora-cold"
+version = "0.0.1"
+dependencies = [
+ "soroban-sdk",
+]
+
+[[package]]
 name = "callora-contracts-e2e"
 version = "0.0.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ members = [
     "contracts/settlement",
     "contracts/checkpoint",
     "contracts/helpers",
+    "contracts/cold",
     "contracts/revenue_pool/fuzz",
     "contracts/tests",
 ]
@@ -21,6 +22,7 @@ default-members = [
     "contracts/settlement",
     "contracts/checkpoint",
     "contracts/helpers",
+    "contracts/cold",
 ]
 
 

--- a/contracts/cold/CAPABILITIES.md
+++ b/contracts/cold/CAPABILITIES.md
@@ -1,0 +1,52 @@
+# Callora Cold — Capability Bitmap
+
+The cold surface exposes a `capabilities()` view that returns a `u64` bitmask.
+Each set bit indicates a cold-storage feature supported by this deployment so
+clients can detect capability deltas across upgrades without parsing versions.
+
+Cold accounting itself lives in the vault (`contracts/vault/src/cold_storage.rs`);
+this bitmap is the discovery API for that feature set.
+
+## Querying capabilities
+
+```typescript
+const caps = await coldClient.capabilities();
+
+if (caps & CAP_COLD_MULTISIG_SWEEP) {
+  // safe to drive propose/approve cold-sweep flow
+}
+```
+
+```rust
+let caps: u64 = CalloraColdClient::new(&env, &cold).capabilities();
+let has_rebalance = caps & CAP_AUTO_REBALANCE != 0;
+```
+
+## Detecting deltas
+
+```typescript
+const before = await oldClient.capabilities();
+const after = await newClient.capabilities();
+const added = after & ~before;
+const removed = before & ~after;
+```
+
+## Bit registry
+
+| Bit | Hex | Constant | Feature | Introduced |
+|-----|-----|----------|---------|------------|
+| 0 | `0x01` | `CAP_HOT_COLD_SPLIT` | Hot/cold accounting partition (`hot + cold == total`) | v1.0.0 |
+| 1 | `0x02` | `CAP_AUTO_REBALANCE` | Deposit-time hot→cold rebalance on drift | v1.0.0 |
+| 2 | `0x04` | `CAP_COLD_MULTISIG_SWEEP` | N-of-M propose/approve cold sweep | v1.0.0 |
+| 3 | `0x08` | `CAP_SET_HOT_COLD_RATIO` | Update `hot_bps` / rebalance threshold | v1.0.0 |
+| 4 | `0x10` | `CAP_SET_COLD_SIGNERS` | Rotate cold signer set / threshold | v1.0.0 |
+| 5 | `0x20` | `CAP_COLD_BALANCE_VIEW` | Read `{hot, cold}` split | v1.0.0 |
+| 6 | `0x40` | `CAP_PENDING_COLD_SWEEP_VIEW` | Read pending multisig sweep | v1.0.0 |
+| 7–63 | — | *(reserved)* | Always zero | — |
+
+## Stability guarantee
+
+- A bit position is assigned once and never reused for a different feature.
+- Removed features keep their bit **cleared**; the position stays reserved.
+- New features occupy the lowest available bit index.
+- Reserved bits (7–63) are always `0` in the current version.

--- a/contracts/cold/Cargo.toml
+++ b/contracts/cold/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "callora-cold"
+version = "0.0.1"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+doctest = false
+
+[dependencies]
+soroban-sdk = { workspace = true }
+
+[dev-dependencies]
+soroban-sdk = { workspace = true, features = ["testutils"] }

--- a/contracts/cold/src/lib.rs
+++ b/contracts/cold/src/lib.rs
@@ -1,0 +1,43 @@
+#![no_std]
+//! Callora cold-storage capability surface.
+//!
+//! The hot/cold balance split lives as an accounting partition inside the
+//! vault (`contracts/vault/src/cold_storage.rs`). This crate exposes a
+//! **read-only** [`views::capabilities`] bitmap so clients can detect which
+//! cold features a deployment supports without parsing version strings.
+//!
+//! # Quick-start
+//! ```ignore
+//! let caps = client.capabilities();
+//! if caps & CAP_COLD_MULTISIG_SWEEP != 0 {
+//!     // safe to drive propose/approve cold-sweep flow
+//! }
+//! ```
+
+mod views;
+
+pub use views::{
+    capabilities, ALL_CAPABILITIES, CAP_AUTO_REBALANCE, CAP_COLD_BALANCE_VIEW,
+    CAP_COLD_MULTISIG_SWEEP, CAP_HOT_COLD_SPLIT, CAP_PENDING_COLD_SWEEP_VIEW,
+    CAP_SET_COLD_SIGNERS, CAP_SET_HOT_COLD_RATIO,
+};
+
+use soroban_sdk::{contract, contractimpl, Env};
+
+/// Thin contract facade that exposes cold capability discovery on-chain.
+///
+/// Cold accounting itself remains in the vault; this entrypoint exists so
+/// integrators (and capability-delta monitors) have a stable `capabilities()`
+/// view keyed to the cold feature set.
+#[contract]
+pub struct CalloraCold;
+
+#[contractimpl]
+impl CalloraCold {
+    /// Return the cold-feature capability bitmap for this deployment.
+    ///
+    /// Pure view: no auth, no storage writes, no TTL bump.
+    pub fn capabilities(env: Env) -> u64 {
+        views::capabilities(&env)
+    }
+}

--- a/contracts/cold/src/views.rs
+++ b/contracts/cold/src/views.rs
@@ -1,0 +1,93 @@
+//! Read-only capability views for Callora cold storage.
+//!
+//! Each bit in the `u64` returned by [`capabilities`] represents a distinct,
+//! stable cold-storage feature. Bits are assigned once and never reassigned,
+//! so clients can detect capability deltas across upgrades with simple
+//! bitwise comparison:
+//!
+//! ```ignore
+//! let before = old_client.capabilities();
+//! let after = new_client.capabilities();
+//! let added = after & !before;
+//! let removed = before & !after;
+//! ```
+//!
+//! # Mapping to vault cold storage
+//! These bits describe features implemented by
+//! `contracts/vault/src/cold_storage.rs` (hot/cold split, auto-rebalance,
+//! N-of-M cold sweep). Reserved bits (7–63) are always zero.
+
+use soroban_sdk::Env;
+
+/// Bit 0 — Hot/cold split: vault balance is partitioned into hot + cold pools
+/// with `hot + cold == tracked total`. Configured via cold-storage init.
+/// Introduced: v1.0.0
+pub const CAP_HOT_COLD_SPLIT: u64 = 1 << 0;
+
+/// Bit 1 — Auto-rebalance: deposits may move excess hot funds into cold when
+/// hot share drifts beyond `rebalance_threshold_bps` from `hot_bps`.
+/// Introduced: v1.0.0
+pub const CAP_AUTO_REBALANCE: u64 = 1 << 1;
+
+/// Bit 2 — Multisig cold sweep: moving funds out of cold requires N-of-M
+/// propose/approve (`propose_cold_sweep` / `approve_cold_sweep`).
+/// Introduced: v1.0.0
+pub const CAP_COLD_MULTISIG_SWEEP: u64 = 1 << 2;
+
+/// Bit 3 — Hot/cold ratio update: target `hot_bps` (and related threshold)
+/// can be updated without replacing the full signer set.
+/// Introduced: v1.0.0
+pub const CAP_SET_HOT_COLD_RATIO: u64 = 1 << 3;
+
+/// Bit 4 — Cold signer set update: the N-of-M signer roster / threshold can
+/// be rotated independently of the hot/cold ratio.
+/// Introduced: v1.0.0
+pub const CAP_SET_COLD_SIGNERS: u64 = 1 << 4;
+
+/// Bit 5 — Cold balance view: clients can read the current `{hot, cold}`
+/// accounting split (and derive `total`).
+/// Introduced: v1.0.0
+pub const CAP_COLD_BALANCE_VIEW: u64 = 1 << 5;
+
+/// Bit 6 — Pending cold-sweep view: clients can inspect an in-flight
+/// multisig sweep (`amount`, `destination`, `approvals`, `proposed_at`).
+/// Introduced: v1.0.0
+pub const CAP_PENDING_COLD_SWEEP_VIEW: u64 = 1 << 6;
+
+// Bits 7–63 are reserved for future cold capabilities and are always zero.
+
+/// Bitmask of all cold capabilities exposed by this version.
+pub const ALL_CAPABILITIES: u64 = CAP_HOT_COLD_SPLIT
+    | CAP_AUTO_REBALANCE
+    | CAP_COLD_MULTISIG_SWEEP
+    | CAP_SET_HOT_COLD_RATIO
+    | CAP_SET_COLD_SIGNERS
+    | CAP_COLD_BALANCE_VIEW
+    | CAP_PENDING_COLD_SWEEP_VIEW;
+
+/// Return the cold capability bitmap.
+///
+/// Pure view: ignores `_env` (no storage reads). Authentication is not
+/// required. Reserved bits (7–63) are always clear.
+pub fn capabilities(_env: &Env) -> u64 {
+    ALL_CAPABILITIES
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use soroban_sdk::Env;
+
+    #[test]
+    fn capabilities_equals_all_mask() {
+        let env = Env::default();
+        assert_eq!(capabilities(&env), ALL_CAPABILITIES);
+    }
+
+    #[test]
+    fn reserved_bits_are_clear() {
+        let env = Env::default();
+        let caps = capabilities(&env);
+        assert_eq!(caps & !((1u64 << 7) - 1), 0);
+    }
+}

--- a/contracts/cold/tests/capabilities.rs
+++ b/contracts/cold/tests/capabilities.rs
@@ -1,0 +1,72 @@
+//! Focused tests for the cold `capabilities()` view (#714).
+
+extern crate std;
+
+use callora_cold::{
+    CalloraCold, CalloraColdClient, ALL_CAPABILITIES, CAP_AUTO_REBALANCE, CAP_COLD_BALANCE_VIEW,
+    CAP_COLD_MULTISIG_SWEEP, CAP_HOT_COLD_SPLIT, CAP_PENDING_COLD_SWEEP_VIEW, CAP_SET_COLD_SIGNERS,
+    CAP_SET_HOT_COLD_RATIO,
+};
+use soroban_sdk::Env;
+
+fn client(env: &Env) -> CalloraColdClient<'_> {
+    let addr = env.register(CalloraCold, ());
+    CalloraColdClient::new(env, &addr)
+}
+
+#[test]
+fn capabilities_returns_nonzero() {
+    let env = Env::default();
+    assert_ne!(client(&env).capabilities(), 0);
+}
+
+#[test]
+fn capabilities_equals_all_capabilities_constant() {
+    let env = Env::default();
+    assert_eq!(client(&env).capabilities(), ALL_CAPABILITIES);
+}
+
+#[test]
+fn each_documented_cold_bit_is_set() {
+    let env = Env::default();
+    let caps = client(&env).capabilities();
+    for bit in [
+        CAP_HOT_COLD_SPLIT,
+        CAP_AUTO_REBALANCE,
+        CAP_COLD_MULTISIG_SWEEP,
+        CAP_SET_HOT_COLD_RATIO,
+        CAP_SET_COLD_SIGNERS,
+        CAP_COLD_BALANCE_VIEW,
+        CAP_PENDING_COLD_SWEEP_VIEW,
+    ] {
+        assert_ne!(caps & bit, 0, "missing capability bit {bit:#x}");
+    }
+}
+
+#[test]
+fn capability_delta_detects_added_and_removed_bits() {
+    // Simulate an older deployment that lacked pending-sweep view, and a
+    // future one that drops auto-rebalance — clients XOR/mask to find deltas.
+    let old = ALL_CAPABILITIES & !CAP_PENDING_COLD_SWEEP_VIEW;
+    let new = ALL_CAPABILITIES & !CAP_AUTO_REBALANCE;
+
+    let added = new & !old;
+    let removed = old & !new;
+
+    assert_eq!(added, CAP_PENDING_COLD_SWEEP_VIEW);
+    assert_eq!(removed, CAP_AUTO_REBALANCE);
+}
+
+#[test]
+fn reserved_high_bits_remain_zero() {
+    let env = Env::default();
+    let caps = client(&env).capabilities();
+    assert_eq!(caps >> 7, 0);
+}
+
+#[test]
+fn capabilities_is_stable_across_calls() {
+    let env = Env::default();
+    let c = client(&env);
+    assert_eq!(c.capabilities(), c.capabilities());
+}


### PR DESCRIPTION
## Overview

This PR adds a read-only **`capabilities()`** view for Callora cold storage: a stable `u64` feature bitmap so clients can detect capability deltas across upgrades without parsing version strings. Cold accounting remains in the vault; this crate is the discovery surface for the cold feature set.

## Related Issue

Closes #714

## Changes

### 🧊 Cold Capability Bitmap

* **[ADD]** `contracts/cold/src/views.rs`
  * Defines stable `CAP_*` bit constants for hot/cold split, auto-rebalance, multisig cold sweep, ratio/signer updates, and balance/pending-sweep views.
  * Implements pure `capabilities(env) -> u64` (no auth, no storage writes, no TTL bump).
  * Reserved bits 7–63 remain clear.

* **[ADD]** `contracts/cold/src/lib.rs`
  * `CalloraCold` contract facade exposing on-chain `capabilities()`.
  * Re-exports bit constants for off-chain / cross-contract use.

* **[ADD]** `contracts/cold/CAPABILITIES.md`
  * Bit registry, query examples, and add/remove delta detection guide.

### 🧪 Tests

* **[ADD]** `contracts/cold/tests/capabilities.rs`
  * Asserts nonzero bitmap, equality with `ALL_CAPABILITIES`, each documented bit set, reserved-bit clearance, call stability, and simulated capability deltas.

### 📦 Workspace

* **[MODIFY]** root `Cargo.toml` / `Cargo.lock` — register `contracts/cold` as a workspace member.

## Verification Results

```
cargo test -p callora-cold
✅ 8/8 passed

running 2 tests (lib)
test views::tests::capabilities_equals_all_mask ... ok
test views::tests::reserved_bits_are_clear ... ok

running 6 tests (integration)
test capabilities_returns_nonzero ... ok
test capabilities_equals_all_capabilities_constant ... ok
test each_documented_cold_bit_is_set ... ok
test capability_delta_detects_added_and_removed_bits ... ok
test reserved_high_bits_remain_zero ... ok
test capabilities_is_stable_across_calls ... ok
```

| Acceptance Criteria | Status |
| --- | --- |
| `contracts/cold/src/views.rs` with `capabilities()` u64 bitmap | ✅ |
| Clients can detect capability deltas | ✅ documented + tested add/remove masks |
| Focused tests passing | ✅ `cargo test -p callora-cold` 8/8 |
| Documented bit registry | ✅ `contracts/cold/CAPABILITIES.md` |