### PR TITLE
fix: bump TTL on checkpoint storage reads (buffer #26)

### DIFF
--- a/contracts/checkpoint/src/lib.rs
+++ b/contracts/checkpoint/src/lib.rs
@@ -451,14 +451,28 @@ impl CalloraCheckpoint {
 
     /// Return a single checkpoint record by its unique ID.
     ///
+    /// Reading a checkpoint bumps its persistent TTL (buffer #26): audit
+    /// records that are queried often but rarely rewritten would otherwise
+    /// keep counting down to archival on the strength of their original
+    /// write-time bump alone. A read extends the same [`LIFETIME_THRESHOLD`]
+    /// / [`BUMP_AMOUNT`] window used at write time.
+    ///
     /// # Errors
     /// * [`CheckpointError::CheckpointNotFound`] -- no checkpoint exists with
     ///   the requested ID.
     pub fn get_checkpoint(env: Env, id: u64) -> Result<CheckpointRecord, CheckpointError> {
+        let key = StorageKey::Checkpoint(id);
+        let record = env
+            .storage()
+            .persistent()
+            .get(&key)
+            .ok_or(CheckpointError::CheckpointNotFound)?;
+
         env.storage()
             .persistent()
-            .get(&StorageKey::Checkpoint(id))
-            .ok_or(CheckpointError::CheckpointNotFound)
+            .extend_ttl(&key, LIFETIME_THRESHOLD, BUMP_AMOUNT);
+
+        Ok(record)
     }
 
     /// Return a paginated range of checkpoint records.
@@ -470,6 +484,9 @@ impl CalloraCheckpoint {
     /// Checkpoint IDs are sequential starting at 1, so a query with
     /// `start_id = 1, limit = 50` returns the first 50 checkpoints
     /// (or fewer if fewer exist).
+    ///
+    /// Every record returned has its persistent TTL bumped (buffer #26),
+    /// same as [`CalloraCheckpoint::get_checkpoint`].
     ///
     /// # Parameters
     /// * `start_id` -- The first checkpoint ID to retrieve (inclusive, 1-based).
@@ -502,7 +519,11 @@ impl CalloraCheckpoint {
 
         let mut result: Vec<CheckpointRecord> = Vec::new(&env);
         for id in start_id..end_id {
-            if let Some(record) = env.storage().persistent().get(&StorageKey::Checkpoint(id)) {
+            let key = StorageKey::Checkpoint(id);
+            if let Some(record) = env.storage().persistent().get(&key) {
+                env.storage()
+                    .persistent()
+                    .extend_ttl(&key, LIFETIME_THRESHOLD, BUMP_AMOUNT);
                 result.push_back(record);
             }
         }
@@ -537,15 +558,14 @@ impl CalloraCheckpoint {
     ///
     /// This is a convenience wrapper around
     /// [`CalloraCheckpoint::get_latest_checkpoint_id`] and
-    /// [`CalloraCheckpoint::get_checkpoint`].
+    /// [`CalloraCheckpoint::get_checkpoint`], and so also bumps the
+    /// returned record's persistent TTL (buffer #26).
     pub fn get_latest_checkpoint(env: Env) -> Option<CheckpointRecord> {
         let latest_id = Self::get_latest_checkpoint_id(env.clone());
         if latest_id == 0 {
             return None;
         }
-        env.storage()
-            .persistent()
-            .get(&StorageKey::Checkpoint(latest_id))
+        Self::get_checkpoint(env, latest_id).ok()
     }
 
     // -----------------------------------------------------------------------

--- a/contracts/checkpoint/src/test.rs
+++ b/contracts/checkpoint/src/test.rs
@@ -1,5 +1,8 @@
-use crate::{CalloraCheckpoint, CalloraCheckpointClient, MAX_BATCH_SIZE, MAX_PAGE_SIZE};
-use soroban_sdk::testutils::Address as _;
+use crate::{
+    CalloraCheckpoint, CalloraCheckpointClient, StorageKey, BUMP_AMOUNT, LIFETIME_THRESHOLD,
+    MAX_BATCH_SIZE, MAX_PAGE_SIZE,
+};
+use soroban_sdk::testutils::{Address as _, Ledger as _};
 use soroban_sdk::{Address, BytesN, Env, Symbol, Vec};
 
 /// Helper: initialise a fresh checkpoint contract and return `(env, admin, client)`.
@@ -521,6 +524,131 @@ fn test_bump_checkpoints_ttl_range_skips_missing_ids() {
     // Bump range 1–3 should not error on missing ID 2.
     let result = client.try_bump_checkpoints_ttl_range(&admin, &1u64, &3u64);
     assert!(result.is_ok());
+}
+
+// ===========================================================================
+// Read-path TTL bump tests (buffer #26)
+// ===========================================================================
+//
+// Write paths (`create_checkpoint`, `batch_create_checkpoints`) and the
+// explicit admin bump entrypoints already extend a checkpoint's persistent
+// TTL. These tests cover the remaining gap: hot *read* paths
+// (`get_checkpoint`, `get_checkpoints_range`, `get_latest_checkpoint`) must
+// also extend TTL, so an audit record that is queried often but never
+// rewritten does not silently archive.
+
+#[test]
+fn test_get_checkpoint_bumps_ttl_on_read() {
+    let (env, admin, client) = setup();
+    let subject = Address::generate(&env);
+    let token = Address::generate(&env);
+    let meta = Symbol::new(&env, "read_bump");
+
+    let id = client.create_checkpoint(&admin, &subject, &token, &1000i128, &meta);
+    let key = StorageKey::Checkpoint(id);
+
+    // Advance the ledger until the write-path bump's TTL has dropped below
+    // the threshold, but the entry has not yet expired.
+    let seq = env.ledger().sequence();
+    env.ledger()
+        .set_sequence_number(seq + BUMP_AMOUNT - LIFETIME_THRESHOLD + 1);
+
+    let ttl_before = env.storage().persistent().get_ttl(&key);
+    assert!(
+        ttl_before < LIFETIME_THRESHOLD,
+        "sanity: TTL should be below the bump threshold before the read"
+    );
+
+    // The read must bump TTL back out to BUMP_AMOUNT from the current ledger.
+    let record = client.get_checkpoint(&id);
+    assert_eq!(record.balance, 1000);
+
+    let ttl_after = env.storage().persistent().get_ttl(&key);
+    assert_eq!(
+        ttl_after, BUMP_AMOUNT,
+        "buffer #26: get_checkpoint must bump TTL back to BUMP_AMOUNT"
+    );
+}
+
+#[test]
+fn test_get_checkpoints_range_bumps_ttl_for_every_returned_record() {
+    let (env, admin, client) = setup();
+    let subject = Address::generate(&env);
+    let token = Address::generate(&env);
+    let meta = Symbol::new(&env, "range_read_bump");
+
+    for i in 1..=3u64 {
+        client.create_checkpoint(&admin, &subject, &token, &(i as i128 * 10), &meta);
+    }
+
+    let seq = env.ledger().sequence();
+    env.ledger()
+        .set_sequence_number(seq + BUMP_AMOUNT - LIFETIME_THRESHOLD + 1);
+
+    let results = client.get_checkpoints_range(&1u64, &10u32);
+    assert_eq!(results.len(), 3);
+
+    for id in 1..=3u64 {
+        let key = StorageKey::Checkpoint(id);
+        let ttl = env.storage().persistent().get_ttl(&key);
+        assert_eq!(
+            ttl, BUMP_AMOUNT,
+            "buffer #26: get_checkpoints_range must bump TTL for checkpoint {id}"
+        );
+    }
+}
+
+#[test]
+fn test_get_latest_checkpoint_bumps_ttl_on_read() {
+    let (env, admin, client) = setup();
+    let subject = Address::generate(&env);
+    let token = Address::generate(&env);
+    let meta = Symbol::new(&env, "latest_read_bump");
+
+    client.create_checkpoint(&admin, &subject, &token, &500i128, &meta);
+    let id = client.create_checkpoint(&admin, &subject, &token, &900i128, &meta);
+    let key = StorageKey::Checkpoint(id);
+
+    let seq = env.ledger().sequence();
+    env.ledger()
+        .set_sequence_number(seq + BUMP_AMOUNT - LIFETIME_THRESHOLD + 1);
+
+    let latest = client.get_latest_checkpoint().unwrap();
+    assert_eq!(latest.id, id);
+
+    let ttl = env.storage().persistent().get_ttl(&key);
+    assert_eq!(
+        ttl, BUMP_AMOUNT,
+        "buffer #26: get_latest_checkpoint must bump TTL of the returned record"
+    );
+}
+
+#[test]
+fn test_get_checkpoint_ttl_survives_past_original_bump_window() {
+    // Without the read-path bump, this checkpoint would archive at
+    // seq_init + BUMP_AMOUNT. A read before that point must push the
+    // expiry further out, so a *second* advance past the original window
+    // still finds the record alive.
+    let (env, admin, client) = setup();
+    let subject = Address::generate(&env);
+    let token = Address::generate(&env);
+    let meta = Symbol::new(&env, "survive");
+
+    let id = client.create_checkpoint(&admin, &subject, &token, &42i128, &meta);
+    let seq_init = env.ledger().sequence();
+
+    // Advance to just before the original write-path bump would expire.
+    env.ledger()
+        .set_sequence_number(seq_init + BUMP_AMOUNT - 1);
+    let _ = client.get_checkpoint(&id); // read-path bump
+
+    // Advance past where the *original* bump would have expired.
+    let seq_after_read = env.ledger().sequence();
+    env.ledger()
+        .set_sequence_number(seq_after_read + LIFETIME_THRESHOLD + 10);
+
+    let record = client.get_checkpoint(&id);
+    assert_eq!(record.balance, 42, "read-path bump must keep the record alive");
 }
 
 // ===========================================================================


### PR DESCRIPTION
Closes #671

## Problem

`create_checkpoint`, `batch_create_checkpoints`, and the explicit admin
`bump_checkpoint_ttl` / `bump_checkpoints_ttl_range` entrypoints all extend
a checkpoint's persistent-storage TTL. The read paths did not:
`get_checkpoint`, `get_checkpoints_range`, and `get_latest_checkpoint` only
called `.get()`. A checkpoint that's queried frequently but never rewritten
(the common case for an append-only audit log) would still count down to
archival based solely on its original write-time bump.

## Fix

All three read paths now call `extend_ttl(key, LIFETIME_THRESHOLD, BUMP_AMOUNT)`
after a successful read, using the same constants already used at write time.
`get_latest_checkpoint` was simplified to delegate to `get_checkpoint` so the
bump logic isn't duplicated.

## Tests

Added 4 tests in `contracts/checkpoint/src/test.rs` under "Read-path TTL bump
tests (buffer #26)":
- `test_get_checkpoint_bumps_ttl_on_read`
- `test_get_checkpoints_range_bumps_ttl_for_every_returned_record`
- `test_get_latest_checkpoint_bumps_ttl_on_read`
- `test_get_checkpoint_ttl_survives_past_original_bump_window`

Each advances the ledger sequence past the original write-time bump window
and asserts `get_ttl` reflects the new read-triggered bump, following the
same ledger-advance pattern used in `contracts/vault/src/test_ttl_bump.rs`.

**Note on local verification:** I could not get a linked Rust build on this
machine (no MSVC Build Tools installed; `link.exe` on PATH resolves to Git's
own utility rather than the MSVC linker), so I was unable to run
`cargo test -p callora-checkpoint` locally. I did a careful manual review of
the diff and the TTL-expiry arithmetic in each new test against the existing
`extend_ttl` semantics used elsewhere in this contract and in
`contracts/vault/src/test_ttl_bump.rs`, but please treat CI as the
authoritative test run for this PR rather than assuming it's already green.

Also worth flagging separately: while investigating I found the workspace
member `contracts/migrate/fuzz/Cargo.toml` has `callora-settlement = { path = "../settlement" }`,
which doesn't exist (should be `../../settlement`) — this breaks any
`cargo test`/`cargo check` run against the full workspace on a clean clone.
Unrelated to this PR so I left it alone, but flagging in case it's not
already known.