### PR TITLE
Add global admin cooldown for vault critical actions

### DIFF
--- a/contracts/vault/src/admin.rs
+++ b/contracts/vault/src/admin.rs
@@ -1,0 +1,181 @@
+//! Global cool-off guard for critical vault admin actions.
+//!
+//! The vault already timelocks pause, upgrade, and sweep proposals. Because
+//! those proposal slots are independent, several actions can mature together
+//! and otherwise be executed back-to-back. This module enforces one global
+//! cool-off window between successful critical executions, giving monitors and
+//! governance time to react before another sensitive operation can run.
+
+use crate::{StorageKey, VaultError};
+use soroban_sdk::{contracttype, Env, Symbol};
+
+/// Minimum configurable cool-off window: one second.
+pub const MIN_COOLDOWN_SECONDS: u64 = 1;
+
+/// Maximum configurable cool-off window: thirty days.
+pub const MAX_COOLDOWN_SECONDS: u64 = 30 * 24 * 60 * 60;
+
+/// Default cool-off window: one hour.
+pub const DEFAULT_COOLDOWN_SECONDS: u64 = 60 * 60;
+
+/// Audit record for the most recently executed critical admin action.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct CriticalAdminAction {
+    /// Stable action tag such as `"pause"`, `"upgrade"`, or `"sweep"`.
+    pub action: Symbol,
+    /// Ledger timestamp at which the action was executed.
+    pub executed_at: u64,
+}
+
+/// Return the configured cool-off window, falling back to the secure default.
+pub fn get_cooldown(env: &Env) -> u64 {
+    match env.storage().instance().get(&StorageKey::AdminCooldown) {
+        Some(seconds) => seconds,
+        None => DEFAULT_COOLDOWN_SECONDS,
+    }
+}
+
+/// Validate and persist a new global cool-off window.
+///
+/// # Errors
+/// Returns [`VaultError::InvalidAdminCooldown`] when `seconds` is outside
+/// [`MIN_COOLDOWN_SECONDS`]..=[`MAX_COOLDOWN_SECONDS`].
+pub fn set_cooldown(env: &Env, seconds: u64) -> Result<(), VaultError> {
+    if !(MIN_COOLDOWN_SECONDS..=MAX_COOLDOWN_SECONDS).contains(&seconds) {
+        return Err(VaultError::InvalidAdminCooldown);
+    }
+
+    env.storage()
+        .instance()
+        .set(&StorageKey::AdminCooldown, &seconds);
+    Ok(())
+}
+
+/// Return the last successfully executed critical admin action, if any.
+pub fn last_action(env: &Env) -> Option<CriticalAdminAction> {
+    env.storage()
+        .instance()
+        .get(&StorageKey::LastCriticalAdminAction)
+}
+
+/// Return the timestamp at which the next critical action becomes available.
+///
+/// Saturating arithmetic prevents timestamp wraparound. A vault with no prior
+/// critical action returns `0`, meaning an action may execute immediately.
+pub fn ready_at(env: &Env) -> u64 {
+    match last_action(env) {
+        Some(record) => record.executed_at.saturating_add(get_cooldown(env)),
+        None => 0,
+    }
+}
+
+/// Return the seconds remaining in the global admin cool-off window.
+pub fn remaining(env: &Env) -> u64 {
+    ready_at(env).saturating_sub(env.ledger().timestamp())
+}
+
+/// Return whether a critical admin action may execute at the current timestamp.
+pub fn is_ready(env: &Env) -> bool {
+    remaining(env) == 0
+}
+
+/// Enforce and arm the global cool-off window for `action`.
+///
+/// Call this only after authorization, proposal, timelock, and action-specific
+/// validations have succeeded. Soroban transaction rollback ensures the record
+/// is not retained if the subsequent critical operation fails.
+///
+/// # Errors
+/// Returns [`VaultError::AdminCooldownActive`] while another critical action's
+/// cool-off window is still active.
+pub fn guard(env: &Env, action: Symbol) -> Result<(), VaultError> {
+    if !is_ready(env) {
+        return Err(VaultError::AdminCooldownActive);
+    }
+
+    let record = CriticalAdminAction {
+        action,
+        executed_at: env.ledger().timestamp(),
+    };
+    env.storage()
+        .instance()
+        .set(&StorageKey::LastCriticalAdminAction, &record);
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use soroban_sdk::testutils::Ledger as _;
+    use soroban_sdk::{contract, Env};
+
+    #[contract]
+    struct CooldownHarness;
+
+    fn in_contract<T>(env: &Env, f: impl FnOnce() -> T) -> T {
+        let contract_id = env.register(CooldownHarness, ());
+        env.as_contract(&contract_id, f)
+    }
+
+    #[test]
+    fn defaults_and_configuration_bounds_are_stable() {
+        let env = Env::default();
+        in_contract(&env, || {
+            assert_eq!(VaultError::AdminCooldownActive as u32, 49);
+            assert_eq!(VaultError::InvalidAdminCooldown as u32, 50);
+            assert_eq!(get_cooldown(&env), DEFAULT_COOLDOWN_SECONDS);
+            assert_eq!(set_cooldown(&env, 0), Err(VaultError::InvalidAdminCooldown));
+            assert_eq!(
+                set_cooldown(&env, MAX_COOLDOWN_SECONDS.saturating_add(1)),
+                Err(VaultError::InvalidAdminCooldown)
+            );
+            assert_eq!(set_cooldown(&env, MIN_COOLDOWN_SECONDS), Ok(()));
+            assert_eq!(get_cooldown(&env), MIN_COOLDOWN_SECONDS);
+            assert_eq!(set_cooldown(&env, MAX_COOLDOWN_SECONDS), Ok(()));
+            assert_eq!(get_cooldown(&env), MAX_COOLDOWN_SECONDS);
+        });
+    }
+
+    #[test]
+    fn one_action_blocks_a_different_critical_action_until_boundary() {
+        let env = Env::default();
+        env.ledger().set_timestamp(1_000);
+        in_contract(&env, || {
+            set_cooldown(&env, 300).unwrap();
+            assert_eq!(guard(&env, Symbol::new(&env, "pause")), Ok(()));
+            assert_eq!(remaining(&env), 300);
+            assert_eq!(
+                guard(&env, Symbol::new(&env, "sweep")),
+                Err(VaultError::AdminCooldownActive)
+            );
+
+            env.ledger().set_timestamp(1_299);
+            assert_eq!(remaining(&env), 1);
+            assert!(!is_ready(&env));
+
+            env.ledger().set_timestamp(1_300);
+            assert!(is_ready(&env));
+            assert_eq!(guard(&env, Symbol::new(&env, "sweep")), Ok(()));
+
+            let record = last_action(&env).expect("critical action record");
+            assert_eq!(record.action, Symbol::new(&env, "sweep"));
+            assert_eq!(record.executed_at, 1_300);
+        });
+    }
+
+    #[test]
+    fn readiness_math_saturates_at_timestamp_limit() {
+        let env = Env::default();
+        env.ledger().set_timestamp(u64::MAX - 10);
+        in_contract(&env, || {
+            set_cooldown(&env, 60).unwrap();
+            guard(&env, Symbol::new(&env, "upgrade")).unwrap();
+            assert_eq!(ready_at(&env), u64::MAX);
+            assert_eq!(remaining(&env), 10);
+
+            env.ledger().set_timestamp(u64::MAX);
+            assert!(is_ready(&env));
+        });
+    }
+}

--- a/contracts/vault/src/errors.rs
+++ b/contracts/vault/src/errors.rs
@@ -46,6 +46,8 @@ use soroban_sdk::contracterror;
 /// | 36   | RateLimited                    | Developer rate limit has been exceeded                   |
 /// | 37   | PausedState                    | Operation is rejected because the vault is paused        |
 /// | 44   | CallerNotInAllowlist           | Caller not in allowlist and not owner                    |
+/// | 49   | AdminCooldownActive            | Critical admin cool-off window is still active           |
+/// | 50   | InvalidAdminCooldown           | Admin cool-off window is outside accepted bounds         |
 #[contracterror]
 #[repr(u32)]
 #[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
@@ -146,4 +148,8 @@ pub enum VaultError {
     /// Returned instead of panicking to provide machine-readable feedback to
     /// integrators and prevent information leakage.
     CallerNotInAllowlist = 44,
+    /// A critical admin action is still inside the global cool-off window (code 49).
+    AdminCooldownActive = 49,
+    /// Admin cool-off window is outside the accepted bounds (code 50).
+    InvalidAdminCooldown = 50,
 }

--- a/contracts/vault/src/lib.rs
+++ b/contracts/vault/src/lib.rs
@@ -17,6 +17,11 @@
 //! defaults to 48 h (`172_800`). Valid bounds are 1 h – 30 d. All three slots
 //! are independent so multiple proposals can coexist concurrently.
 //!
+//! Successful executions also share a global admin cool-off window. This
+//! prevents several independently matured proposals from being executed in
+//! rapid succession. The window defaults to one hour and is configurable with
+//! `set_admin_cooldown` within the bounds exposed by [`admin`].
+//!
 ///
 /// ## Pause Circuit Breaker
 ///
@@ -51,6 +56,7 @@ use soroban_sdk::{
     contract, contractclient, contractimpl, contracttype, Address, BytesN, Env, String, Symbol, Vec,
 };
 
+pub mod admin;
 pub mod timelock;
 pub mod views;
 
@@ -150,6 +156,10 @@ pub enum VaultError {
     InvalidTimelockWindow = 40,
     /// Caller is not in the allowlist and is not the owner (code 44).
     CallerNotInAllowlist = 44,
+    /// A critical admin action is still inside the global cool-off window (code 49).
+    AdminCooldownActive = 49,
+    /// Admin cool-off window is outside the accepted bounds (code 50).
+    InvalidAdminCooldown = 50,
 }
 
 #[contracttype]
@@ -193,6 +203,10 @@ pub enum StorageKey {
     ContractVersion,
     /// Vector of addresses allowed to deposit (owner-managed allowlist).
     AllowedDepositors,
+    /// Global cool-off window between critical admin executions.
+    AdminCooldown,
+    /// Audit record for the most recently executed critical admin action.
+    LastCriticalAdminAction,
 }
 
 /// Ledgers per day at a 5-second close cadence.
@@ -1091,6 +1105,50 @@ impl CalloraVault {
     }
 
     // -----------------------------------------------------------------------
+    // Critical admin action cooldown
+    // -----------------------------------------------------------------------
+
+    /// Return the global cool-off window between critical admin executions.
+    ///
+    /// The secure one-hour default is returned until an admin explicitly sets
+    /// a value. This read-only view requires no authorization.
+    pub fn get_admin_cooldown(env: Env) -> u64 {
+        admin::get_cooldown(&env)
+    }
+
+    /// Configure the global cool-off window between critical admin executions.
+    ///
+    /// # Authorization
+    /// `caller` must be the current admin and must authorize this invocation.
+    ///
+    /// # Errors
+    /// - [`VaultError::Unauthorized`] when `caller` is not the current admin.
+    /// - [`VaultError::NotInitialized`] when the vault has no configured admin.
+    /// - [`VaultError::InvalidAdminCooldown`] when `seconds` is outside
+    ///   [`admin::MIN_COOLDOWN_SECONDS`]..=[`admin::MAX_COOLDOWN_SECONDS`].
+    pub fn set_admin_cooldown(env: Env, caller: Address, seconds: u64) -> Result<(), VaultError> {
+        Self::require_admin(&env, &caller)?;
+        admin::set_cooldown(&env, seconds)?;
+        Self::bump_instance_ttl(&env);
+        Ok(())
+    }
+
+    /// Return seconds remaining before another critical admin action may run.
+    pub fn admin_cooldown_remaining(env: Env) -> u64 {
+        admin::remaining(&env)
+    }
+
+    /// Return whether a critical admin action may execute now.
+    pub fn is_admin_action_ready(env: Env) -> bool {
+        admin::is_ready(&env)
+    }
+
+    /// Return the most recently executed critical admin action, if any.
+    pub fn get_last_critical_admin_action(env: Env) -> Option<admin::CriticalAdminAction> {
+        admin::last_action(&env)
+    }
+
+    // -----------------------------------------------------------------------
     // Timelock window
     // -----------------------------------------------------------------------
 
@@ -1165,6 +1223,7 @@ impl CalloraVault {
         if env.ledger().timestamp() < proposal.execute_after {
             return Err(VaultError::TimelockNotExpired);
         }
+        admin::guard(&env, Symbol::new(&env, "pause"))?;
         env.storage().instance().set(&DataKey::Paused, &true);
         timelock::clear_pending_pause(&env);
         env.events().publish(
@@ -1225,6 +1284,7 @@ impl CalloraVault {
         if env.ledger().timestamp() < proposal.execute_after {
             return Err(VaultError::TimelockNotExpired);
         }
+        admin::guard(&env, Symbol::new(&env, "upgrade"))?;
         let wasm_hash = proposal.wasm_hash.clone();
         let _admin = Self::get_admin(env.clone())?;
         env.deployer()
@@ -1327,6 +1387,7 @@ impl CalloraVault {
         if usdc.balance(&env.current_contract_address()) < proposal.amount {
             return Err(VaultError::InsufficientBalance);
         }
+        admin::guard(&env, Symbol::new(&env, "sweep"))?;
         usdc.transfer(
             &env.current_contract_address(),
             &proposal.to,

--- a/docs/ERROR_CODES.md
+++ b/docs/ERROR_CODES.md
@@ -63,6 +63,8 @@ must not be reassigned once released.
 | 46 | `TimelockOverflow` | Vault | `proposed_at + window` overflowed `u64` |
 | 47 | `InvalidTimelockWindow` | Vault | Proposed timelock window is outside the allowed `MIN..=MAX` bounds |
 | 48 | `BelowMinTransferAmount` | Vault | Amount is below the vault's configured minimum transfer unit (rejects sub-unit/dust transfers); currently enforced on `propose_sweep` |
+| 49 | `AdminCooldownActive` | Vault | A critical admin action is still inside the global cool-off window |
+| 50 | `InvalidAdminCooldown` | Vault | Admin cool-off window is outside the accepted bounds |
 
 ## Settlement
 

--- a/docs/VAULT_ADMIN_COOLDOWN.md
+++ b/docs/VAULT_ADMIN_COOLDOWN.md
@@ -1,0 +1,32 @@
+# Vault Critical-Action Cooldown
+
+The vault applies one global cool-off window between successful executions of
+its three timelocked critical admin actions:
+
+- `execute_pause`
+- `execute_upgrade`
+- `execute_sweep`
+
+The global design is intentional. Pause, upgrade, and sweep proposals use
+independent slots and may mature together; a per-action cooldown would still
+allow all three to execute back-to-back. The shared guard permits the first
+execution and rejects subsequent critical executions with
+`VaultError::AdminCooldownActive` until the window expires.
+
+## Configuration and views
+
+The default window is 3,600 seconds. An authenticated current admin may call
+`set_admin_cooldown(caller, seconds)` with a value from 1 second through 30
+days. Values outside this range return `VaultError::InvalidAdminCooldown`.
+
+Read-only integrations can use:
+
+- `get_admin_cooldown()` for the configured window
+- `admin_cooldown_remaining()` for seconds until the next execution
+- `is_admin_action_ready()` for a direct readiness check
+- `get_last_critical_admin_action()` for the last action tag and timestamp
+
+Cooldown arithmetic is saturating. The guard is armed only after authorization,
+proposal lookup, timelock expiry, and action-specific validation succeed. If the
+subsequent contract operation fails, Soroban transaction rollback also reverts
+the cooldown record.


### PR DESCRIPTION
## Summary

- add a global cool-off guard between successful vault pause, upgrade, and sweep executions
- add authenticated cooldown configuration plus readiness, remaining-time, and last-action views
- persist a structured audit record containing the last critical action tag and timestamp
- use saturating timestamp arithmetic and arm the guard only after action-specific validation
- add stable error codes and focused documentation

## Why

The issue references a conceptual `contracts/escrow` path; in this repository, `contracts/vault` is the escrow that holds user USDC and exposes the critical admin escape hatches.

The cooldown is global rather than per action. Pause, upgrade, and sweep proposals use independent slots and can mature together, so per-action timers would still permit all three actions to execute back-to-back. The shared guard creates an actual response window between any two critical executions.

## Security properties

- `set_admin_cooldown` uses the existing `require_admin` path, including `caller.require_auth()`
- the window is bounded from 1 second through 30 days and defaults to 1 hour
- failed or premature executions do not arm the cooldown
- subsequent operation failure rolls back the cooldown record with the transaction
- timestamp calculations use saturating arithmetic
- new storage variants are appended, preserving existing key encodings

## Validation

- isolated Soroban 22 harness importing the exact production `contracts/vault/src/admin.rs`: 3 passed
- isolated `cargo clippy --all-targets -- -D warnings`
- targeted `rustfmt --check`
- `git diff --check`

### Upstream baseline limitation

`cargo test --manifest-path contracts/vault/Cargo.toml --lib` fails before compilation because the vault package is intentionally omitted from the root workspace. Commit `99dc38a` documents that removal as a response to 112+ pre-existing structural compilation errors. This PR does not broaden scope into that unrelated vault reconstruction; the new security module is validated independently against the repository's Soroban 22 version.

The repository's `main` branch is also already failing CI at the base commit (`d5cc7d7`) due to duplicate settlement definitions and workspace-formatting defects. This PR produces the same unrelated failures while its event-shape job passes.

Closes #854
