### PR TITLE
feat(upgrade): emit structured lifecycle events for upgrade and cooldown

### DIFF
--- a/contracts/upgrade/src/admin.rs
+++ b/contracts/upgrade/src/admin.rs
@@ -2,8 +2,18 @@
 //!
 //! Enforces a cooldown period between critical upgrade actions to prevent
 //! rapid abuse. This implements the requirements for the GrantFox FWC26 campaign.
+//!
+//! ## Events
+//!
+//! | Function                  | Topic              | Topics                          | Data                              |
+//! |---------------------------|--------------------|---------------------------------|-----------------------------------|
+//! | `check_and_record_upgrade`| `upgrade_started`  | `(topic, caller)`               | `(current_timestamp, cooldown)`   |
+//! | `check_and_record_upgrade`| `upgrade_recorded` | `(topic, caller)`               | `recorded_timestamp`              |
+//! | `set_cooldown`            | `cooldown_set`     | `(topic, caller)`               | `new_cooldown_secs`               |
 
 use soroban_sdk::{contracterror, Address, Env, Symbol};
+
+use crate::events;
 
 #[contracterror]
 #[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
@@ -24,11 +34,17 @@ pub const DEFAULT_COOLDOWN_SECONDS: u64 = 86400;
 /// Set the cooldown window (in seconds).
 ///
 /// Requires auth from the caller.
+///
+/// # Events
+/// Emits `cooldown_set` with `caller` as topic and `cooldown` as data.
 pub fn set_cooldown(env: &Env, caller: &Address, cooldown: u64) {
     caller.require_auth();
     env.storage()
         .instance()
         .set(&Symbol::new(env, UPGRADE_COOLDOWN_KEY), &cooldown);
+
+    env.events()
+        .publish((events::event_cooldown_set(env), caller), cooldown);
 }
 
 /// Retrieve the current cooldown window.
@@ -46,6 +62,15 @@ pub fn get_cooldown(env: &Env) -> u64 {
 /// Requires auth from the caller. Returns `Ok(())` if the cooldown has elapsed
 /// or if this is the first upgrade. Otherwise, returns `UpgradeError::CooldownNotElapsed`.
 /// Also updates the last upgrade time to the current ledger timestamp upon success.
+///
+/// # Events
+/// On success, emits two events in order:
+/// 1. `upgrade_started` — topics `(upgrade_started, caller)`, data `(current_timestamp, cooldown)`.
+///    Signals that auth passed and the cooldown constraint was satisfied.
+/// 2. `upgrade_recorded` — topics `(upgrade_recorded, caller)`, data `recorded_timestamp`.
+///    Signals that the new baseline timestamp has been persisted to storage.
+///
+/// No events are emitted when the call returns `Err`.
 pub fn check_and_record_upgrade(env: &Env, caller: &Address) -> Result<(), UpgradeError> {
     caller.require_auth();
 
@@ -67,9 +92,19 @@ pub fn check_and_record_upgrade(env: &Env, caller: &Address) -> Result<(), Upgra
         }
     }
 
+    // Auth passed and cooldown satisfied — signal the start of the upgrade.
+    env.events().publish(
+        (events::event_upgrade_started(env), caller),
+        (current_time, cooldown),
+    );
+
     env.storage()
         .instance()
         .set(&Symbol::new(env, LAST_UPGRADE_TIME_KEY), &current_time);
+
+    // Timestamp is now persisted — confirm the record.
+    env.events()
+        .publish((events::event_upgrade_recorded(env), caller), current_time);
 
     Ok(())
 }

--- a/contracts/upgrade/src/events.rs
+++ b/contracts/upgrade/src/events.rs
@@ -1,0 +1,102 @@
+//! Event topic Symbol constructors for the Callora Upgrade contract.
+//!
+//! This module centralizes all event topic strings into dedicated functions,
+//! ensuring byte-identity is preserved and preventing accidental topic name
+//! drift across call sites.
+//!
+//! ## Event Overview
+//!
+//! | Topic               | Trigger                                            |
+//! |---------------------|----------------------------------------------------|
+//! | `"upgrade_started"` | Cooldown check passed; upgrade is authorized       |
+//! | `"upgrade_recorded"`| Last-upgrade timestamp persisted in storage        |
+//! | `"cooldown_set"`    | Cooldown window updated via `set_cooldown`         |
+//!
+//! ## Topic Shape
+//!
+//! All events follow the canonical 2-topic shape used across Callora contracts:
+//!
+//! ```text
+//! topics: (action: Symbol, caller: Address)
+//! data:   <event-specific payload>
+//! ```
+//!
+//! Off-chain indexers should filter on `topic[0]` (action) and scope queries
+//! to the emitting contract address to avoid cross-contract topic collisions.
+
+use soroban_sdk::{Env, Symbol};
+
+/// Returns the Symbol for the `"upgrade_started"` event topic.
+///
+/// Emitted at the beginning of a successful [`crate::check_and_record_upgrade`]
+/// call, immediately after the cooldown check passes and auth is verified.
+/// An indexer that receives this topic knows the caller was authorized and the
+/// cooldown constraint was satisfied.
+///
+/// Topics: `(upgrade_started, caller: Address)`
+/// Data:   `(current_timestamp: u64, cooldown: u64)`
+pub fn event_upgrade_started(env: &Env) -> Symbol {
+    Symbol::new(env, "upgrade_started")
+}
+
+/// Returns the Symbol for the `"upgrade_recorded"` event topic.
+///
+/// Emitted after the last-upgrade timestamp has been written to instance
+/// storage, confirming that the new baseline for future cooldown checks is
+/// persisted. Pairing `upgrade_started` → `upgrade_recorded` lets indexers
+/// confirm a complete, non-interrupted upgrade lifecycle.
+///
+/// Topics: `(upgrade_recorded, caller: Address)`
+/// Data:   `(recorded_timestamp: u64)`
+pub fn event_upgrade_recorded(env: &Env) -> Symbol {
+    Symbol::new(env, "upgrade_recorded")
+}
+
+/// Returns the Symbol for the `"cooldown_set"` event topic.
+///
+/// Emitted when the admin updates the global cooldown window via
+/// [`crate::set_cooldown`].
+///
+/// Topics: `(cooldown_set, caller: Address)`
+/// Data:   `new_cooldown_secs: u64`
+pub fn event_cooldown_set(env: &Env) -> Symbol {
+    Symbol::new(env, "cooldown_set")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use soroban_sdk::Env;
+
+    /// Snapshot: proves event_upgrade_started still maps to exactly the bytes
+    /// for `"upgrade_started"`. If this test fails, the topic was accidentally
+    /// renamed — all off-chain indexers subscribed to that topic would silently
+    /// stop receiving events.
+    #[test]
+    fn test_event_upgrade_started_bytes() {
+        let env = Env::default();
+        assert_eq!(
+            event_upgrade_started(&env),
+            Symbol::new(&env, "upgrade_started")
+        );
+    }
+
+    /// Snapshot: proves event_upgrade_recorded still maps to exactly the bytes
+    /// for `"upgrade_recorded"`.
+    #[test]
+    fn test_event_upgrade_recorded_bytes() {
+        let env = Env::default();
+        assert_eq!(
+            event_upgrade_recorded(&env),
+            Symbol::new(&env, "upgrade_recorded")
+        );
+    }
+
+    /// Snapshot: proves event_cooldown_set still maps to exactly the bytes for
+    /// `"cooldown_set"`.
+    #[test]
+    fn test_event_cooldown_set_bytes() {
+        let env = Env::default();
+        assert_eq!(event_cooldown_set(&env), Symbol::new(&env, "cooldown_set"));
+    }
+}

--- a/contracts/upgrade/src/lib.rs
+++ b/contracts/upgrade/src/lib.rs
@@ -1,3 +1,4 @@
 #![no_std]
 
 pub mod admin;
+pub mod events;

--- a/contracts/upgrade/src/test.rs
+++ b/contracts/upgrade/src/test.rs
@@ -1,10 +1,47 @@
+//! Tests for the Callora Upgrade crate.
+//!
+//! Covers:
+//! - default and configured cooldown values
+//! - cooldown enforcement (not-elapsed, exact-boundary, elapsed)
+//! - event emission: `cooldown_set`, `upgrade_started`, `upgrade_recorded`
 #![cfg(test)]
 extern crate std;
 use super::*;
 use soroban_sdk::{
-    testutils::{Address as _, Ledger as _},
-    Address, Env, Symbol,
+    testutils::{Address as _, Events as _, Ledger as _},
+    Address, Env, IntoVal, Symbol,
 };
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// Return all events published by any contract in the environment, filtered
+/// to those whose first topic is the given string.
+fn events_with_topic<'a>(
+    env: &'a Env,
+    topic: &str,
+) -> std::vec::Vec<(
+    soroban_sdk::Vec<soroban_sdk::Val>,
+    soroban_sdk::Val,
+)> {
+    let needle = Symbol::new(env, topic);
+    env.events()
+        .all()
+        .iter()
+        .filter(|e| {
+            !e.1.is_empty() && {
+                let t0: Symbol = e.1.get(0).unwrap().into_val(env);
+                t0 == needle
+            }
+        })
+        .map(|e| (e.1, e.2))
+        .collect()
+}
+
+// ===========================================================================
+// Existing cooldown behaviour tests
+// ===========================================================================
 
 #[test]
 fn test_default_cooldown() {
@@ -37,7 +74,7 @@ fn test_check_and_record_upgrade_first_time() {
     let last_time = env
         .storage()
         .instance()
-        .get::<_, u64>(&Symbol::new(&env, LAST_UPGRADE_TIME_KEY))
+        .get::<_, u64>(&Symbol::new(&env, "last_upg_tm"))
         .unwrap();
     assert_eq!(last_time, env.ledger().timestamp());
 }
@@ -84,7 +121,244 @@ fn test_check_and_record_upgrade_cooldown_elapsed() {
     let last_time = env
         .storage()
         .instance()
-        .get::<_, u64>(&Symbol::new(&env, LAST_UPGRADE_TIME_KEY))
+        .get::<_, u64>(&Symbol::new(&env, "last_upg_tm"))
         .unwrap();
     assert_eq!(last_time, 100 + DEFAULT_COOLDOWN_SECONDS);
+}
+
+// ===========================================================================
+// Event emission tests
+// ===========================================================================
+
+/// `set_cooldown` must publish exactly one `cooldown_set` event.
+///
+/// Shape: topics `(cooldown_set, caller)`, data `new_cooldown_secs`.
+#[test]
+fn set_cooldown_emits_cooldown_set_event() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let caller = Address::generate(&env);
+    let new_cooldown: u64 = 3_600;
+
+    set_cooldown(&env, &caller, new_cooldown);
+
+    let matches = events_with_topic(&env, "cooldown_set");
+    assert_eq!(matches.len(), 1, "expected exactly one cooldown_set event");
+
+    let (topics, data) = &matches[0];
+    assert_eq!(topics.len(), 2, "cooldown_set must carry exactly 2 topics");
+
+    let topic0: Symbol = topics.get(0).unwrap().into_val(&env);
+    assert_eq!(topic0, Symbol::new(&env, "cooldown_set"));
+
+    let topic1: Address = topics.get(1).unwrap().into_val(&env);
+    assert_eq!(topic1, caller, "topic[1] must be the caller address");
+
+    let payload: u64 = data.into_val(&env);
+    assert_eq!(payload, new_cooldown, "data must be the new cooldown value");
+}
+
+/// `set_cooldown` called twice emits two separate `cooldown_set` events,
+/// one for each invocation.
+#[test]
+fn set_cooldown_emits_separate_events_on_repeated_calls() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let caller = Address::generate(&env);
+
+    set_cooldown(&env, &caller, 1_800);
+    set_cooldown(&env, &caller, 7_200);
+
+    let matches = events_with_topic(&env, "cooldown_set");
+    assert_eq!(matches.len(), 2, "expected two cooldown_set events");
+
+    let payload_a: u64 = matches[0].1.into_val(&env);
+    let payload_b: u64 = matches[1].1.into_val(&env);
+    assert_eq!(payload_a, 1_800);
+    assert_eq!(payload_b, 7_200);
+}
+
+/// A successful `check_and_record_upgrade` (first call, no prior record) must
+/// emit `upgrade_started` followed by `upgrade_recorded`.
+///
+/// `upgrade_started` shape:
+///   topics `(upgrade_started, caller)`, data `(current_timestamp, cooldown)`.
+/// `upgrade_recorded` shape:
+///   topics `(upgrade_recorded, caller)`, data `recorded_timestamp`.
+#[test]
+fn check_and_record_upgrade_first_call_emits_started_and_recorded() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let caller = Address::generate(&env);
+    env.ledger().set_timestamp(500);
+
+    check_and_record_upgrade(&env, &caller).unwrap();
+
+    // ── upgrade_started ──────────────────────────────────────────────────
+    let started = events_with_topic(&env, "upgrade_started");
+    assert_eq!(started.len(), 1, "expected exactly one upgrade_started event");
+
+    let (topics_s, data_s) = &started[0];
+    assert_eq!(topics_s.len(), 2);
+    let s_topic0: Symbol = topics_s.get(0).unwrap().into_val(&env);
+    assert_eq!(s_topic0, Symbol::new(&env, "upgrade_started"));
+    let s_topic1: Address = topics_s.get(1).unwrap().into_val(&env);
+    assert_eq!(s_topic1, caller, "upgrade_started topic[1] must be caller");
+
+    let (ts, cooldown): (u64, u64) = data_s.into_val(&env);
+    assert_eq!(ts, 500, "upgrade_started data[0] must be current_timestamp");
+    assert_eq!(
+        cooldown,
+        DEFAULT_COOLDOWN_SECONDS,
+        "upgrade_started data[1] must be the cooldown window"
+    );
+
+    // ── upgrade_recorded ─────────────────────────────────────────────────
+    let recorded = events_with_topic(&env, "upgrade_recorded");
+    assert_eq!(
+        recorded.len(),
+        1,
+        "expected exactly one upgrade_recorded event"
+    );
+
+    let (topics_r, data_r) = &recorded[0];
+    assert_eq!(topics_r.len(), 2);
+    let r_topic0: Symbol = topics_r.get(0).unwrap().into_val(&env);
+    assert_eq!(r_topic0, Symbol::new(&env, "upgrade_recorded"));
+    let r_topic1: Address = topics_r.get(1).unwrap().into_val(&env);
+    assert_eq!(r_topic1, caller, "upgrade_recorded topic[1] must be caller");
+
+    let recorded_ts: u64 = data_r.into_val(&env);
+    assert_eq!(
+        recorded_ts, 500,
+        "upgrade_recorded data must be the recorded timestamp"
+    );
+}
+
+/// When the cooldown has elapsed, a second `check_and_record_upgrade` call
+/// also emits both events with the updated timestamp.
+#[test]
+fn check_and_record_upgrade_second_call_after_cooldown_emits_events() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let caller = Address::generate(&env);
+
+    env.ledger().set_timestamp(100);
+    check_and_record_upgrade(&env, &caller).unwrap();
+
+    // Advance past the default cooldown.
+    env.ledger().set_timestamp(100 + DEFAULT_COOLDOWN_SECONDS);
+    check_and_record_upgrade(&env, &caller).unwrap();
+
+    // Two pairs of events should have been emitted in total.
+    let started = events_with_topic(&env, "upgrade_started");
+    let recorded = events_with_topic(&env, "upgrade_recorded");
+    assert_eq!(started.len(), 2);
+    assert_eq!(recorded.len(), 2);
+
+    // The second upgrade_started data must carry the new timestamp.
+    let (ts2, _): (u64, u64) = started[1].1.into_val(&env);
+    assert_eq!(ts2, 100 + DEFAULT_COOLDOWN_SECONDS);
+
+    let recorded_ts2: u64 = recorded[1].1.into_val(&env);
+    assert_eq!(recorded_ts2, 100 + DEFAULT_COOLDOWN_SECONDS);
+}
+
+/// When the cooldown has NOT elapsed, `check_and_record_upgrade` returns
+/// `Err(CooldownNotElapsed)` and must NOT emit any events.
+#[test]
+fn check_and_record_upgrade_cooldown_not_elapsed_emits_no_events() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let caller = Address::generate(&env);
+
+    env.ledger().set_timestamp(100);
+    check_and_record_upgrade(&env, &caller).unwrap();
+
+    // Advance to just before the cooldown window expires.
+    env.ledger()
+        .set_timestamp(100 + DEFAULT_COOLDOWN_SECONDS - 1);
+    let res = check_and_record_upgrade(&env, &caller);
+    assert_eq!(res, Err(UpgradeError::CooldownNotElapsed));
+
+    // Only the first call's events should be present (one each).
+    let started = events_with_topic(&env, "upgrade_started");
+    let recorded = events_with_topic(&env, "upgrade_recorded");
+    assert_eq!(
+        started.len(),
+        1,
+        "failed call must not emit additional upgrade_started events"
+    );
+    assert_eq!(
+        recorded.len(),
+        1,
+        "failed call must not emit additional upgrade_recorded events"
+    );
+}
+
+/// `upgrade_started` is emitted BEFORE `upgrade_recorded` within the same call.
+/// We verify ordering by comparing their positions in `env.events().all()`.
+#[test]
+fn upgrade_started_precedes_upgrade_recorded_in_event_order() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let caller = Address::generate(&env);
+    env.ledger().set_timestamp(1_000);
+
+    check_and_record_upgrade(&env, &caller).unwrap();
+
+    let started_sym = Symbol::new(&env, "upgrade_started");
+    let recorded_sym = Symbol::new(&env, "upgrade_recorded");
+
+    let all = env.events().all();
+    let mut started_pos: Option<usize> = None;
+    let mut recorded_pos: Option<usize> = None;
+
+    for (i, event) in all.iter().enumerate() {
+        if event.1.is_empty() {
+            continue;
+        }
+        let t0: Symbol = event.1.get(0).unwrap().into_val(&env);
+        if t0 == started_sym {
+            started_pos = Some(i);
+        } else if t0 == recorded_sym {
+            recorded_pos = Some(i);
+        }
+    }
+
+    assert!(
+        started_pos.is_some(),
+        "upgrade_started event not found in event log"
+    );
+    assert!(
+        recorded_pos.is_some(),
+        "upgrade_recorded event not found in event log"
+    );
+    assert!(
+        started_pos.unwrap() < recorded_pos.unwrap(),
+        "upgrade_started must appear before upgrade_recorded in the event log"
+    );
+}
+
+/// `check_and_record_upgrade` with a custom cooldown reports the custom window
+/// in the `upgrade_started` data payload.
+#[test]
+fn upgrade_started_data_reflects_custom_cooldown() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let caller = Address::generate(&env);
+    let custom_cooldown: u64 = 7_200;
+
+    set_cooldown(&env, &caller, custom_cooldown);
+    env.ledger().set_timestamp(300);
+    check_and_record_upgrade(&env, &caller).unwrap();
+
+    let started = events_with_topic(&env, "upgrade_started");
+    assert_eq!(started.len(), 1);
+    let (ts, cw): (u64, u64) = started[0].1.into_val(&env);
+    assert_eq!(ts, 300);
+    assert_eq!(
+        cw, custom_cooldown,
+        "upgrade_started data must report the active cooldown window"
+    );
 }


### PR DESCRIPTION
Implements upgrade lifecycle event emission in the callora-upgrade crate for the GrantFox FWC26 campaign (Stellar Wave).

Changes:
- contracts/upgrade/src/events.rs (new): centralised event topic constructors for upgrade_started, upgrade_recorded, and cooldown_set. Each constructor has a snapshot test that pins the byte-level topic string identity.
- contracts/upgrade/src/lib.rs: declares pub mod events.
- contracts/upgrade/src/admin.rs:
  * check_and_record_upgrade now emits upgrade_started (after auth/cooldown check passes, before storage write) and upgrade_recorded (after the new baseline timestamp is persisted). Failed calls emit no events.
  * set_cooldown now emits cooldown_set after writing the new window.
- contracts/upgrade/src/test.rs: 7 new focused event tests covering topic shape, caller identity, payload values, ordering, repeated calls, failed call emits no events, and custom cooldown payload.

Closes #741