### PR TITLE
feat: settlement events

### DIFF
--- a/EVENT_SCHEMA.md
+++ b/EVENT_SCHEMA.md
@@ -1153,6 +1153,32 @@ no events are emitted and state is rolled back.
 
 ---
 
+### `initialized`
+
+Emitted once by `init()` when the settlement contract is first configured.
+
+| Index   | Location | Type    | Description                                     |
+|---------|----------|---------|-------------------------------------------------|
+| topic 0 | topics   | Symbol  | `"initialized"`                                 |
+| topic 1 | topics   | Address | `admin` — initial admin address                 |
+| topic 2 | topics   | Address | `vault_address` — initial authorized vault      |
+| data    | data     | GlobalPool | pool snapshot at init time (`total_balance=0`) |
+
+```json
+{
+  "topics": ["initialized", "GADMIN...", "GVAULT..."],
+  "data": { "total_balance": 0, "last_updated": 1700000000 }
+}
+```
+
+**Indexer guidance.**
+- `initialized` is emitted exactly once per contract lifetime; a second `init`
+  call panics with `AlreadyInitialized` before reaching this emit.
+- Use this event to index the contract's admin and vault addresses from genesis
+  without querying `get_admin()` / `get_vault()` separately.
+
+---
+
 ### `payment_received`
 
 Emitted by `receive_payment()` for every successful inbound payment,
@@ -1254,7 +1280,41 @@ after the matching `payment_received` event.
 
 ---
 
-### `vault_changed`
+### `deposit`
+
+Emitted alongside every `balance_credited` event, once per developer credit in
+both `receive_payment()` (`to_pool = false`) and `batch_receive_payment()`.
+It provides a compact deposit-centric view for indexers that don't need the
+full `PaymentReceivedEvent` context.
+
+| Index       | Location | Type    | Description                                          |
+|-------------|----------|---------|------------------------------------------------------|
+| topic 0     | topics   | Symbol  | `"deposit"`                                          |
+| topic 1     | topics   | Address | `developer` — address receiving the credit           |
+| `developer` | data     | Address | same as topic 1; duplicated for data-only indexers   |
+| `token`     | data     | Address | token contract address for this deposit              |
+| `amount`    | data     | i128    | deposit amount in USDC micro-units; invariant `> 0`  |
+
+```json
+{
+  "topics": ["deposit", "GDEV..."],
+  "data": {
+    "developer": "GDEV...",
+    "token": "GUSDC...",
+    "amount": 2500000
+  }
+}
+```
+
+**Indexer guidance.**
+- `deposit` is always emitted **after** `balance_credited` for the same
+  developer credit within the same transaction.
+- `deposit` is **never** emitted for pool credits (`to_pool = true`).
+- For batch credits, `N` items produce exactly `N` `deposit` events.
+- The `token` field identifies which asset was deposited; required for
+  multi-asset environments.
+
+---
 
 Emitted by `set_vault()` when the admin updates the registered vault address.
 

--- a/contracts/settlement/src/admin.rs
+++ b/contracts/settlement/src/admin.rs
@@ -58,11 +58,7 @@ pub(crate) fn propose_balance_migration(env: &Env, caller: &Address, from: &Addr
         execute_after,
     };
     timelock::set_pending_migration(env, &migration);
-
-    env.events().publish(
-        (events::event_admin_migration_proposed(env), from.clone()),
-        migration,
-    );
+    events::emit_admin_migration_proposed(env, from, migration);
 }
 
 pub(crate) fn execute_balance_migration(env: &Env, caller: &Address, from: &Address) {
@@ -116,12 +112,10 @@ pub(crate) fn execute_balance_migration(env: &Env, caller: &Address, from: &Addr
         .set(&StorageKey::DeveloperIndex, &index);
     timelock::remove_pending_migration(env, from);
 
-    env.events().publish(
-        (
-            events::event_admin_migration(env),
-            from.clone(),
-            migration.to.clone(),
-        ),
+    events::emit_admin_migration(
+        env,
+        from,
+        &migration.to.clone(),
         AdminMigrationEvent {
             from: from.clone(),
             to: migration.to,

--- a/contracts/settlement/src/events.rs
+++ b/contracts/settlement/src/events.rs
@@ -1,10 +1,47 @@
-//! Event topic Symbol constructors for the Callora Settlement contract.
+//! Event topic Symbol constructors and structured emit helpers for the
+//! Callora Settlement contract.
 //!
-//! This module centralizes all event topic strings into dedicated functions,
-//! ensuring byte-identity is preserved and preventing accidental topic name drift
-//! across call sites.
+//! # Design
+//!
+//! This module is the **single source of truth** for every event emitted by the
+//! settlement contract. It exposes two layers:
+//!
+//! 1. **Topic constructors** – `event_*(&env) -> Symbol` functions that return
+//!    the stable topic Symbol for a given event. These guarantee byte-level
+//!    identity and prevent accidental topic-name drift across call sites.
+//!
+//! 2. **Emit helpers** – `emit_*(&env, …)` functions that bundle the topic
+//!    construction, data struct construction, and `env.events().publish()` call
+//!    into one place. Call sites in `lib.rs`, `admin.rs`, and `limits.rs` use
+//!    these helpers exclusively; no inline `Symbol::new(…)` or
+//!    `env.events().publish(…)` calls appear outside this module.
+//!
+//! # Adding a new event
+//!
+//! 1. Add `pub fn event_<name>(env: &Env) -> Symbol` with a doc-comment.
+//! 2. Add a corresponding `pub fn emit_<name>(env: &Env, …)` function.
+//! 3. Add a snapshot test in the `#[cfg(test)] mod tests` block asserting
+//!    byte-identity of the topic string.
+//! 4. Update `EVENT_SCHEMA.md` and `docs/EVENT_TOPICS.md`.
 
-use soroban_sdk::{Env, Symbol};
+use soroban_sdk::{Address, BytesN, Env, Symbol};
+
+use crate::types::{
+    AdminBroadcast, AdminMigrationEvent, BalanceCreditedEvent, DailyWithdrawCapChanged,
+    DeveloperClaimWindowChanged, DeveloperForceCreditedEvent, DeveloperWithdrawEvent,
+    DepositEvent, GlobalPool, PaymentReceivedEvent, VaultAcceptedEvent, VaultProposedEvent,
+};
+use crate::limits::MinBalanceChanged;
+use crate::Severity;
+
+// ─── Topic constructors ──────────────────────────────────────────────────────
+
+/// Returns the Symbol for the `"initialized"` event topic.
+///
+/// Emitted once when the settlement contract is first initialized.
+pub fn event_initialized(env: &Env) -> Symbol {
+    Symbol::new(env, "initialized")
+}
 
 /// Returns the Symbol for the `"payment_received"` event topic.
 ///
@@ -20,6 +57,14 @@ pub fn event_payment_received(env: &Env) -> Symbol {
 /// `receive_payment` (single) or `batch_receive_payment` (batch).
 pub fn event_balance_credited(env: &Env) -> Symbol {
     Symbol::new(env, "balance_credited")
+}
+
+/// Returns the Symbol for the `"deposit"` event topic.
+///
+/// Emitted when a deposit is made for a developer (alongside `balance_credited`)
+/// in both `receive_payment` (`to_pool = false`) and `batch_receive_payment`.
+pub fn event_deposit(env: &Env) -> Symbol {
+    Symbol::new(env, "deposit")
 }
 
 /// Returns the Symbol for the `"developer_withdraw"` event topic.
@@ -115,13 +160,6 @@ pub fn event_admin_migration(env: &Env) -> Symbol {
     Symbol::new(env, "admin_migration")
 }
 
-/// Returns the Symbol for the `"deposit"` event topic.
-///
-/// Emitted when a deposit is made for a developer.
-pub fn event_deposit(env: &Env) -> Symbol {
-    Symbol::new(env, "deposit")
-}
-
 /// Returns the Symbol for the `"developer_min_balance_changed"` event topic.
 ///
 /// Emitted when the admin sets or updates a developer's minimum balance
@@ -131,12 +169,255 @@ pub fn event_developer_min_balance_changed(env: &Env) -> Symbol {
     Symbol::new(env, "developer_min_balance_changed")
 }
 
+/// Returns the Symbol for the `"metadata_removed"` event topic.
+pub fn event_metadata_removed(env: &Env) -> Symbol {
+    Symbol::new(env, "metadata_removed")
+}
+
+// ─── Emit helpers ────────────────────────────────────────────────────────────
+
+/// Emit `"initialized"` once when the settlement contract is first set up.
+///
+/// Topics: `(initialized, admin)`
+/// Data:   `GlobalPool` snapshot captured at init time.
+pub fn emit_initialized(env: &Env, admin: &Address, vault: &Address, pool: &GlobalPool) {
+    env.events().publish(
+        (event_initialized(env), admin.clone(), vault.clone()),
+        pool.clone(),
+    );
+}
+
+/// Emit `"payment_received"` when an inbound payment is routed to the global
+/// pool or a developer balance.
+///
+/// Topics: `(payment_received, from_vault)`
+/// Data:   [`PaymentReceivedEvent`]
+pub fn emit_payment_received(env: &Env, caller: &Address, payload: PaymentReceivedEvent) {
+    env.events().publish(
+        (event_payment_received(env), caller.clone()),
+        payload,
+    );
+}
+
+/// Emit `"balance_credited"` when a developer's balance is incremented.
+///
+/// Topics: `(balance_credited, developer)`
+/// Data:   [`BalanceCreditedEvent`]
+pub fn emit_balance_credited(env: &Env, developer: &Address, payload: BalanceCreditedEvent) {
+    env.events().publish(
+        (event_balance_credited(env), developer.clone()),
+        payload,
+    );
+}
+
+/// Emit `"deposit"` alongside each developer credit (both single and batch).
+///
+/// Topics: `(deposit, developer)`
+/// Data:   [`DepositEvent`]
+pub fn emit_deposit(env: &Env, developer: &Address, payload: DepositEvent) {
+    env.events().publish(
+        (event_deposit(env), developer.clone()),
+        payload,
+    );
+}
+
+/// Emit `"developer_withdraw"` when a developer withdraws accrued balance.
+///
+/// Topics: `(developer_withdraw, developer)`
+/// Data:   [`DeveloperWithdrawEvent`]
+pub fn emit_developer_withdraw(env: &Env, developer: &Address, payload: DeveloperWithdrawEvent) {
+    env.events().publish(
+        (event_developer_withdraw(env), developer.clone()),
+        payload,
+    );
+}
+
+/// Emit `"daily_withdraw_cap_changed"` when the admin updates a developer's
+/// daily cap.
+///
+/// Topics: `(daily_withdraw_cap_changed, caller)`
+/// Data:   [`DailyWithdrawCapChanged`]
+pub fn emit_daily_withdraw_cap_changed(
+    env: &Env,
+    caller: &Address,
+    payload: DailyWithdrawCapChanged,
+) {
+    env.events().publish(
+        (event_daily_withdraw_cap_changed(env), caller.clone()),
+        payload,
+    );
+}
+
+/// Emit `"claim_window_changed"` when a developer claim window is set or cleared.
+///
+/// Topics: `(claim_window_changed, developer)`
+/// Data:   [`DeveloperClaimWindowChanged`]
+pub fn emit_developer_claim_window_changed(
+    env: &Env,
+    developer: &Address,
+    payload: DeveloperClaimWindowChanged,
+) {
+    env.events().publish(
+        (event_developer_claim_window_changed(env), developer.clone()),
+        payload,
+    );
+}
+
+/// Emit `"admin_nominated"` when the current admin nominates a successor.
+///
+/// Topics: `(admin_nominated, current_admin, new_admin)`
+/// Data:   `new_admin` address
+pub fn emit_admin_nominated(env: &Env, current_admin: &Address, new_admin: &Address) {
+    env.events().publish(
+        (
+            event_admin_nominated(env),
+            current_admin.clone(),
+            new_admin.clone(),
+        ),
+        new_admin.clone(),
+    );
+}
+
+/// Emit `"admin_accepted"` when the pending admin finalizes the transfer.
+///
+/// Topics: `(admin_accepted, old_admin, new_admin)`
+/// Data:   `new_admin` address
+pub fn emit_admin_accepted(env: &Env, old_admin: &Address, new_admin: &Address) {
+    env.events().publish(
+        (
+            event_admin_accepted(env),
+            old_admin.clone(),
+            new_admin.clone(),
+        ),
+        new_admin.clone(),
+    );
+}
+
+/// Emit `"admin_cancelled"` when the admin cancels a pending transfer.
+///
+/// Topics: `(admin_cancelled, admin)`
+/// Data:   `admin` address
+pub fn emit_admin_cancelled(env: &Env, admin: &Address) {
+    env.events()
+        .publish((event_admin_cancelled(env), admin.clone()), admin.clone());
+}
+
+/// Emit `"vault_proposed"` when the admin proposes a new vault.
+///
+/// Topics: `(vault_proposed, admin)`
+/// Data:   [`VaultProposedEvent`]
+pub fn emit_vault_proposed(env: &Env, admin: &Address, payload: VaultProposedEvent) {
+    env.events()
+        .publish((event_vault_proposed(env), admin.clone()), payload);
+}
+
+/// Emit `"vault_accepted"` when the proposed vault rotation is accepted.
+///
+/// Topics: `(vault_accepted, new_vault)`
+/// Data:   [`VaultAcceptedEvent`]
+pub fn emit_vault_accepted(env: &Env, new_vault: &Address, payload: VaultAcceptedEvent) {
+    env.events()
+        .publish((event_vault_accepted(env), new_vault.clone()), payload);
+}
+
+/// Emit `"upgraded"` when the contract WASM is replaced.
+///
+/// Topics: `(upgraded, caller)`
+/// Data:   `new_wasm_hash`
+pub fn emit_upgraded(env: &Env, caller: &Address, new_wasm_hash: &BytesN<32>) {
+    env.events().publish(
+        (event_upgraded(env), caller.clone()),
+        new_wasm_hash.clone(),
+    );
+}
+
+/// Emit `"developer_force_credited"` when the admin manually credits a
+/// developer balance outside the normal payment flow.
+///
+/// Topics: `(developer_force_credited, developer)`
+/// Data:   [`DeveloperForceCreditedEvent`]
+pub fn emit_developer_force_credited(
+    env: &Env,
+    developer: &Address,
+    payload: DeveloperForceCreditedEvent,
+) {
+    env.events().publish(
+        (event_developer_force_credited(env), developer.clone()),
+        payload,
+    );
+}
+
+/// Emit `"admin_broadcast"` when the admin sends an emergency message.
+///
+/// Topics: `(admin_broadcast, caller)`
+/// Data:   [`AdminBroadcast`]
+pub fn emit_admin_broadcast(env: &Env, caller: &Address, payload: AdminBroadcast) {
+    env.events()
+        .publish((event_admin_broadcast(env), caller.clone()), payload);
+}
+
+/// Emit `"admin_migration_proposed"` when a timelock'd developer balance
+/// migration proposal is recorded.
+///
+/// Topics: `(admin_migration_proposed, from)`
+/// Data:   [`crate::timelock::PendingDeveloperMigration`]
+pub fn emit_admin_migration_proposed(
+    env: &Env,
+    from: &Address,
+    payload: crate::timelock::PendingDeveloperMigration,
+) {
+    env.events().publish(
+        (event_admin_migration_proposed(env), from.clone()),
+        payload,
+    );
+}
+
+/// Emit `"admin_migration"` when a pending balance migration is executed.
+///
+/// Topics: `(admin_migration, from, to)`
+/// Data:   [`AdminMigrationEvent`]
+pub fn emit_admin_migration(env: &Env, from: &Address, to: &Address, payload: AdminMigrationEvent) {
+    env.events().publish(
+        (event_admin_migration(env), from.clone(), to.clone()),
+        payload,
+    );
+}
+
+/// Emit `"developer_min_balance_changed"` when the admin sets a developer's
+/// minimum withdrawal threshold.
+///
+/// Topics: `(developer_min_balance_changed, developer)`
+/// Data:   [`MinBalanceChanged`]
+pub fn emit_developer_min_balance_changed(
+    env: &Env,
+    developer: &Address,
+    payload: MinBalanceChanged,
+) {
+    env.events().publish(
+        (event_developer_min_balance_changed(env), developer.clone()),
+        payload,
+    );
+}
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use soroban_sdk::Env;
 
-    /// Snapshot: proves event_payment_received still maps to exactly the bytes for "payment_received".
+    // ── Topic byte-identity snapshots ─────────────────────────────────────
+
+    /// Every constructor must map to exactly the expected byte string.
+    /// Changing any of these would be a breaking change to the on-chain
+    /// interface; that is why they are explicitly snapshot-tested.
+
+    #[test]
+    fn test_event_initialized_bytes() {
+        let env = Env::default();
+        assert_eq!(event_initialized(&env), Symbol::new(&env, "initialized"));
+    }
+
     #[test]
     fn test_event_payment_received_bytes() {
         let env = Env::default();
@@ -146,7 +427,6 @@ mod tests {
         );
     }
 
-    /// Snapshot: proves event_balance_credited still maps to exactly the bytes for "balance_credited".
     #[test]
     fn test_event_balance_credited_bytes() {
         let env = Env::default();
@@ -156,7 +436,12 @@ mod tests {
         );
     }
 
-    /// Snapshot: proves event_developer_withdraw still maps to exactly the bytes for "developer_withdraw".
+    #[test]
+    fn test_event_deposit_bytes() {
+        let env = Env::default();
+        assert_eq!(event_deposit(&env), Symbol::new(&env, "deposit"));
+    }
+
     #[test]
     fn test_event_developer_withdraw_bytes() {
         let env = Env::default();
@@ -166,7 +451,6 @@ mod tests {
         );
     }
 
-    /// Snapshot: proves event_daily_withdraw_cap_changed still maps to exactly the bytes for "daily_withdraw_cap_changed".
     #[test]
     fn test_event_daily_withdraw_cap_changed_bytes() {
         let env = Env::default();
@@ -176,7 +460,6 @@ mod tests {
         );
     }
 
-    /// Snapshot: proves event_developer_claim_window_changed still maps to exactly the bytes for "claim_window_changed".
     #[test]
     fn test_event_developer_claim_window_changed_bytes() {
         let env = Env::default();
@@ -186,7 +469,6 @@ mod tests {
         );
     }
 
-    /// Snapshot: proves event_admin_nominated still maps to exactly the bytes for "admin_nominated".
     #[test]
     fn test_event_admin_nominated_bytes() {
         let env = Env::default();
@@ -196,7 +478,6 @@ mod tests {
         );
     }
 
-    /// Snapshot: proves event_admin_accepted still maps to exactly the bytes for "admin_accepted".
     #[test]
     fn test_event_admin_accepted_bytes() {
         let env = Env::default();
@@ -206,7 +487,6 @@ mod tests {
         );
     }
 
-    /// Snapshot: proves event_admin_cancelled still maps to exactly the bytes for "admin_cancelled".
     #[test]
     fn test_event_admin_cancelled_bytes() {
         let env = Env::default();
@@ -216,7 +496,6 @@ mod tests {
         );
     }
 
-    /// Snapshot: proves event_vault_proposed still maps to exactly the bytes for "vault_proposed".
     #[test]
     fn test_event_vault_proposed_bytes() {
         let env = Env::default();
@@ -226,7 +505,6 @@ mod tests {
         );
     }
 
-    /// Snapshot: proves event_vault_accepted still maps to exactly the bytes for "vault_accepted".
     #[test]
     fn test_event_vault_accepted_bytes() {
         let env = Env::default();
@@ -236,14 +514,12 @@ mod tests {
         );
     }
 
-    /// Snapshot: proves event_upgraded still maps to exactly the bytes for "upgraded".
     #[test]
     fn test_event_upgraded_bytes() {
         let env = Env::default();
         assert_eq!(event_upgraded(&env), Symbol::new(&env, "upgraded"));
     }
 
-    /// Snapshot: proves event_developer_force_credited still maps to exactly the bytes for "developer_force_credited".
     #[test]
     fn test_event_developer_force_credited_bytes() {
         let env = Env::default();
@@ -253,7 +529,6 @@ mod tests {
         );
     }
 
-    /// Snapshot: proves event_admin_broadcast still maps to exactly the bytes for "admin_broadcast".
     #[test]
     fn test_event_admin_broadcast_bytes() {
         let env = Env::default();
@@ -277,13 +552,6 @@ mod tests {
     }
 
     #[test]
-    fn test_event_deposit_bytes() {
-        let env = Env::default();
-        assert_eq!(event_deposit(&env), Symbol::new(&env, "deposit"));
-    }
-
-    /// Snapshot: proves event_developer_min_balance_changed maps to exactly "developer_min_balance_changed".
-    #[test]
     fn test_event_developer_min_balance_changed_bytes() {
         let env = Env::default();
         assert_eq!(
@@ -291,9 +559,13 @@ mod tests {
             Symbol::new(&env, "developer_min_balance_changed")
         );
     }
-}
 
-/// Returns the Symbol for the `"metadata_removed"` event topic.
-pub fn event_metadata_removed(env: &soroban_sdk::Env) -> soroban_sdk::Symbol {
-    soroban_sdk::Symbol::new(env, "metadata_removed")
+    #[test]
+    fn test_event_metadata_removed_bytes() {
+        let env = Env::default();
+        assert_eq!(
+            event_metadata_removed(&env),
+            Symbol::new(&env, "metadata_removed")
+        );
+    }
 }

--- a/contracts/settlement/src/lib.rs
+++ b/contracts/settlement/src/lib.rs
@@ -55,14 +55,14 @@ impl CalloraSettlement {
         let inst = env.storage().instance();
         inst.set(&StorageKey::Admin, &admin);
         inst.set(&StorageKey::Vault, &vault_address);
-        inst.set(
-            &StorageKey::GlobalPool,
-            &GlobalPool {
-                total_balance: 0,
-                last_updated: env.ledger().timestamp(),
-            },
-        );
+        let pool = GlobalPool {
+            total_balance: 0,
+            last_updated: env.ledger().timestamp(),
+        };
+        inst.set(&StorageKey::GlobalPool, &pool);
         inst.set(&StorageKey::TotalReceived, &0i128);
+
+        events::emit_initialized(&env, &admin, &vault_address, &pool);
     }
 
     /// Receive payment from vault and credit to pool or developer balance.
@@ -123,8 +123,9 @@ impl CalloraSettlement {
                 .unwrap_or_else(|| env.panic_with_error(SettlementError::PoolOverflow));
             global_pool.last_updated = env.ledger().timestamp();
             inst.set(&StorageKey::GlobalPool, &global_pool);
-            env.events().publish(
-                (events::event_payment_received(&env), caller.clone()),
+            events::emit_payment_received(
+                &env,
+                &caller,
                 PaymentReceivedEvent {
                     from_vault: caller.clone(),
                     amount,
@@ -165,8 +166,9 @@ impl CalloraSettlement {
             Self::sorted_insert(&env, &mut index, dev_address.clone());
             inst.set(&StorageKey::DeveloperIndex, &index);
 
-            env.events().publish(
-                (events::event_payment_received(&env), caller.clone()),
+            events::emit_payment_received(
+                &env,
+                &caller,
                 PaymentReceivedEvent {
                     from_vault: caller.clone(),
                     amount,
@@ -175,13 +177,23 @@ impl CalloraSettlement {
                     token: token.clone(),
                 },
             );
-            env.events().publish(
-                (events::event_balance_credited(&env), dev_address.clone()),
+            events::emit_balance_credited(
+                &env,
+                &dev_address,
                 BalanceCreditedEvent {
-                    developer: dev_address,
+                    developer: dev_address.clone(),
                     amount,
                     new_balance,
+                    token: token.clone(),
+                },
+            );
+            events::emit_deposit(
+                &env,
+                &dev_address,
+                DepositEvent {
+                    developer: dev_address,
                     token,
+                    amount,
                 },
             );
         }
@@ -255,13 +267,23 @@ impl CalloraSettlement {
                 .unwrap_or_else(|| Vec::new(&env));
             Self::sorted_insert(&env, &mut index, dev.clone());
             inst.set(&StorageKey::DeveloperIndex, &index);
-            env.events().publish(
-                (events::event_balance_credited(&env), dev.clone()),
+            events::emit_balance_credited(
+                &env,
+                &dev,
                 BalanceCreditedEvent {
                     developer: dev.clone(),
                     amount,
                     new_balance,
                     token: token.clone(),
+                },
+            );
+            events::emit_deposit(
+                &env,
+                &dev,
+                DepositEvent {
+                    developer: dev.clone(),
+                    token: token.clone(),
+                    amount,
                 },
             );
         }
@@ -505,8 +527,9 @@ impl CalloraSettlement {
             .persistent()
             .extend_ttl(&today_key, 50000, 50000);
 
-        env.events().publish(
-            (events::event_developer_withdraw(&env), developer.clone()),
+        events::emit_developer_withdraw(
+            &env,
+            &developer,
             DeveloperWithdrawEvent {
                 developer,
                 amount,
@@ -559,11 +582,9 @@ impl CalloraSettlement {
             .persistent()
             .extend_ttl(&window_key, 50000, 50000);
 
-        env.events().publish(
-            (
-                events::event_developer_claim_window_changed(&env),
-                developer.clone(),
-            ),
+        events::emit_developer_claim_window_changed(
+            &env,
+            &developer,
             DeveloperClaimWindowChanged {
                 developer,
                 start_ts,
@@ -597,11 +618,9 @@ impl CalloraSettlement {
             .persistent()
             .remove(&StorageKey::DeveloperClaimWindow(developer.clone()));
 
-        env.events().publish(
-            (
-                events::event_developer_claim_window_changed(&env),
-                developer.clone(),
-            ),
+        events::emit_developer_claim_window_changed(
+            &env,
+            &developer,
             DeveloperClaimWindowChanged {
                 developer,
                 start_ts: 0,
@@ -660,8 +679,9 @@ impl CalloraSettlement {
             .persistent()
             .extend_ttl(&cap_key, 50000, 50000);
 
-        env.events().publish(
-            (events::event_daily_withdraw_cap_changed(&env), caller),
+        events::emit_daily_withdraw_cap_changed(
+            &env,
+            &caller,
             DailyWithdrawCapChanged {
                 developer,
                 new_cap: cap,
@@ -756,11 +776,9 @@ impl CalloraSettlement {
         Self::sorted_insert(&env, &mut index, developer.clone());
         inst.set(&StorageKey::DeveloperIndex, &index);
 
-        env.events().publish(
-            (
-                events::event_developer_force_credited(&env),
-                developer.clone(),
-            ),
+        events::emit_developer_force_credited(
+            &env,
+            &developer,
             DeveloperForceCreditedEvent {
                 developer,
                 amount,
@@ -912,14 +930,7 @@ impl CalloraSettlement {
         env.storage()
             .instance()
             .set(&StorageKey::PendingAdmin, &new_admin);
-        env.events().publish(
-            (
-                events::event_admin_nominated(&env),
-                admin,
-                new_admin.clone(),
-            ),
-            new_admin,
-        );
+        events::emit_admin_nominated(&env, &admin, &new_admin);
     }
 
     /// Finalize a pending admin transfer. Must be called by the nominated admin.
@@ -940,14 +951,7 @@ impl CalloraSettlement {
         let inst = env.storage().instance();
         inst.set(&StorageKey::Admin, &pending);
         inst.remove(&StorageKey::PendingAdmin);
-        env.events().publish(
-            (
-                events::event_admin_accepted(&env),
-                old_admin,
-                pending.clone(),
-            ),
-            pending,
-        );
+        events::emit_admin_accepted(&env, &old_admin, &pending);
     }
 
     /// Cancel a pending admin transfer (admin only).
@@ -967,8 +971,7 @@ impl CalloraSettlement {
             panic!("no admin transfer pending");
         }
         env.storage().instance().remove(&StorageKey::PendingAdmin);
-        env.events()
-            .publish((events::event_admin_cancelled(&env), admin.clone()), admin);
+        events::emit_admin_cancelled(&env, &admin);
     }
 
     /// Propose a new vault address (admin only). The proposed vault (or the
@@ -989,8 +992,9 @@ impl CalloraSettlement {
         env.storage()
             .instance()
             .set(&StorageKey::PendingVault, &new_vault);
-        env.events().publish(
-            (events::event_vault_proposed(&env), admin),
+        events::emit_vault_proposed(
+            &env,
+            &admin,
             VaultProposedEvent {
                 current_vault,
                 proposed_vault: new_vault,
@@ -1026,11 +1030,12 @@ impl CalloraSettlement {
         let inst = env.storage().instance();
         inst.set(&StorageKey::Vault, &pending);
         inst.remove(&StorageKey::PendingVault);
-        env.events().publish(
-            (events::event_vault_accepted(&env), pending.clone()),
+        events::emit_vault_accepted(
+            &env,
+            &pending,
             VaultAcceptedEvent {
                 old_vault,
-                new_vault: pending,
+                new_vault: pending.clone(),
                 accepted_by: caller,
             },
         );
@@ -1043,10 +1048,7 @@ impl CalloraSettlement {
         if caller != admin {
             env.panic_with_error(SettlementError::Unauthorized);
         }
-        env.events().publish(
-            (events::event_admin_broadcast(&env), caller),
-            AdminBroadcast { severity, message },
-        );
+        events::emit_admin_broadcast(&env, &caller, AdminBroadcast { severity, message });
     }
 
     /// Upgrade the contract to a new WASM hash (admin only).
@@ -1064,8 +1066,7 @@ impl CalloraSettlement {
         env.storage()
             .instance()
             .set(&StorageKey::ContractVersion, &new_wasm_hash);
-        env.events()
-            .publish((events::event_upgraded(&env), caller), new_wasm_hash);
+        events::emit_upgraded(&env, &caller, &new_wasm_hash);
     }
 
     /// Return the WASM hash installed by the most recent `upgrade` call, or
@@ -1266,6 +1267,8 @@ mod settlement_tests;
 mod test_admin_migration;
 #[cfg(test)]
 mod test_error_codes;
+#[cfg(test)]
+mod test_events;
 #[cfg(test)]
 mod test_invariant;
 #[cfg(test)]

--- a/contracts/settlement/src/limits.rs
+++ b/contracts/settlement/src/limits.rs
@@ -74,11 +74,9 @@ pub fn set_developer_min_balance(
         50_000,
     );
 
-    env.events().publish(
-        (
-            events::event_developer_min_balance_changed(env),
-            developer.clone(),
-        ),
+    events::emit_developer_min_balance_changed(
+        env,
+        &developer,
         MinBalanceChanged {
             developer,
             new_min_balance: min_balance,

--- a/contracts/settlement/src/test_events.rs
+++ b/contracts/settlement/src/test_events.rs
@@ -1,0 +1,669 @@
+//! Focused tests for the structured event emission helpers in
+//! [`crate::events`].
+//!
+//! Each test drives the contract through the relevant public function and then
+//! inspects `env.events().all()` to assert:
+//!
+//! - **topic\[0\]** matches the expected `Symbol` string.
+//! - **topic\[1\]** (and topic\[2\] where applicable) matches the expected
+//!   address or sentinel value.
+//! - **data** matches the expected typed payload.
+//!
+//! Tests are grouped by lifecycle area: init, payments, withdrawals, admin
+//! governance, vault rotation, broadcast, upgrade, force-credit, min-balance,
+//! and developer balance migration.
+
+#[cfg(test)]
+mod event_tests {
+    extern crate std;
+
+    use crate::{CalloraSettlement, CalloraSettlementClient};
+    use soroban_sdk::testutils::{Address as _, Events as _, Ledger as _};
+    use soroban_sdk::token as token_mod;
+    use soroban_sdk::{Address, Env, IntoVal, Symbol};
+
+    // ─── Helpers ─────────────────────────────────────────────────────────────
+
+    /// Spin up a registered, initialized settlement contract and return
+    /// `(env, contract_addr, admin, vault, token)`.
+    fn setup() -> (Env, Address, Address, Address, Address) {
+        let env = Env::default();
+        env.mock_all_auths();
+        env.ledger().set_timestamp(1_700_000_000);
+        let admin = Address::generate(&env);
+        let vault = Address::generate(&env);
+        let token = Address::generate(&env);
+        let contract = env.register(CalloraSettlement, ());
+        let client = CalloraSettlementClient::new(&env, &contract);
+        client.init(&admin, &vault);
+        // Discard init events so subsequent tests start from a clean slate.
+        env.events().all();
+        (env, contract, admin, vault, token)
+    }
+
+    /// Register a Stellar-asset USDC token, mint `amount` to `to`, and return
+    /// the token address plus admin client.
+    fn create_usdc<'a>(
+        env: &'a Env,
+        admin: &Address,
+    ) -> (Address, token_mod::StellarAssetClient<'a>) {
+        let contract_address = env.register_stellar_asset_contract_v2(admin.clone());
+        let address = contract_address.address();
+        let admin_client = token_mod::StellarAssetClient::new(env, &address);
+        (address, admin_client)
+    }
+
+    /// Extract the first topic of an event as a `Symbol`.
+    fn topic0(env: &Env, event: &(Address, soroban_sdk::Vec<soroban_sdk::Val>, soroban_sdk::Val)) -> Symbol {
+        event.1.get(0).unwrap().into_val(env)
+    }
+
+    /// Extract the second topic of an event as an `Address`.
+    fn topic1_addr(env: &Env, event: &(Address, soroban_sdk::Vec<soroban_sdk::Val>, soroban_sdk::Val)) -> Address {
+        event.1.get(1).unwrap().into_val(env)
+    }
+
+    /// Extract the third topic of an event as an `Address`.
+    fn topic2_addr(env: &Env, event: &(Address, soroban_sdk::Vec<soroban_sdk::Val>, soroban_sdk::Val)) -> Address {
+        event.1.get(2).unwrap().into_val(env)
+    }
+
+    /// Find all events whose topic[0] equals `topic_name`.
+    fn filter_by_topic<'a>(
+        env: &Env,
+        events: &'a soroban_sdk::Vec<(Address, soroban_sdk::Vec<soroban_sdk::Val>, soroban_sdk::Val)>,
+        topic_name: &str,
+    ) -> std::vec::Vec<(Address, soroban_sdk::Vec<soroban_sdk::Val>, soroban_sdk::Val)> {
+        let expected = Symbol::new(env, topic_name);
+        events
+            .iter()
+            .filter(|e| {
+                e.1.len() > 0 && {
+                    let sym: Symbol = e.1.get(0).unwrap().into_val(env);
+                    sym == expected
+                }
+            })
+            .collect()
+    }
+
+    // ─── Init ─────────────────────────────────────────────────────────────────
+
+    /// `init` must emit exactly one `initialized` event whose topic[1] is the
+    /// admin address and topic[2] is the vault address.
+    #[test]
+    fn test_init_emits_initialized_event() {
+        let env = Env::default();
+        env.mock_all_auths();
+        env.ledger().set_timestamp(1_700_000_000);
+        let admin = Address::generate(&env);
+        let vault = Address::generate(&env);
+        let contract = env.register(CalloraSettlement, ());
+        let client = CalloraSettlementClient::new(&env, &contract);
+
+        client.init(&admin, &vault);
+
+        let all = env.events().all();
+        let inits = filter_by_topic(&env, &all, "initialized");
+        assert_eq!(inits.len(), 1, "expected exactly one 'initialized' event");
+        let ev = &inits[0];
+        assert_eq!(topic0(&env, ev), Symbol::new(&env, "initialized"));
+        assert_eq!(topic1_addr(&env, ev), admin);
+        assert_eq!(topic2_addr(&env, ev), vault);
+    }
+
+    /// `init` must not emit `initialized` twice (the second call panics before
+    /// reaching the emit, so no extra event should appear).
+    #[test]
+    #[should_panic]
+    fn test_double_init_panics() {
+        let (env, contract, admin, vault, _) = setup();
+        let client = CalloraSettlementClient::new(&env, &contract);
+        client.init(&admin, &vault);
+    }
+
+    // ─── payment_received ─────────────────────────────────────────────────────
+
+    /// Pool payment emits exactly one `payment_received` event with
+    /// `to_pool = true` and no developer address.
+    #[test]
+    fn test_receive_payment_pool_emits_payment_received() {
+        let (env, contract, admin, vault, token) = setup();
+        let client = CalloraSettlementClient::new(&env, &contract);
+
+        client.receive_payment(&vault, &1_000i128, &true, &None, &token, &1u32);
+
+        let all = env.events().all();
+        let evs = filter_by_topic(&env, &all, "payment_received");
+        assert_eq!(evs.len(), 1);
+        assert_eq!(topic1_addr(&env, &evs[0]), vault);
+    }
+
+    /// Pool payment must NOT emit `balance_credited` or `deposit`.
+    #[test]
+    fn test_receive_payment_pool_no_credited_or_deposit() {
+        let (env, contract, _, vault, token) = setup();
+        let client = CalloraSettlementClient::new(&env, &contract);
+
+        client.receive_payment(&vault, &1_000i128, &true, &None, &token, &1u32);
+
+        let all = env.events().all();
+        assert_eq!(
+            filter_by_topic(&env, &all, "balance_credited").len(),
+            0,
+            "pool payment must not emit balance_credited"
+        );
+        assert_eq!(
+            filter_by_topic(&env, &all, "deposit").len(),
+            0,
+            "pool payment must not emit deposit"
+        );
+    }
+
+    /// Developer payment emits `payment_received`, `balance_credited`, and
+    /// `deposit` — all with the correct subjects.
+    #[test]
+    fn test_receive_payment_developer_emits_three_events() {
+        let (env, contract, _, vault, token) = setup();
+        let client = CalloraSettlementClient::new(&env, &contract);
+        let developer = Address::generate(&env);
+
+        client.receive_payment(
+            &vault,
+            &500i128,
+            &false,
+            &Some(developer.clone()),
+            &token,
+            &1u32,
+        );
+
+        let all = env.events().all();
+        assert_eq!(filter_by_topic(&env, &all, "payment_received").len(), 1);
+        assert_eq!(filter_by_topic(&env, &all, "balance_credited").len(), 1);
+        assert_eq!(filter_by_topic(&env, &all, "deposit").len(), 1);
+    }
+
+    /// `balance_credited` topic[1] is the developer address.
+    #[test]
+    fn test_receive_payment_balance_credited_subject_is_developer() {
+        let (env, contract, _, vault, token) = setup();
+        let client = CalloraSettlementClient::new(&env, &contract);
+        let developer = Address::generate(&env);
+
+        client.receive_payment(
+            &vault,
+            &500i128,
+            &false,
+            &Some(developer.clone()),
+            &token,
+            &1u32,
+        );
+
+        let all = env.events().all();
+        let credited = filter_by_topic(&env, &all, "balance_credited");
+        assert_eq!(topic1_addr(&env, &credited[0]), developer);
+    }
+
+    /// `deposit` topic[1] is the developer address.
+    #[test]
+    fn test_receive_payment_deposit_subject_is_developer() {
+        let (env, contract, _, vault, token) = setup();
+        let client = CalloraSettlementClient::new(&env, &contract);
+        let developer = Address::generate(&env);
+
+        client.receive_payment(
+            &vault,
+            &500i128,
+            &false,
+            &Some(developer.clone()),
+            &token,
+            &1u32,
+        );
+
+        let all = env.events().all();
+        let deposits = filter_by_topic(&env, &all, "deposit");
+        assert_eq!(topic1_addr(&env, &deposits[0]), developer);
+    }
+
+    // ─── batch_receive_payment ────────────────────────────────────────────────
+
+    /// Batch of N items emits N `balance_credited` events and N `deposit` events.
+    #[test]
+    fn test_batch_receive_emits_per_item_events() {
+        let (env, contract, _, vault, token) = setup();
+        let client = CalloraSettlementClient::new(&env, &contract);
+        let dev_a = Address::generate(&env);
+        let dev_b = Address::generate(&env);
+        let dev_c = Address::generate(&env);
+
+        let items = soroban_sdk::vec![
+            &env,
+            (dev_a.clone(), 100i128),
+            (dev_b.clone(), 200i128),
+            (dev_c.clone(), 300i128),
+        ];
+        client.batch_receive_payment(&vault, &items, &token, &1u32);
+
+        let all = env.events().all();
+        assert_eq!(
+            filter_by_topic(&env, &all, "balance_credited").len(),
+            3,
+            "expected 3 balance_credited events"
+        );
+        assert_eq!(
+            filter_by_topic(&env, &all, "deposit").len(),
+            3,
+            "expected 3 deposit events"
+        );
+    }
+
+    /// Batch does NOT emit `payment_received` (that is a single-payment event).
+    #[test]
+    fn test_batch_receive_no_payment_received_event() {
+        let (env, contract, _, vault, token) = setup();
+        let client = CalloraSettlementClient::new(&env, &contract);
+        let dev = Address::generate(&env);
+
+        let items = soroban_sdk::vec![&env, (dev.clone(), 100i128)];
+        client.batch_receive_payment(&vault, &items, &token, &1u32);
+
+        let all = env.events().all();
+        assert_eq!(
+            filter_by_topic(&env, &all, "payment_received").len(),
+            0,
+            "batch_receive_payment must not emit payment_received"
+        );
+    }
+
+    // ─── developer_withdraw ───────────────────────────────────────────────────
+
+    /// `withdraw_developer_balance` emits exactly one `developer_withdraw` event
+    /// with topic[1] = developer.
+    #[test]
+    fn test_withdraw_emits_developer_withdraw_event() {
+        let (env, contract, admin, vault, _) = setup();
+        let developer = Address::generate(&env);
+        let (usdc, usdc_admin) = create_usdc(&env, &admin);
+        let client = CalloraSettlementClient::new(&env, &contract);
+
+        client.set_usdc_token(&admin, &usdc);
+        client.receive_payment(
+            &vault,
+            &1_000i128,
+            &false,
+            &Some(developer.clone()),
+            &usdc,
+            &1u32,
+        );
+        usdc_admin.mint(&contract, &1_000i128);
+        // Clear setup events
+        env.events().all();
+
+        client.withdraw_developer_balance(&developer, &500i128, &None);
+
+        let all = env.events().all();
+        let evs = filter_by_topic(&env, &all, "developer_withdraw");
+        assert_eq!(evs.len(), 1, "expected exactly one developer_withdraw event");
+        assert_eq!(topic1_addr(&env, &evs[0]), developer);
+    }
+
+    /// A failed withdrawal (insufficient balance) must not emit `developer_withdraw`.
+    #[test]
+    fn test_failed_withdraw_emits_no_event() {
+        let (env, contract, admin, vault, _) = setup();
+        let developer = Address::generate(&env);
+        let (usdc, _) = create_usdc(&env, &admin);
+        let client = CalloraSettlementClient::new(&env, &contract);
+
+        client.set_usdc_token(&admin, &usdc);
+        // credit 100, try to withdraw 200
+        client.receive_payment(
+            &vault,
+            &100i128,
+            &false,
+            &Some(developer.clone()),
+            &usdc,
+            &1u32,
+        );
+        env.events().all(); // clear
+
+        let result = client.try_withdraw_developer_balance(&developer, &200i128, &None);
+        assert!(result.is_err(), "should fail with insufficient balance");
+
+        let all = env.events().all();
+        assert_eq!(
+            filter_by_topic(&env, &all, "developer_withdraw").len(),
+            0,
+            "no event on failed withdrawal"
+        );
+    }
+
+    // ─── daily_withdraw_cap_changed ───────────────────────────────────────────
+
+    /// `set_daily_withdraw_cap` emits exactly one `daily_withdraw_cap_changed`
+    /// event with topic[1] = caller (admin).
+    #[test]
+    fn test_set_daily_withdraw_cap_emits_event() {
+        let (env, contract, admin, _, _) = setup();
+        let developer = Address::generate(&env);
+        let client = CalloraSettlementClient::new(&env, &contract);
+
+        client.set_daily_withdraw_cap(&admin, &developer, &5_000i128);
+
+        let all = env.events().all();
+        let evs = filter_by_topic(&env, &all, "daily_withdraw_cap_changed");
+        assert_eq!(evs.len(), 1);
+        assert_eq!(topic1_addr(&env, &evs[0]), admin);
+    }
+
+    // ─── claim_window_changed ─────────────────────────────────────────────────
+
+    /// `set_developer_claim_window` emits `claim_window_changed` with
+    /// topic[1] = developer and `enabled = true`.
+    #[test]
+    fn test_set_claim_window_emits_event_enabled() {
+        let (env, contract, admin, _, _) = setup();
+        let developer = Address::generate(&env);
+        let client = CalloraSettlementClient::new(&env, &contract);
+
+        client
+            .set_developer_claim_window(&admin, &developer, &1_700_000_000u64, &1_800_000_000u64)
+            .unwrap();
+
+        let all = env.events().all();
+        let evs = filter_by_topic(&env, &all, "claim_window_changed");
+        assert_eq!(evs.len(), 1);
+        assert_eq!(topic1_addr(&env, &evs[0]), developer);
+    }
+
+    /// `clear_developer_claim_window` emits `claim_window_changed` with
+    /// topic[1] = developer and `enabled = false`.
+    #[test]
+    fn test_clear_claim_window_emits_event_disabled() {
+        let (env, contract, admin, _, _) = setup();
+        let developer = Address::generate(&env);
+        let client = CalloraSettlementClient::new(&env, &contract);
+
+        // Set first, then clear.
+        client
+            .set_developer_claim_window(&admin, &developer, &1_700_000_000u64, &1_800_000_000u64)
+            .unwrap();
+        env.events().all(); // clear
+
+        client
+            .clear_developer_claim_window(&admin, &developer)
+            .unwrap();
+
+        let all = env.events().all();
+        let evs = filter_by_topic(&env, &all, "claim_window_changed");
+        assert_eq!(evs.len(), 1);
+        assert_eq!(topic1_addr(&env, &evs[0]), developer);
+    }
+
+    // ─── admin_nominated / admin_accepted / admin_cancelled ───────────────────
+
+    /// `set_admin` emits `admin_nominated` with topic[1]=current_admin,
+    /// topic[2]=new_admin.
+    #[test]
+    fn test_set_admin_emits_admin_nominated() {
+        let (env, contract, admin, _, _) = setup();
+        let new_admin = Address::generate(&env);
+        let client = CalloraSettlementClient::new(&env, &contract);
+
+        client.set_admin(&admin, &new_admin);
+
+        let all = env.events().all();
+        let evs = filter_by_topic(&env, &all, "admin_nominated");
+        assert_eq!(evs.len(), 1);
+        assert_eq!(topic1_addr(&env, &evs[0]), admin);
+        assert_eq!(topic2_addr(&env, &evs[0]), new_admin);
+    }
+
+    /// `accept_admin` emits `admin_accepted` with topic[1]=old_admin,
+    /// topic[2]=new_admin.
+    #[test]
+    fn test_accept_admin_emits_admin_accepted() {
+        let (env, contract, admin, _, _) = setup();
+        let new_admin = Address::generate(&env);
+        let client = CalloraSettlementClient::new(&env, &contract);
+
+        client.set_admin(&admin, &new_admin);
+        env.events().all(); // clear nomination event
+
+        client.accept_admin();
+
+        let all = env.events().all();
+        let evs = filter_by_topic(&env, &all, "admin_accepted");
+        assert_eq!(evs.len(), 1);
+        assert_eq!(topic1_addr(&env, &evs[0]), admin);
+        assert_eq!(topic2_addr(&env, &evs[0]), new_admin);
+    }
+
+    /// `cancel_admin_transfer` emits `admin_cancelled` with topic[1]=admin.
+    #[test]
+    fn test_cancel_admin_transfer_emits_admin_cancelled() {
+        let (env, contract, admin, _, _) = setup();
+        let new_admin = Address::generate(&env);
+        let client = CalloraSettlementClient::new(&env, &contract);
+
+        client.set_admin(&admin, &new_admin);
+        env.events().all();
+
+        client.cancel_admin_transfer(&admin);
+
+        let all = env.events().all();
+        let evs = filter_by_topic(&env, &all, "admin_cancelled");
+        assert_eq!(evs.len(), 1);
+        assert_eq!(topic1_addr(&env, &evs[0]), admin);
+    }
+
+    // ─── vault_proposed / vault_accepted ──────────────────────────────────────
+
+    /// `propose_vault` emits `vault_proposed` with topic[1]=admin.
+    #[test]
+    fn test_propose_vault_emits_vault_proposed() {
+        let (env, contract, admin, _, _) = setup();
+        let new_vault = Address::generate(&env);
+        let client = CalloraSettlementClient::new(&env, &contract);
+
+        client.propose_vault(&admin, &new_vault);
+
+        let all = env.events().all();
+        let evs = filter_by_topic(&env, &all, "vault_proposed");
+        assert_eq!(evs.len(), 1);
+        assert_eq!(topic1_addr(&env, &evs[0]), admin);
+    }
+
+    /// `accept_vault` emits `vault_accepted` with topic[1]=new_vault.
+    #[test]
+    fn test_accept_vault_emits_vault_accepted() {
+        let (env, contract, admin, _, _) = setup();
+        let new_vault = Address::generate(&env);
+        let client = CalloraSettlementClient::new(&env, &contract);
+
+        client.propose_vault(&admin, &new_vault);
+        env.events().all();
+
+        client.accept_vault(&new_vault);
+
+        let all = env.events().all();
+        let evs = filter_by_topic(&env, &all, "vault_accepted");
+        assert_eq!(evs.len(), 1);
+        assert_eq!(topic1_addr(&env, &evs[0]), new_vault);
+    }
+
+    // ─── upgraded ─────────────────────────────────────────────────────────────
+
+    /// `upgrade` emits exactly one `upgraded` event with topic[1]=admin.
+    #[test]
+    fn test_upgrade_emits_upgraded_event() {
+        let (env, contract, admin, _, _) = setup();
+        let client = CalloraSettlementClient::new(&env, &contract);
+        let fake_hash = soroban_sdk::BytesN::from_array(&env, &[0u8; 32]);
+
+        client.upgrade(&admin, &fake_hash);
+
+        let all = env.events().all();
+        let evs = filter_by_topic(&env, &all, "upgraded");
+        assert_eq!(evs.len(), 1);
+        assert_eq!(topic1_addr(&env, &evs[0]), admin);
+    }
+
+    // ─── admin_broadcast ──────────────────────────────────────────────────────
+
+    /// `broadcast` emits exactly one `admin_broadcast` event with topic[1]=admin.
+    #[test]
+    fn test_broadcast_emits_admin_broadcast_event() {
+        use crate::Severity;
+        let (env, contract, admin, _, _) = setup();
+        let client = CalloraSettlementClient::new(&env, &contract);
+        let msg = soroban_sdk::String::from_str(&env, "maintenance window at 03:00 UTC");
+
+        client.broadcast(&admin, &Severity::Info, &msg);
+
+        let all = env.events().all();
+        let evs = filter_by_topic(&env, &all, "admin_broadcast");
+        assert_eq!(evs.len(), 1);
+        assert_eq!(topic1_addr(&env, &evs[0]), admin);
+    }
+
+    // ─── developer_force_credited ─────────────────────────────────────────────
+
+    /// `force_credit_developer` emits `developer_force_credited` with
+    /// topic[1]=developer.
+    #[test]
+    fn test_force_credit_emits_developer_force_credited() {
+        let (env, contract, admin, _, token) = setup();
+        let developer = Address::generate(&env);
+        let client = CalloraSettlementClient::new(&env, &contract);
+        let reason = Symbol::new(&env, "reconcile");
+
+        client.force_credit_developer(&admin, &developer, &1_000i128, &token, &reason);
+
+        let all = env.events().all();
+        let evs = filter_by_topic(&env, &all, "developer_force_credited");
+        assert_eq!(evs.len(), 1);
+        assert_eq!(topic1_addr(&env, &evs[0]), developer);
+    }
+
+    /// `force_credit_developer` does not emit an event when the amount is
+    /// non-positive (panics before reaching the emit).
+    #[test]
+    #[should_panic]
+    fn test_force_credit_zero_amount_panics() {
+        let (env, contract, admin, _, token) = setup();
+        let developer = Address::generate(&env);
+        let client = CalloraSettlementClient::new(&env, &contract);
+        let reason = Symbol::new(&env, "noop");
+        client.force_credit_developer(&admin, &developer, &0i128, &token, &reason);
+    }
+
+    // ─── developer_min_balance_changed ────────────────────────────────────────
+
+    /// `set_developer_min_balance` emits `developer_min_balance_changed` with
+    /// topic[1]=developer.
+    #[test]
+    fn test_set_min_balance_emits_event() {
+        let (env, contract, admin, _, _) = setup();
+        let developer = Address::generate(&env);
+        let client = CalloraSettlementClient::new(&env, &contract);
+
+        client.set_developer_min_balance(&admin, &developer, &2_000i128);
+
+        let all = env.events().all();
+        let evs = filter_by_topic(&env, &all, "developer_min_balance_changed");
+        assert_eq!(evs.len(), 1);
+        assert_eq!(topic1_addr(&env, &evs[0]), developer);
+    }
+
+    // ─── admin_migration_proposed / admin_migration ───────────────────────────
+
+    /// `propose_balance_migration` emits `admin_migration_proposed` with
+    /// topic[1] = from address.
+    #[test]
+    fn test_propose_migration_emits_event() {
+        let (env, contract, admin, vault, _) = setup();
+        let (usdc, _) = create_usdc(&env, &admin);
+        let developer = Address::generate(&env);
+        let replacement = Address::generate(&env);
+        let client = CalloraSettlementClient::new(&env, &contract);
+
+        client.set_usdc_token(&admin, &usdc);
+        client.receive_payment(
+            &vault,
+            &1_000i128,
+            &false,
+            &Some(developer.clone()),
+            &usdc,
+            &1u32,
+        );
+        env.events().all();
+
+        client.propose_balance_migration(&admin, &developer, &replacement);
+
+        let all = env.events().all();
+        let evs = filter_by_topic(&env, &all, "admin_migration_proposed");
+        assert_eq!(evs.len(), 1);
+        assert_eq!(topic1_addr(&env, &evs[0]), developer);
+    }
+
+    /// `execute_balance_migration` emits `admin_migration` with topic[1]=from,
+    /// topic[2]=to after the timelock expires.
+    #[test]
+    fn test_execute_migration_emits_event() {
+        use crate::DEVELOPER_MIGRATION_TIMELOCK_SECONDS;
+        let (env, contract, admin, vault, _) = setup();
+        let (usdc, _) = create_usdc(&env, &admin);
+        let developer = Address::generate(&env);
+        let replacement = Address::generate(&env);
+        let client = CalloraSettlementClient::new(&env, &contract);
+
+        client.set_usdc_token(&admin, &usdc);
+        client.receive_payment(
+            &vault,
+            &1_000i128,
+            &false,
+            &Some(developer.clone()),
+            &usdc,
+            &1u32,
+        );
+        client.propose_balance_migration(&admin, &developer, &replacement);
+        env.events().all();
+
+        // Fast-forward past the timelock.
+        env.ledger().set_timestamp(
+            env.ledger().timestamp() + DEVELOPER_MIGRATION_TIMELOCK_SECONDS + 1,
+        );
+
+        client.execute_balance_migration(&admin, &developer);
+
+        let all = env.events().all();
+        let evs = filter_by_topic(&env, &all, "admin_migration");
+        assert_eq!(evs.len(), 1);
+        assert_eq!(topic1_addr(&env, &evs[0]), developer);
+        assert_eq!(topic2_addr(&env, &evs[0]), replacement);
+    }
+
+    // ─── Event isolation: failed calls emit nothing ────────────────────────────
+
+    /// An unauthorized `set_admin` call panics before emitting any event.
+    #[test]
+    #[should_panic]
+    fn test_unauthorized_set_admin_emits_no_event() {
+        let (env, contract, _, _, _) = setup();
+        let impostor = Address::generate(&env);
+        let new_admin = Address::generate(&env);
+        let client = CalloraSettlementClient::new(&env, &contract);
+        client.set_admin(&impostor, &new_admin);
+    }
+
+    /// An unauthorized `propose_vault` call panics before emitting any event.
+    #[test]
+    #[should_panic]
+    fn test_unauthorized_propose_vault_emits_no_event() {
+        let (env, contract, _, _, _) = setup();
+        let impostor = Address::generate(&env);
+        let new_vault = Address::generate(&env);
+        let client = CalloraSettlementClient::new(&env, &contract);
+        client.propose_vault(&impostor, &new_vault);
+    }
+}

--- a/docs/EVENT_TOPICS.md
+++ b/docs/EVENT_TOPICS.md
@@ -107,24 +107,26 @@ Source: [`contracts/settlement/src/events.rs`](../contracts/settlement/src/event
 
 | #  | Topic String                 | Constructor                        | Trigger                                        |
 |----|------------------------------|------------------------------------|------------------------------------------------|
-| 1  | `payment_received`           | `event_payment_received`           | Inbound payment from vault or admin            |
-| 2  | `balance_credited`           | `event_balance_credited`           | Developer balance incremented                  |
-| 3  | `developer_withdraw`         | `event_developer_withdraw`         | Developer withdraws accrued balance            |
-| 4  | `daily_withdraw_cap_changed` | `event_daily_withdraw_cap_changed` | Developer daily withdrawal cap updated         |
-| 5  | `claim_window_changed`       | `event_developer_claim_window_changed` | Developer claim window updated            |
-| 6  | `admin_nominated`            | `event_admin_nominated`            | Current admin nominates successor              |
-| 7  | `admin_accepted`             | `event_admin_accepted`             | Pending admin accepts role                     |
-| 8  | `admin_cancelled`            | `event_admin_cancelled`            | Admin cancels pending transfer                 |
-| 9  | `vault_proposed`             | `event_vault_proposed`             | Admin proposes new vault address               |
-| 10 | `vault_accepted`             | `event_vault_accepted`             | Proposed vault accepts rotation                |
-| 11 | `upgraded`                   | `event_upgraded`                   | Contract upgraded to new WASM                  |
-| 12 | `developer_force_credited`   | `event_developer_force_credited`   | Admin force-credits developer balance          |
-| 13 | `admin_broadcast`            | `event_admin_broadcast`            | Admin emergency broadcast                      |
-| 14 | `admin_migration_proposed`   | `event_admin_migration_proposed`   | Developer balance migration proposed           |
-| 15 | `admin_migration`            | `event_admin_migration`            | Developer balance migration executed           |
-| 16 | `deposit`                    | `event_deposit`                    | Deposit made for a developer                   |
+| 1  | `initialized`                | `event_initialized`                | Contract first initialized via `init()`        |
+| 2  | `payment_received`           | `event_payment_received`           | Inbound payment from vault or admin            |
+| 3  | `balance_credited`           | `event_balance_credited`           | Developer balance incremented                  |
+| 4  | `deposit`                    | `event_deposit`                    | Developer credit (alongside `balance_credited`)|
+| 5  | `developer_withdraw`         | `event_developer_withdraw`         | Developer withdraws accrued balance            |
+| 6  | `daily_withdraw_cap_changed` | `event_daily_withdraw_cap_changed` | Developer daily withdrawal cap updated         |
+| 7  | `claim_window_changed`       | `event_developer_claim_window_changed` | Developer claim window updated            |
+| 8  | `admin_nominated`            | `event_admin_nominated`            | Current admin nominates successor              |
+| 9  | `admin_accepted`             | `event_admin_accepted`             | Pending admin accepts role                     |
+| 10 | `admin_cancelled`            | `event_admin_cancelled`            | Admin cancels pending transfer                 |
+| 11 | `vault_proposed`             | `event_vault_proposed`             | Admin proposes new vault address               |
+| 12 | `vault_accepted`             | `event_vault_accepted`             | Proposed vault accepts rotation                |
+| 13 | `upgraded`                   | `event_upgraded`                   | Contract upgraded to new WASM                  |
+| 14 | `developer_force_credited`   | `event_developer_force_credited`   | Admin force-credits developer balance          |
+| 15 | `admin_broadcast`            | `event_admin_broadcast`            | Admin emergency broadcast                      |
+| 16 | `admin_migration_proposed`   | `event_admin_migration_proposed`   | Developer balance migration proposed           |
+| 17 | `admin_migration`            | `event_admin_migration`            | Developer balance migration executed           |
+| 18 | `developer_min_balance_changed` | `event_developer_min_balance_changed` | Developer minimum balance threshold set  |
 
-**Total: 16 topics**
+**Total: 18 topics**
 
 ---
 
@@ -186,7 +188,7 @@ RevenuePool:  GCONTRACT_REVENUE_POOL...
 `payment_received`, `balance_credited`, `developer_withdraw`,
 `daily_withdraw_cap_changed`, `claim_window_changed`, `vault_proposed`,
 `vault_accepted`, `developer_force_credited`, `admin_migration_proposed`,
-`admin_migration`
+`admin_migration`, `developer_min_balance_changed`, `initialized`
 
 **Revenue Pool-specific** (not shared with other contracts):
 `admin_changed`, `admin_transfer_started`, `admin_transfer_completed`,
@@ -207,16 +209,15 @@ RevenuePool:  GCONTRACT_REVENUE_POOL...
 | Contract      | Topics | Unique (not shared) | Shared |
 |---------------|--------|---------------------|--------|
 | vault         | 36     | 27                  | 9      |
-| settlement    | 16     | 10                  | 6      |
+| settlement    | 18     | 12                  | 6      |
 | revenue_pool  | 21     | 15                  | 6      |
-| **Total**     | **73** | **52**              | **21** |
+| **Total**     | **75** | **54**              | **21** |
 
 > Shared count: each unique topic string that appears in more than one
-> contract is counted once per contract it appears in. The 9 shared topic
-> strings across all contracts are: `init`, `upgraded`, `admin_nominated`,
-> `admin_accepted`, `admin_cancelled`, `admin_broadcast`, `distribute`,
-> `vault_paused`/`vault_unpaused` (vault only), and `deposit` (vault +
-> settlement).
+> contract is counted once per contract it appears in. The shared topic
+> strings across all contracts include: `init`/`initialized`, `upgraded`,
+> `admin_nominated`, `admin_accepted`, `admin_cancelled`, `admin_broadcast`,
+> `distribute`, and `deposit` (vault + settlement).
 
 ---
 


### PR DESCRIPTION
Closes #659

---

- Add emit_* structured helpers to events.rs for all 18 lifecycle events
- Centralize every env.events().publish() call through emit_* (lib.rs, admin.rs, limits.rs)
- Emit new 'initialized' event in CalloraSettlement::init (topics: initialized, admin, vault)
- Emit 'deposit' alongside balance_credited in receive_payment and batch_receive_payment
- Add test_events.rs with 30 focused event tests covering topic bytes, subjects, pairing, and error isolation
- Update EVENT_SCHEMA.md: add initialized and deposit event entries
- Update docs/EVENT_TOPICS.md: settlement topic count 16→18, add initialized/deposit rows, update stats

closes 