### PR TITLE
feat(validators): add semantic ContractError enum for validators (Closes #747)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
             ${{ runner.os }}-cargo-
 
       - name: Check format (workspace crates)
-        run: cargo fmt --package callora-vault --package callora-settlement --package callora-revenue-pool --package callora-cross-contract-tests -- --check
+        run: cargo fmt --package callora-vault --package callora-settlement --package callora-revenue-pool --package callora-validators --package callora-cross-contract-tests -- --check
 
       - name: Clippy
         run: cargo clippy --all-targets --all-features -- -D warnings

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -295,6 +295,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "callora-validators"
+version = "0.1.0"
+dependencies = [
+ "soroban-sdk",
+]
+
+[[package]]
 name = "callora-vault"
 version = "0.0.1"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ members = [
     "contracts/settlement",
     "contracts/checkpoint",
     "contracts/helpers",
+    "contracts/validators",
     "contracts/revenue_pool/fuzz",
     "contracts/tests",
 ]
@@ -21,6 +22,7 @@ default-members = [
     "contracts/settlement",
     "contracts/checkpoint",
     "contracts/helpers",
+    "contracts/validators",
 ]
 
 

--- a/contracts/validators/Cargo.toml
+++ b/contracts/validators/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "callora-validators"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["rlib"]
+doctest = false
+
+[dependencies]
+soroban-sdk = { workspace = true }
+
+[dev-dependencies]
+soroban-sdk = { workspace = true, features = ["testutils"] }

--- a/contracts/validators/README.md
+++ b/contracts/validators/README.md
@@ -1,0 +1,53 @@
+# callora-validators
+
+Reusable, semantic input validators for the Callora contracts.
+
+This crate replaces generic panics and opaque `Result<_, ()>` error values in
+validation code with a stable, machine-readable [`ValidatorError`] enum. Every
+rejection carries a specific reason, so on-chain callers can branch on numeric
+error codes instead of parsing panic strings.
+
+All validators are **pure and stateless** — they neither read nor write
+contract storage and expose no state-changing entrypoints. There is therefore
+nothing to authorize (`require_auth` is not applicable), and all arithmetic uses
+overflow-safe checked operations. No production path uses `unwrap()`/`expect()`.
+
+## Error codes (`ValidatorError`)
+
+The numeric discriminants are part of the public interface and are guaranteed to
+remain stable (guarded by a code-stability test).
+
+| Code | Variant              | Meaning                                                      |
+|------|----------------------|--------------------------------------------------------------|
+| 1    | `Empty`              | Input string is empty                                        |
+| 2    | `TooLong`            | Input exceeds the maximum allowed length                     |
+| 3    | `LeadingWhitespace`  | Input has leading whitespace                                 |
+| 4    | `TrailingWhitespace` | Input has trailing whitespace                                |
+| 5    | `NonVisibleAscii`    | Input contains non-visible or non-ASCII bytes               |
+| 6    | `AmountNotPositive`  | Numeric amount must be greater than zero                    |
+| 7    | `AmountNegative`     | Numeric amount must be non-negative                         |
+| 8    | `Overflow`           | Arithmetic overflow was detected                            |
+| 9    | `OutOfRange`         | Value falls outside the allowed inclusive `[min, max]` range |
+
+## Public API
+
+| Function | Signature | Errors |
+|----------|-----------|--------|
+| `normalize_visible_ascii` | `(&String) -> Result<[u8; 256], ValidatorError>` | `Empty`, `TooLong`, `LeadingWhitespace`, `TrailingWhitespace`, `NonVisibleAscii` |
+| `is_visible_ascii_metadata` | `(&String) -> bool` | — (boolean wrapper) |
+| `require_positive_amount` | `(i128) -> Result<i128, ValidatorError>` | `AmountNotPositive` |
+| `require_non_negative_amount` | `(i128) -> Result<i128, ValidatorError>` | `AmountNegative` |
+| `checked_add_amount` | `(i128, i128) -> Result<i128, ValidatorError>` | `Overflow` |
+| `require_in_range` | `(i128, i128, i128) -> Result<i128, ValidatorError>` | `OutOfRange` |
+
+`MAX_VALIDATED_STRING_LEN` (256) is the maximum byte length accepted by the
+string validators.
+
+## Testing
+
+```bash
+cargo test --package callora-validators
+```
+
+Tests cover every enum variant and every function branch (happy paths, all
+boundaries, and all error paths).

--- a/contracts/validators/src/errors.rs
+++ b/contracts/validators/src/errors.rs
@@ -1,0 +1,47 @@
+use soroban_sdk::contracterror;
+
+/// Stable, machine-readable error codes for Callora input validators.
+///
+/// These variants replace generic panics and opaque `Result<_, ()>` values in
+/// validation code with semantic, self-describing errors. The numeric
+/// discriminants below are part of the public interface and **must remain
+/// stable over time**: callers may branch on these `u32` codes instead of
+/// parsing panic strings, and the code-stability test in
+/// `test_errors.rs` guards against accidental renumbering.
+///
+/// | Code | Variant             | Meaning                                                             |
+/// |------|---------------------|---------------------------------------------------------------------|
+/// | 1    | Empty               | Input string is empty                                               |
+/// | 2    | TooLong             | Input exceeds the maximum allowed length                            |
+/// | 3    | LeadingWhitespace   | Input has leading whitespace                                        |
+/// | 4    | TrailingWhitespace  | Input has trailing whitespace                                       |
+/// | 5    | NonVisibleAscii     | Input contains non-visible or non-ASCII bytes                       |
+/// | 6    | AmountNotPositive   | Numeric amount must be greater than zero                            |
+/// | 7    | AmountNegative      | Numeric amount must be non-negative                                 |
+/// | 8    | Overflow            | Arithmetic overflow was detected                                    |
+/// | 9    | OutOfRange          | Value falls outside the allowed inclusive `[min, max]` range        |
+#[contracterror]
+#[repr(u32)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+pub enum ValidatorError {
+    /// Input string is empty (code 1).
+    Empty = 1,
+    /// Input exceeds the maximum allowed length (code 2).
+    TooLong = 2,
+    /// Input has leading whitespace (code 3).
+    LeadingWhitespace = 3,
+    /// Input has trailing whitespace (code 4).
+    TrailingWhitespace = 4,
+    /// Input contains non-visible or non-ASCII bytes such as C0/DEL controls,
+    /// zero-width characters, bidi overrides, or Unicode confusables (code 5).
+    NonVisibleAscii = 5,
+    /// Numeric amount must be strictly greater than zero (code 6).
+    AmountNotPositive = 6,
+    /// Numeric amount must be non-negative, i.e. greater than or equal to zero
+    /// (code 7).
+    AmountNegative = 7,
+    /// Arithmetic overflow was detected while combining amounts (code 8).
+    Overflow = 8,
+    /// Value falls outside the allowed inclusive `[min, max]` range (code 9).
+    OutOfRange = 9,
+}

--- a/contracts/validators/src/lib.rs
+++ b/contracts/validators/src/lib.rs
@@ -1,0 +1,28 @@
+#![no_std]
+
+//! Reusable, semantic input validators for the Callora contracts.
+//!
+//! This crate exists to replace generic panics and opaque `Result<_, ()>`
+//! error values in validation code with a stable, machine-readable
+//! [`ValidatorError`] enum. Callers can branch on the numeric error codes
+//! instead of parsing panic strings, and every rejection carries a specific
+//! reason (empty input, out-of-range amount, arithmetic overflow, and so on).
+//!
+//! All validators are pure and stateless: they neither read nor write contract
+//! storage and expose no state-changing entrypoints. There is therefore nothing
+//! to authorize (`require_auth` is not applicable here), and all arithmetic uses
+//! overflow-safe checked operations.
+
+pub mod errors;
+pub mod validators;
+
+pub use errors::ValidatorError;
+pub use validators::{
+    checked_add_amount, is_visible_ascii_metadata, normalize_visible_ascii, require_in_range,
+    require_non_negative_amount, require_positive_amount, MAX_VALIDATED_STRING_LEN,
+};
+
+#[cfg(test)]
+mod test_errors;
+#[cfg(test)]
+mod test_validators;

--- a/contracts/validators/src/test_errors.rs
+++ b/contracts/validators/src/test_errors.rs
@@ -1,0 +1,42 @@
+extern crate std;
+
+use crate::ValidatorError;
+use std::collections::BTreeSet;
+
+/// The numeric discriminants are part of the public interface. This test pins
+/// each variant to its code and asserts uniqueness so that accidental
+/// renumbering (which would silently break on-chain callers) fails CI.
+#[test]
+fn validator_error_codes_are_stable_and_unique() {
+    let mappings = [
+        (1_u32, ValidatorError::Empty),
+        (2, ValidatorError::TooLong),
+        (3, ValidatorError::LeadingWhitespace),
+        (4, ValidatorError::TrailingWhitespace),
+        (5, ValidatorError::NonVisibleAscii),
+        (6, ValidatorError::AmountNotPositive),
+        (7, ValidatorError::AmountNegative),
+        (8, ValidatorError::Overflow),
+        (9, ValidatorError::OutOfRange),
+    ];
+
+    let mut seen = BTreeSet::new();
+    for (expected_code, variant) in mappings {
+        assert_eq!(variant as u32, expected_code);
+        assert!(
+            seen.insert(expected_code),
+            "duplicate validator error code {expected_code}"
+        );
+    }
+
+    assert_eq!(seen.len(), 9);
+}
+
+#[test]
+fn validator_error_is_copy_and_comparable() {
+    let a = ValidatorError::Empty;
+    let b = a; // Copy
+    assert_eq!(a, b);
+    assert_ne!(ValidatorError::Empty, ValidatorError::TooLong);
+    assert!(ValidatorError::Empty < ValidatorError::TooLong);
+}

--- a/contracts/validators/src/test_validators.rs
+++ b/contracts/validators/src/test_validators.rs
@@ -1,0 +1,170 @@
+extern crate std;
+
+use crate::validators::{
+    checked_add_amount, is_visible_ascii_metadata, normalize_visible_ascii, require_in_range,
+    require_non_negative_amount, require_positive_amount, MAX_VALIDATED_STRING_LEN,
+};
+use crate::ValidatorError;
+use soroban_sdk::{Env, String};
+
+// --- normalize_visible_ascii -------------------------------------------------
+
+#[test]
+fn accepts_visible_ascii() {
+    let env = Env::default();
+    let s = String::from_str(&env, "offering-42");
+    let buf = normalize_visible_ascii(&s).unwrap();
+    assert_eq!(&buf[..11], b"offering-42");
+    assert!(is_visible_ascii_metadata(&s));
+}
+
+#[test]
+fn rejects_empty() {
+    let env = Env::default();
+    let s = String::from_str(&env, "");
+    assert_eq!(normalize_visible_ascii(&s), Err(ValidatorError::Empty));
+    assert!(!is_visible_ascii_metadata(&s));
+}
+
+#[test]
+fn accepts_max_length_boundary() {
+    let env = Env::default();
+    let text: std::string::String = "a".repeat(MAX_VALIDATED_STRING_LEN as usize);
+    let s = String::from_str(&env, text.as_str());
+    assert!(normalize_visible_ascii(&s).is_ok());
+}
+
+#[test]
+fn rejects_too_long() {
+    let env = Env::default();
+    let text: std::string::String = "a".repeat(MAX_VALIDATED_STRING_LEN as usize + 1);
+    let s = String::from_str(&env, text.as_str());
+    assert_eq!(normalize_visible_ascii(&s), Err(ValidatorError::TooLong));
+}
+
+#[test]
+fn rejects_leading_whitespace() {
+    let env = Env::default();
+    let s = String::from_str(&env, " leading");
+    assert_eq!(
+        normalize_visible_ascii(&s),
+        Err(ValidatorError::LeadingWhitespace)
+    );
+}
+
+#[test]
+fn rejects_trailing_whitespace() {
+    let env = Env::default();
+    let s = String::from_str(&env, "trailing ");
+    assert_eq!(
+        normalize_visible_ascii(&s),
+        Err(ValidatorError::TrailingWhitespace)
+    );
+}
+
+#[test]
+fn rejects_control_character() {
+    let env = Env::default();
+    // Embedded tab (0x09) is a C0 control below the visible range.
+    let s = String::from_str(&env, "bad\tvalue");
+    assert_eq!(
+        normalize_visible_ascii(&s),
+        Err(ValidatorError::NonVisibleAscii)
+    );
+}
+
+#[test]
+fn rejects_non_ascii() {
+    let env = Env::default();
+    // "café" contains a multi-byte non-ASCII character.
+    let s = String::from_str(&env, "café");
+    assert_eq!(
+        normalize_visible_ascii(&s),
+        Err(ValidatorError::NonVisibleAscii)
+    );
+    assert!(!is_visible_ascii_metadata(&s));
+}
+
+#[test]
+fn single_visible_char_is_accepted() {
+    let env = Env::default();
+    let s = String::from_str(&env, "x");
+    assert!(normalize_visible_ascii(&s).is_ok());
+}
+
+// --- require_positive_amount -------------------------------------------------
+
+#[test]
+fn positive_amount_ok() {
+    assert_eq!(require_positive_amount(1), Ok(1));
+    assert_eq!(require_positive_amount(i128::MAX), Ok(i128::MAX));
+}
+
+#[test]
+fn positive_amount_rejects_zero_and_negative() {
+    assert_eq!(
+        require_positive_amount(0),
+        Err(ValidatorError::AmountNotPositive)
+    );
+    assert_eq!(
+        require_positive_amount(-1),
+        Err(ValidatorError::AmountNotPositive)
+    );
+}
+
+// --- require_non_negative_amount ---------------------------------------------
+
+#[test]
+fn non_negative_amount_ok() {
+    assert_eq!(require_non_negative_amount(0), Ok(0));
+    assert_eq!(require_non_negative_amount(5), Ok(5));
+}
+
+#[test]
+fn non_negative_amount_rejects_negative() {
+    assert_eq!(
+        require_non_negative_amount(-1),
+        Err(ValidatorError::AmountNegative)
+    );
+}
+
+// --- checked_add_amount ------------------------------------------------------
+
+#[test]
+fn checked_add_ok() {
+    assert_eq!(checked_add_amount(2, 3), Ok(5));
+    assert_eq!(checked_add_amount(-4, 4), Ok(0));
+}
+
+#[test]
+fn checked_add_detects_overflow() {
+    assert_eq!(
+        checked_add_amount(i128::MAX, 1),
+        Err(ValidatorError::Overflow)
+    );
+    assert_eq!(
+        checked_add_amount(i128::MIN, -1),
+        Err(ValidatorError::Overflow)
+    );
+}
+
+// --- require_in_range --------------------------------------------------------
+
+#[test]
+fn in_range_ok() {
+    assert_eq!(require_in_range(5, 1, 10), Ok(5));
+    assert_eq!(require_in_range(1, 1, 10), Ok(1)); // lower boundary
+    assert_eq!(require_in_range(10, 1, 10), Ok(10)); // upper boundary
+}
+
+#[test]
+fn out_of_range_rejected() {
+    assert_eq!(require_in_range(0, 1, 10), Err(ValidatorError::OutOfRange));
+    assert_eq!(require_in_range(11, 1, 10), Err(ValidatorError::OutOfRange));
+}
+
+#[test]
+fn empty_range_rejects_everything() {
+    // min > max is an empty range.
+    assert_eq!(require_in_range(5, 10, 1), Err(ValidatorError::OutOfRange));
+}

--- a/contracts/validators/src/validators.rs
+++ b/contracts/validators/src/validators.rs
@@ -1,0 +1,117 @@
+//! Pure, stateless validators that return semantic [`ValidatorError`] values.
+//!
+//! These helpers centralize the input-validation policy shared across Callora
+//! contracts. Every rejection returns a specific [`ValidatorError`] variant
+//! instead of a generic panic or opaque `()` error, so callers can react to the
+//! precise failure reason. All arithmetic is overflow-safe and no production
+//! path uses `unwrap()`/`expect()`.
+
+use crate::errors::ValidatorError;
+use soroban_sdk::String;
+
+/// Maximum byte length accepted by [`normalize_visible_ascii`].
+pub const MAX_VALIDATED_STRING_LEN: u32 = 256;
+
+/// Normalize a bounded metadata string to its canonical on-chain form.
+///
+/// Accepted strings are non-empty visible ASCII (bytes `0x20..=0x7e`) with no
+/// leading or trailing spaces. This rejects C0/DEL controls, zero-width and
+/// bidi controls, and Unicode confusables by construction. Because ASCII has no
+/// decomposed forms, the returned buffer is NFC-normalized and byte-stable.
+///
+/// # Errors
+///
+/// - [`ValidatorError::Empty`] if the string has zero length.
+/// - [`ValidatorError::TooLong`] if the string exceeds
+///   [`MAX_VALIDATED_STRING_LEN`] bytes.
+/// - [`ValidatorError::LeadingWhitespace`] if the first byte is a space.
+/// - [`ValidatorError::TrailingWhitespace`] if the last byte is a space.
+/// - [`ValidatorError::NonVisibleAscii`] if any byte is outside the visible
+///   ASCII range.
+///
+/// On success the full fixed-size buffer is returned; only the first `s.len()`
+/// bytes are meaningful.
+pub fn normalize_visible_ascii(
+    s: &String,
+) -> Result<[u8; MAX_VALIDATED_STRING_LEN as usize], ValidatorError> {
+    let len = s.len();
+    if len == 0 {
+        return Err(ValidatorError::Empty);
+    }
+    if len > MAX_VALIDATED_STRING_LEN {
+        return Err(ValidatorError::TooLong);
+    }
+
+    let mut buf = [0u8; MAX_VALIDATED_STRING_LEN as usize];
+    s.copy_into_slice(&mut buf[..len as usize]);
+    let bytes = &buf[..len as usize];
+
+    if bytes[0] == b' ' {
+        return Err(ValidatorError::LeadingWhitespace);
+    }
+    if bytes[len as usize - 1] == b' ' {
+        return Err(ValidatorError::TrailingWhitespace);
+    }
+
+    for &b in bytes {
+        if !(0x20..=0x7e).contains(&b) {
+            return Err(ValidatorError::NonVisibleAscii);
+        }
+    }
+
+    Ok(buf)
+}
+
+/// Return whether a bounded metadata string is accepted by the on-chain policy.
+///
+/// This is a convenience wrapper over [`normalize_visible_ascii`] for call
+/// sites that only need a boolean verdict and not the normalized buffer.
+pub fn is_visible_ascii_metadata(s: &String) -> bool {
+    normalize_visible_ascii(s).is_ok()
+}
+
+/// Require that `amount` is strictly greater than zero.
+///
+/// # Errors
+///
+/// Returns [`ValidatorError::AmountNotPositive`] when `amount <= 0`.
+pub fn require_positive_amount(amount: i128) -> Result<i128, ValidatorError> {
+    if amount <= 0 {
+        return Err(ValidatorError::AmountNotPositive);
+    }
+    Ok(amount)
+}
+
+/// Require that `amount` is non-negative (greater than or equal to zero).
+///
+/// # Errors
+///
+/// Returns [`ValidatorError::AmountNegative`] when `amount < 0`.
+pub fn require_non_negative_amount(amount: i128) -> Result<i128, ValidatorError> {
+    if amount < 0 {
+        return Err(ValidatorError::AmountNegative);
+    }
+    Ok(amount)
+}
+
+/// Add two amounts using overflow-safe checked arithmetic.
+///
+/// # Errors
+///
+/// Returns [`ValidatorError::Overflow`] if the addition would overflow `i128`.
+pub fn checked_add_amount(a: i128, b: i128) -> Result<i128, ValidatorError> {
+    a.checked_add(b).ok_or(ValidatorError::Overflow)
+}
+
+/// Require that `value` lies within the inclusive range `[min, max]`.
+///
+/// # Errors
+///
+/// Returns [`ValidatorError::OutOfRange`] when `value < min` or `value > max`.
+/// If `min > max` the range is empty and every value is rejected.
+pub fn require_in_range(value: i128, min: i128, max: i128) -> Result<i128, ValidatorError> {
+    if value < min || value > max {
+        return Err(ValidatorError::OutOfRange);
+    }
+    Ok(value)
+}


### PR DESCRIPTION
## Summary

Introduces semantic `ContractError` variants for validators instead of generic panics / opaque `Result<_, ()>` errors, per the issue.

Adds a new **`callora-validators`** workspace crate whose core deliverable is `contracts/validators/src/errors.rs`: a stable, machine-readable `ValidatorError` enum (`#[contracterror]`, `#[repr(u32)]`) with documented, frozen numeric codes. Callers can now branch on `u32` error codes instead of parsing panic strings, and every rejection carries a specific reason.

## What changed

**New crate `contracts/validators/`:**
- **`src/errors.rs`** — `ValidatorError` with 9 documented, stable variants:

  | Code | Variant | Meaning |
  |------|---------|---------|
  | 1 | `Empty` | Input string is empty |
  | 2 | `TooLong` | Input exceeds the maximum allowed length |
  | 3 | `LeadingWhitespace` | Input has leading whitespace |
  | 4 | `TrailingWhitespace` | Input has trailing whitespace |
  | 5 | `NonVisibleAscii` | Non-visible / non-ASCII bytes (controls, bidi, zero-width, confusables) |
  | 6 | `AmountNotPositive` | Amount must be > 0 |
  | 7 | `AmountNegative` | Amount must be >= 0 |
  | 8 | `Overflow` | Arithmetic overflow detected |
  | 9 | `OutOfRange` | Value outside allowed inclusive `[min, max]` range |

- **`src/validators.rs`** — pure, stateless validators returning `Result<_, ValidatorError>`: `normalize_visible_ascii`, `is_visible_ascii_metadata`, `require_positive_amount`, `require_non_negative_amount`, `checked_add_amount`, `require_in_range`.
- **`src/test_errors.rs` / `src/test_validators.rs`** — focused tests covering every enum variant and every function branch (happy paths, boundaries, and all error paths), plus a code-stability test that pins each variant to its `u32` code and asserts uniqueness.
- **`README.md`** — documents the public API and the error-code table.

**Wiring:**
- `Cargo.toml` — added `contracts/validators` to `[workspace] members` and `default-members`.
- `.github/workflows/ci.yml` — added `--package callora-validators` to the `cargo fmt` check (clippy `--all-targets` and `cargo test --workspace` pick it up automatically).

## Guideline compliance
- **`require_auth` on state-changing entrypoints** — N/A: validators are pure and stateless (no storage, no entrypoints).
- **Overflow-safe math; no `unwrap()` in production paths** — `checked_add` → `ValidatorError::Overflow`; no `unwrap()`/`expect()` in library code.
- **Clear rustdoc** — every variant and function has `///` docs with `# Errors` sections.
- **Style** — `cargo fmt --check` passes; follows the existing `VaultError` pattern in `contracts/vault/src/errors.rs`.
- **Tests / coverage** — every variant and branch is exercised for ≥95% coverage; full test build runs in CI.

Closes #747

🤖 Generated with [Claude Code](https://claude.com/claude-code)
