### PR TITLE
docs: add NatSpec-style rustdoc for batch_distribute public entrypoin…

### DIFF
--- a/contracts/revenue_pool/src/lib.rs
+++ b/contracts/revenue_pool/src/lib.rs
@@ -599,23 +599,42 @@ impl RevenuePool {
             .publish((events::event_distribute(&env), to), amount);
     }
 
-    /// Distribute USDC to multiple developer wallets in one atomic transaction.
+    /// Distribute USDC to multiple developer wallets in a single atomic transaction.
     ///
-    /// All validation runs before any transfer. Returns a typed error for size
-    /// violations; panics for all other invalid conditions.
+    /// All payments are validated upfront before any USDC transfer occurs.
+    /// If **any** payment fails validation **no** transfers are executed and the
+    /// entire call reverts. If all payments pass validation every transfer is
+    /// executed and a `batch_distribute` event is emitted per payment leg.
     ///
-    /// # Errors
-    /// * `RevenuePoolError::BatchEmpty` — `payments` is empty.
-    /// * `RevenuePoolError::BatchTooLarge` — `payments` exceeds `MAX_BATCH_SIZE`.
+    /// # Arguments
+    /// * `caller` — must be the current admin and provide `require_auth`.
+    /// * `payments` — a vector of `(recipient: Address, amount: i128)` pairs.
+    ///   Maximum length is [`MAX_BATCH_SIZE`] (currently 50).
+    ///
+    /// # Errors (returned)
+    /// * [`RevenuePoolError::BatchEmpty`] — `payments` is empty.
+    /// * [`RevenuePoolError::BatchTooLarge`] — `payments` exceeds `MAX_BATCH_SIZE`.
     ///
     /// # Panics
-    /// * `ERR_UNAUTHORIZED`, `ERR_PAUSED`, `ERR_AMOUNT_NOT_POSITIVE`,
-    ///   `ERR_AMOUNT_EXCEEDS_MAX_DISTRIBUTE`, `ERR_DUPLICATE_RECIPIENT`,
-    ///   `"total overflow"`, `ERR_INSUFFICIENT_BALANCE`,
-    ///   `"invalid recipient: cannot distribute to the contract itself"`.
+    /// * `ERR_UNAUTHORIZED` — caller is not the current admin.
+    /// * `ERR_PAUSED` — pool is paused.
+    /// * `ERR_AMOUNT_NOT_POSITIVE` — any `amount` ≤ 0.
+    /// * `ERR_AMOUNT_EXCEEDS_MAX_DISTRIBUTE` — any `amount` exceeds the cap.
+    /// * `ERR_DUPLICATE_RECIPIENT` — two payments share the same `to` address.
+    /// * `"total overflow"` — sum of all amounts overflows `i128`.
+    /// * `ERR_INSUFFICIENT_BALANCE` — pool balance is less than the total.
+    /// * `"invalid recipient: cannot distribute to the contract itself"`.
     ///
     /// # Events
-    /// Emits one `batch_distribute` event per payment leg, after all validation.
+    /// Emits one [`events::event_batch_distribute`] event per payment leg with
+    /// the recipient's address as topic and the amount as data. Events are
+    /// published only after all validation passes **and** all transfers succeed.
+    ///
+    /// # Atomicity
+    /// The function is **all-or-nothing**: either every payment succeeds and every
+    /// event is emitted, or the entire transaction reverts. No partial state is
+    /// observable. Indexers can verify atomicity by checking that all
+    /// `batch_distribute` events share the same `(ledger, tx)` pair.
     pub fn batch_distribute(
         env: Env,
         caller: Address,

--- a/contracts/settlement/src/events.rs
+++ b/contracts/settlement/src/events.rs
@@ -26,12 +26,12 @@
 
 use soroban_sdk::{Address, BytesN, Env, Symbol};
 
+use crate::limits::MinBalanceChanged;
 use crate::types::{
     AdminBroadcast, AdminMigrationEvent, BalanceCreditedEvent, DailyWithdrawCapChanged,
-    DeveloperClaimWindowChanged, DeveloperForceCreditedEvent, DeveloperWithdrawEvent,
-    DepositEvent, GlobalPool, PaymentReceivedEvent, VaultAcceptedEvent, VaultProposedEvent,
+    DepositEvent, DeveloperClaimWindowChanged, DeveloperForceCreditedEvent, DeveloperWithdrawEvent,
+    GlobalPool, PaymentReceivedEvent, VaultAcceptedEvent, VaultProposedEvent,
 };
-use crate::limits::MinBalanceChanged;
 use crate::Severity;
 
 // ─── Topic constructors ──────────────────────────────────────────────────────
@@ -193,10 +193,8 @@ pub fn emit_initialized(env: &Env, admin: &Address, vault: &Address, pool: &Glob
 /// Topics: `(payment_received, from_vault)`
 /// Data:   [`PaymentReceivedEvent`]
 pub fn emit_payment_received(env: &Env, caller: &Address, payload: PaymentReceivedEvent) {
-    env.events().publish(
-        (event_payment_received(env), caller.clone()),
-        payload,
-    );
+    env.events()
+        .publish((event_payment_received(env), caller.clone()), payload);
 }
 
 /// Emit `"balance_credited"` when a developer's balance is incremented.
@@ -204,10 +202,8 @@ pub fn emit_payment_received(env: &Env, caller: &Address, payload: PaymentReceiv
 /// Topics: `(balance_credited, developer)`
 /// Data:   [`BalanceCreditedEvent`]
 pub fn emit_balance_credited(env: &Env, developer: &Address, payload: BalanceCreditedEvent) {
-    env.events().publish(
-        (event_balance_credited(env), developer.clone()),
-        payload,
-    );
+    env.events()
+        .publish((event_balance_credited(env), developer.clone()), payload);
 }
 
 /// Emit `"deposit"` alongside each developer credit (both single and batch).
@@ -215,10 +211,8 @@ pub fn emit_balance_credited(env: &Env, developer: &Address, payload: BalanceCre
 /// Topics: `(deposit, developer)`
 /// Data:   [`DepositEvent`]
 pub fn emit_deposit(env: &Env, developer: &Address, payload: DepositEvent) {
-    env.events().publish(
-        (event_deposit(env), developer.clone()),
-        payload,
-    );
+    env.events()
+        .publish((event_deposit(env), developer.clone()), payload);
 }
 
 /// Emit `"developer_withdraw"` when a developer withdraws accrued balance.
@@ -226,10 +220,8 @@ pub fn emit_deposit(env: &Env, developer: &Address, payload: DepositEvent) {
 /// Topics: `(developer_withdraw, developer)`
 /// Data:   [`DeveloperWithdrawEvent`]
 pub fn emit_developer_withdraw(env: &Env, developer: &Address, payload: DeveloperWithdrawEvent) {
-    env.events().publish(
-        (event_developer_withdraw(env), developer.clone()),
-        payload,
-    );
+    env.events()
+        .publish((event_developer_withdraw(env), developer.clone()), payload);
 }
 
 /// Emit `"daily_withdraw_cap_changed"` when the admin updates a developer's
@@ -325,10 +317,8 @@ pub fn emit_vault_accepted(env: &Env, new_vault: &Address, payload: VaultAccepte
 /// Topics: `(upgraded, caller)`
 /// Data:   `new_wasm_hash`
 pub fn emit_upgraded(env: &Env, caller: &Address, new_wasm_hash: &BytesN<32>) {
-    env.events().publish(
-        (event_upgraded(env), caller.clone()),
-        new_wasm_hash.clone(),
-    );
+    env.events()
+        .publish((event_upgraded(env), caller.clone()), new_wasm_hash.clone());
 }
 
 /// Emit `"developer_force_credited"` when the admin manually credits a
@@ -366,10 +356,8 @@ pub fn emit_admin_migration_proposed(
     from: &Address,
     payload: crate::timelock::PendingDeveloperMigration,
 ) {
-    env.events().publish(
-        (event_admin_migration_proposed(env), from.clone()),
-        payload,
-    );
+    env.events()
+        .publish((event_admin_migration_proposed(env), from.clone()), payload);
 }
 
 /// Emit `"admin_migration"` when a pending balance migration is executed.


### PR DESCRIPTION
Closes #705 

Improve the /// rustdoc on atch_distribute in revenue_pool/src/lib.rs to fully cover:
- What: atomic batch USDC distribution to multiple developers
- How: validate-all-then-execute-one pattern
- Why: gas efficiency and atomicity guarantee
- Arguments: caller auth, payments vector constraints
- Errors: RevenuePoolError variants returned vs panic conditions
- Events: batch_distribute emitted per payment leg
- Atomicity: all-or-nothing semantics with indexer guidance

Adheres to existing NatSpec conventions in the repo (distribute, vault, etc.).