### PR TITLE
Add structured distribute lifecycle events

### DIFF
--- a/contracts/revenue_pool/src/events.rs
+++ b/contracts/revenue_pool/src/events.rs
@@ -4,7 +4,51 @@
 //! ensuring byte-identity is preserved and preventing accidental topic name drift
 //! across call sites.
 
-use soroban_sdk::{Env, Symbol};
+use soroban_sdk::{contracttype, Address, Env, Symbol};
+
+/// Schema version for structured distribution lifecycle event payloads.
+pub const DISTRIBUTION_EVENT_VERSION: u32 = 1;
+
+/// Identifies which distribution entry point emitted a lifecycle event.
+#[contracttype]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum DistributionMode {
+    Single,
+    Batch,
+}
+
+/// Stable, versioned payload shared by distribution lifecycle events.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct DistributionLifecycleEvent {
+    pub version: u32,
+    pub amount: i128,
+    pub mode: DistributionMode,
+    pub batch_index: u32,
+    pub batch_size: u32,
+    pub ledger_sequence: u32,
+    pub timestamp: u64,
+}
+
+impl DistributionLifecycleEvent {
+    pub fn new(
+        env: &Env,
+        amount: i128,
+        mode: DistributionMode,
+        batch_index: u32,
+        batch_size: u32,
+    ) -> Self {
+        Self {
+            version: DISTRIBUTION_EVENT_VERSION,
+            amount,
+            mode,
+            batch_index,
+            batch_size,
+            ledger_sequence: env.ledger().sequence(),
+            timestamp: env.ledger().timestamp(),
+        }
+    }
+}
 
 /// Returns the Symbol for the `"init"` event topic.
 ///
@@ -126,6 +170,42 @@ pub fn event_distribute(env: &Env) -> Symbol {
 /// validation has passed.
 pub fn event_batch_distribute(env: &Env) -> Symbol {
     Symbol::new(env, "batch_distribute")
+}
+
+/// Returns the Symbol for the `"distribute_started"` lifecycle event topic.
+pub fn event_distribute_started(env: &Env) -> Symbol {
+    Symbol::new(env, "distribute_started")
+}
+
+/// Returns the Symbol for the `"distribute_completed"` lifecycle event topic.
+pub fn event_distribute_completed(env: &Env) -> Symbol {
+    Symbol::new(env, "distribute_completed")
+}
+
+/// Emits a structured event immediately before a validated distribution transfer.
+pub fn emit_distribute_started(
+    env: &Env,
+    caller: &Address,
+    recipient: &Address,
+    payload: &DistributionLifecycleEvent,
+) {
+    env.events().publish(
+        (event_distribute_started(env), caller, recipient),
+        payload.clone(),
+    );
+}
+
+/// Emits a structured event after a distribution transfer succeeds.
+pub fn emit_distribute_completed(
+    env: &Env,
+    caller: &Address,
+    recipient: &Address,
+    payload: &DistributionLifecycleEvent,
+) {
+    env.events().publish(
+        (event_distribute_completed(env), caller, recipient),
+        payload.clone(),
+    );
 }
 
 /// Returns the Symbol for the `"upgraded"` event topic.
@@ -317,6 +397,33 @@ mod tests {
             event_batch_distribute(&env),
             Symbol::new(&env, "batch_distribute")
         );
+    }
+
+    #[test]
+    fn test_distribution_lifecycle_event_bytes() {
+        let env = Env::default();
+        assert_eq!(
+            event_distribute_started(&env),
+            Symbol::new(&env, "distribute_started")
+        );
+        assert_eq!(
+            event_distribute_completed(&env),
+            Symbol::new(&env, "distribute_completed")
+        );
+    }
+
+    #[test]
+    fn test_distribution_lifecycle_payload_is_versioned() {
+        let env = Env::default();
+        let payload = DistributionLifecycleEvent::new(&env, 42, DistributionMode::Batch, 1, 3);
+
+        assert_eq!(payload.version, DISTRIBUTION_EVENT_VERSION);
+        assert_eq!(payload.amount, 42);
+        assert_eq!(payload.mode, DistributionMode::Batch);
+        assert_eq!(payload.batch_index, 1);
+        assert_eq!(payload.batch_size, 3);
+        assert_eq!(payload.ledger_sequence, env.ledger().sequence());
+        assert_eq!(payload.timestamp, env.ledger().timestamp());
     }
 
     /// Snapshot: proves event_upgraded still maps to exactly the bytes for "upgraded".

--- a/contracts/revenue_pool/src/lib.rs
+++ b/contracts/revenue_pool/src/lib.rs
@@ -568,7 +568,8 @@ impl RevenuePool {
     /// * `ERR_INSUFFICIENT_BALANCE` — pool holds less than `amount`.
     ///
     /// # Events
-    /// Emits `distribute` with `to` as topic and `amount` as data.
+    /// Emits `distribute_started` and `distribute_completed` with a versioned
+    /// payload around the transfer. The legacy `distribute` event is preserved.
     pub fn distribute(env: Env, caller: Address, to: Address, amount: i128) {
         caller.require_auth();
         Self::require_not_paused(&env);
@@ -594,9 +595,19 @@ impl RevenuePool {
         env.storage()
             .instance()
             .extend_ttl(LIFETIME_THRESHOLD, BUMP_AMOUNT);
+
+        let lifecycle = events::DistributionLifecycleEvent::new(
+            &env,
+            amount,
+            events::DistributionMode::Single,
+            0,
+            1,
+        );
+        events::emit_distribute_started(&env, &caller, &to, &lifecycle);
         usdc.transfer(&contract_address, &to, &amount);
         env.events()
-            .publish((events::event_distribute(&env), to), amount);
+            .publish((events::event_distribute(&env), to.clone()), amount);
+        events::emit_distribute_completed(&env, &caller, &to, &lifecycle);
     }
 
     /// Distribute USDC to multiple developer wallets in a single atomic transaction.
@@ -626,9 +637,9 @@ impl RevenuePool {
     /// * `"invalid recipient: cannot distribute to the contract itself"`.
     ///
     /// # Events
-    /// Emits one [`events::event_batch_distribute`] event per payment leg with
-    /// the recipient's address as topic and the amount as data. Events are
-    /// published only after all validation passes **and** all transfers succeed.
+    /// Emits structured `distribute_started` and `distribute_completed` events
+    /// around each transfer. The legacy [`events::event_batch_distribute`] event
+    /// is preserved for every payment leg.
     ///
     /// # Atomicity
     /// The function is **all-or-nothing**: either every payment succeeds and every
@@ -689,12 +700,24 @@ impl RevenuePool {
             .instance()
             .extend_ttl(LIFETIME_THRESHOLD, BUMP_AMOUNT);
 
+        let mut batch_index = 0_u32;
         for payment in payments.iter() {
             let (to, amount) = payment;
             Self::validate_recipient(&to, &contract_address);
+
+            let lifecycle = events::DistributionLifecycleEvent::new(
+                &env,
+                amount,
+                events::DistributionMode::Batch,
+                batch_index,
+                n,
+            );
+            events::emit_distribute_started(&env, &caller, &to, &lifecycle);
             usdc.transfer(&contract_address, &to, &amount);
             env.events()
-                .publish((events::event_batch_distribute(&env), to), amount);
+                .publish((events::event_batch_distribute(&env), to.clone()), amount);
+            events::emit_distribute_completed(&env, &caller, &to, &lifecycle);
+            batch_index = batch_index.saturating_add(1);
         }
 
         Ok(())

--- a/contracts/revenue_pool/src/test_events.rs
+++ b/contracts/revenue_pool/src/test_events.rs
@@ -1,18 +1,18 @@
 //! Focused event tests for revenue_pool structured events
 //!
-//! Tests ensuring all 21 lifecycle events are properly structured.
+//! Tests ensuring all 23 lifecycle events are properly structured.
 
 extern crate std;
 
 use crate::*;
 use soroban_sdk::testutils::{Address as _, Events as _};
-use soroban_sdk::{Address, Env, IntoVal, Symbol, TryFromVal};
+use soroban_sdk::{token, Address, Env, IntoVal, Symbol, TryFromVal};
 
 #[test]
 fn all_event_constructors_return_correct_symbols() {
     let env = Env::default();
 
-    // Test all 21 event constructor functions return correct string symbols
+    // Test all 23 event constructor functions return correct string symbols
     assert_eq!(events::event_init(&env), Symbol::new(&env, "init"));
     assert_eq!(
         events::event_admin_changed(&env),
@@ -74,6 +74,14 @@ fn all_event_constructors_return_correct_symbols() {
         events::event_batch_distribute(&env),
         Symbol::new(&env, "batch_distribute")
     );
+    assert_eq!(
+        events::event_distribute_started(&env),
+        Symbol::new(&env, "distribute_started")
+    );
+    assert_eq!(
+        events::event_distribute_completed(&env),
+        Symbol::new(&env, "distribute_completed")
+    );
     assert_eq!(events::event_upgraded(&env), Symbol::new(&env, "upgraded"));
     assert_eq!(
         events::event_admin_broadcast(&env),
@@ -120,6 +128,65 @@ fn init_event_structure_validation() {
     // Verify event data contains usdc address
     let data: Address = event.2.into_val(&env);
     assert_eq!(data, usdc_addr);
+}
+
+#[test]
+fn distribute_lifecycle_events_have_stable_topics_and_payloads() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let developer = Address::generate(&env);
+    let asset = env.register_stellar_asset_contract_v2(admin.clone());
+    let pool_addr = env.register(RevenuePool, ());
+    let client = RevenuePoolClient::new(&env, &pool_addr);
+
+    client.init(&admin, &asset.address());
+    token::StellarAssetClient::new(&env, &asset.address()).mint(&pool_addr, &1_000_000);
+    client.distribute(&admin, &developer, &1_000_000);
+
+    let lifecycle_events: std::vec::Vec<_> = env
+        .events()
+        .all()
+        .iter()
+        .filter(|event| {
+            event
+                .1
+                .get(0)
+                .and_then(|value| Symbol::try_from_val(&env, &value).ok())
+                .map(|topic| {
+                    topic == Symbol::new(&env, "distribute_started")
+                        || topic == Symbol::new(&env, "distribute_completed")
+                })
+                .unwrap_or(false)
+        })
+        .collect();
+
+    assert_eq!(lifecycle_events.len(), 2);
+    assert_eq!(lifecycle_events[0].1.len(), 3);
+    assert_eq!(
+        Symbol::try_from_val(&env, &lifecycle_events[0].1.get(0).unwrap()).unwrap(),
+        Symbol::new(&env, "distribute_started")
+    );
+    assert_eq!(
+        Symbol::try_from_val(&env, &lifecycle_events[1].1.get(0).unwrap()).unwrap(),
+        Symbol::new(&env, "distribute_completed")
+    );
+
+    for event in lifecycle_events {
+        let caller = Address::try_from_val(&env, &event.1.get(1).unwrap()).unwrap();
+        let recipient = Address::try_from_val(&env, &event.1.get(2).unwrap()).unwrap();
+        let payload = events::DistributionLifecycleEvent::try_from_val(&env, &event.2).unwrap();
+
+        assert_eq!(caller, admin);
+        assert_eq!(recipient, developer);
+        assert_eq!(payload.version, events::DISTRIBUTION_EVENT_VERSION);
+        assert_eq!(payload.amount, 1_000_000);
+        assert_eq!(payload.mode, events::DistributionMode::Single);
+        assert_eq!(payload.batch_index, 0);
+        assert_eq!(payload.batch_size, 1);
+        assert_eq!(payload.ledger_sequence, env.ledger().sequence());
+        assert_eq!(payload.timestamp, env.ledger().timestamp());
+    }
 }
 
 #[test]

--- a/docs/EVENTS_INDEX.md
+++ b/docs/EVENTS_INDEX.md
@@ -112,6 +112,8 @@ individual events through the ladder as indexer needs arise.
 | `set_max_distribute` | `event_set_max_distribute` | admin | `(old_max, max_distribute)` |
 | `distribute` | `event_distribute` | — | — |
 | `batch_distribute` | `event_batch_distribute` | — | — |
+| `distribute_started` | `event_distribute_started` | caller, recipient | `DistributionLifecycleEvent` |
+| `distribute_completed` | `event_distribute_completed` | caller, recipient | `DistributionLifecycleEvent` |
 | `upgraded` | `event_upgraded` | — | new WASM hash |
 | `admin_broadcast` | `event_admin_broadcast` | caller | `AdminBroadcast { severity, message }` |
 

--- a/docs/EVENT_TOPICS.md
+++ b/docs/EVENT_TOPICS.md
@@ -162,13 +162,15 @@ Source: [`contracts/revenue_pool/src/events.rs`](../contracts/revenue_pool/src/e
 | 14 | `set_max_distribute`            | `event_set_max_distribute`            | Per-leg distribution cap updated             |
 | 15 | `distribute`                    | `event_distribute`                    | USDC distributed to a single developer       |
 | 16 | `batch_distribute`              | `event_batch_distribute`              | One payment leg in a batch distribution      |
-| 17 | `upgraded`                      | `event_upgraded`                      | Contract upgraded to new WASM                |
-| 18 | `admin_broadcast`               | `event_admin_broadcast`               | Admin emergency broadcast                    |
-| 19 | `emergency_drain_proposed`      | `event_emergency_drain_proposed`      | Timelocked emergency drain proposed          |
-| 20 | `emergency_drain_executed`      | `event_emergency_drain_executed`      | Pending emergency drain executed             |
-| 21 | `emergency_drain_cancelled`     | `event_emergency_drain_cancelled`     | Pending emergency drain cancelled            |
+| 17 | `distribute_started`            | `event_distribute_started`            | Validated distribution transfer is starting  |
+| 18 | `distribute_completed`          | `event_distribute_completed`          | Distribution transfer completed              |
+| 19 | `upgraded`                      | `event_upgraded`                      | Contract upgraded to new WASM                |
+| 20 | `admin_broadcast`               | `event_admin_broadcast`               | Admin emergency broadcast                    |
+| 21 | `emergency_drain_proposed`      | `event_emergency_drain_proposed`      | Timelocked emergency drain proposed          |
+| 22 | `emergency_drain_executed`      | `event_emergency_drain_executed`      | Pending emergency drain executed             |
+| 23 | `emergency_drain_cancelled`     | `event_emergency_drain_cancelled`     | Pending emergency drain cancelled            |
 
-**Total: 21 topics**
+**Total: 23 topics**
 
 ---
 
@@ -208,7 +210,8 @@ RevenuePool:  GCONTRACT_REVENUE_POOL...
 `pause_guardian_set`, `pause_guardian_cleared`, `pause_set`,
 `receive_payment`, `yield_deposited`, `treasury_transfer_started`,
 `treasury_transfer_completed`, `treasury_cancelled`, `set_max_distribute`,
-`batch_distribute`, `emergency_drain_proposed`, `emergency_drain_executed`,
+`batch_distribute`, `distribute_started`, `distribute_completed`,
+`emergency_drain_proposed`, `emergency_drain_executed`,
 `emergency_drain_cancelled`
 
 **Shared across contracts** (disambiguate by contract address):
@@ -223,8 +226,8 @@ RevenuePool:  GCONTRACT_REVENUE_POOL...
 |---------------|--------|---------------------|--------|
 | vault         | 36     | 27                  | 9      |
 | settlement    | 18     | 12                  | 6      |
-| revenue_pool  | 21     | 15                  | 6      |
-| **Total**     | **75** | **54**              | **21** |
+| revenue_pool  | 23     | 17                  | 6      |
+| **Total**     | **77** | **56**              | **21** |
 
 > Shared count: each unique topic string that appears in more than one
 > contract is counted once per contract it appears in. The shared topic


### PR DESCRIPTION
## Summary

- add stable `distribute_started` and `distribute_completed` lifecycle topics
- publish a versioned structured payload with amount, mode, batch position, ledger sequence, and timestamp
- include caller and recipient as indexed topics for both single and batch distributions
- preserve the existing `distribute` and `batch_distribute` events for backward compatibility
- document and test all 23 revenue-pool event topics

## Why

The issue references a conceptual `contracts/distribute` contract, while distribution is implemented by `contracts/revenue_pool` in this repository. This change adds the requested indexer-facing lifecycle data at the actual distribution entry points without breaking consumers of the legacy event schema.

## Validation

- `cargo test -p callora-revenue-pool` (110 passed)
- `cargo clippy -p callora-revenue-pool --all-targets -- -D warnings`
- `scripts/check-event-shape.sh`
- `git diff --check`

Note: repository-wide `cargo fmt --all -- --check` is currently blocked by a pre-existing syntax error in `contracts/revenue_pool/fuzz/targets/main.rs`; all Rust files changed by this PR were formatted directly with `rustfmt`.

### Upstream CI baseline

The repository's `main` branch is already failing CI at the base commit (`d5cc7d7`), including CI, coverage, and WASM-size workflows. This PR shows the same unrelated settlement failures (`emit_deposit`, `DepositEvent`, and `migrate_v1_to_v2` are duplicated); its event-shape job passes. The scoped revenue-pool suite and strict Clippy checks listed above are green.

Closes #852
