### PR TITLE
feat(hot): add criterion benchmarks for hot entrypoints

### DIFF
--- a/BENCHMARKS.md
+++ b/BENCHMARKS.md
@@ -56,3 +56,47 @@ Soroban fees are configured per network (e.g. Pubnet). They are applied to:
 - Rent for persistent/temporary storage
 
 See [Stellar documentation on Fees and Resource Limits](https://developers.stellar.org/docs/encyclopedia/fees-and-resource-limits) for current fee parameters and a detailed breakdown of metering operations.
+
+# Hot Contract Criterion Benchmarks
+
+The `callora-hot` contract includes `criterion` benchmarks for its hot entrypoints to track performance over time. Benchmarks are located at `contracts/hot/benches/main.rs`.
+
+## Running
+
+```bash
+cargo bench -p callora-hot
+```
+
+This runs all registered benchmarks and prints per-entrypoint timing statistics.
+
+## Benchmark Targets
+
+| Target | Description |
+|---|---|
+| `hot/is_paused` | Read paused flag from instance storage |
+| `hot/get_admin` | Read current admin address |
+| `hot/get_signer` | Read current hot signer address |
+| `hot/get_cooldown` | Read configured cool-off window |
+| `hot/get_pending_admin` | Read pending admin (two-step rotation) |
+| `hot/cooldown_remaining` | Compute remaining cooldown for an action |
+| `hot/is_ready` | Check whether an action may run now |
+| `hot/pause` | Critical action: set paused flag (cooldown-guarded) |
+| `hot/unpause` | Critical action: clear paused flag (cooldown-guarded) |
+| `hot/rotate_signer` | Critical action: rotate hot signer (cooldown-guarded) |
+| `hot/set_cooldown` | Update global cool-off window |
+| `hot/set_admin` | Nominate new admin (two-step rotation) |
+| `hot/accept_admin` | Accept pending admin transfer |
+
+Cooldown-guarded critical actions (`pause`, `unpause`, `rotate_signer`) advance the ledger timestamp by `COOLDOWN_SECS + 1` between iterations so each invocation is accepted.
+
+## Baseline
+
+Run `cargo bench -p callora-hot -- --save-baseline main` to capture a baseline. Future runs can be compared with:
+
+```bash
+cargo bench -p callora-hot -- --baseline main
+```
+
+## Dev-Dependency
+
+`criterion = "0.5"` is added as a dev-dependency in `contracts/hot/Cargo.toml`. This does not affect the production WASM artifact.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15,6 +15,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -22,6 +31,18 @@ checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
+name = "anstyle"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
 
 [[package]]
 name = "arbitrary"
@@ -256,6 +277,7 @@ dependencies = [
 name = "callora-contracts-e2e"
 version = "0.0.0"
 dependencies = [
+ "callora-distribute",
  "callora-revenue-pool",
  "callora-settlement",
  "soroban-sdk",
@@ -268,6 +290,13 @@ dependencies = [
  "callora-revenue-pool",
  "callora-settlement",
  "rand 0.8.7",
+ "soroban-sdk",
+]
+
+[[package]]
+name = "callora-distribute"
+version = "0.0.1"
+dependencies = [
  "soroban-sdk",
 ]
 
@@ -287,6 +316,7 @@ version = "0.1.0"
 name = "callora-hot"
 version = "0.1.0"
 dependencies = [
+ "criterion",
  "soroban-sdk",
 ]
 
@@ -355,6 +385,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "callora-yield"
+version = "0.0.1"
+dependencies = [
+ "callora-revenue-pool",
+ "soroban-sdk",
+]
+
+[[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
 name = "cc"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -383,6 +427,58 @@ dependencies = [
  "serde",
  "windows-link",
 ]
+
+[[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
+]
+
+[[package]]
+name = "clap"
+version = "4.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d91e0c145792ef73a6ad36d27c75ac09f1832222a3c209689d90f534685ee5b7"
+dependencies = [
+ "clap_builder",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f09628afdcc538b57f3c6341e9c8e9970f18e4a481690a64974d7023bd33548b"
+dependencies = [
+ "anstyle",
+ "clap_lex",
+]
+
+[[package]]
+name = "clap_lex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "const-oid"
@@ -415,6 +511,73 @@ dependencies = [
  "serde_derive",
  "serde_json",
 ]
+
+[[package]]
+name = "criterion"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
+dependencies = [
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot",
+ "is-terminal",
+ "itertools",
+ "num-traits",
+ "once_cell",
+ "oorandom",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+dependencies = [
+ "cast",
+ "itertools",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5181e0de7b61eb03a81e347d6dd8797bae9da5146707b51077e2d71a54ec0ceb"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-bigint"
@@ -826,6 +989,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -845,6 +1019,12 @@ name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+
+[[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "hex"
@@ -928,6 +1108,17 @@ name = "indexmap-nostd"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e04e2fd2b8188ea827b32ef11de88377086d690286ab35747ef7f9bf3ccb590"
+
+[[package]]
+name = "is-terminal"
+version = "0.4.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "windows-sys",
+]
 
 [[package]]
 name = "itertools"
@@ -1078,6 +1269,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
+name = "oorandom"
+version = "11.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
+
+[[package]]
 name = "p256"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1109,6 +1306,34 @@ checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
 dependencies = [
  "der",
  "spki",
+]
+
+[[package]]
+name = "plotters"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aeb6f403d7a4911efb1e33402027fc44f29b5bf6def3effcc22d7bb75f2b747"
+dependencies = [
+ "num-traits",
+ "plotters-backend",
+ "plotters-svg",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df42e13c12958a16b3f7f4386b9ab1f3e7933914ecea48da7139435263a4172a"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
+dependencies = [
+ "plotters-backend",
 ]
 
 [[package]]
@@ -1269,6 +1494,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "rayon"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "ref-cast"
 version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1286,6 +1531,29 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 3.0.3",
+]
+
+[[package]]
+name = "regex"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f020237b6c8eed93db2e2cb53c00c60a8e1bc73da7d073199a1180401450218d"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fcfdb36bda0c880c5931cdc7a2bcdc8ba4556847b9d912bca70bc94708711ad"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -1342,6 +1610,15 @@ dependencies = [
  "quick-error",
  "tempfile",
  "wait-timeout",
+]
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
 ]
 
 [[package]]
@@ -1858,6 +2135,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "tinyvec"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1903,6 +2190,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
 ]
 
 [[package]]
@@ -2000,6 +2297,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d5a015fe95f3504a94bb1462c717aae75253e39b9dd6c3fb1062c934535c64aa"
 dependencies = [
  "indexmap-nostd",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.103"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8622dcb61c0bcc9fffa6938bed81210af2da9a7e4a1a834b2e37a59b6dfb6141"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys",
 ]
 
 [[package]]

--- a/contracts/hot/Cargo.toml
+++ b/contracts/hot/Cargo.toml
@@ -13,3 +13,8 @@ soroban-sdk = { workspace = true }
 
 [dev-dependencies]
 soroban-sdk = { workspace = true, features = ["testutils"] }
+criterion = "0.5"
+
+[[bench]]
+name = "main"
+harness = false

--- a/contracts/hot/benches/main.rs
+++ b/contracts/hot/benches/main.rs
@@ -1,0 +1,149 @@
+use callora_hot::{CalloraHot, CalloraHotClient, ACTION_PAUSE};
+use criterion::{criterion_group, criterion_main, Criterion};
+use soroban_sdk::testutils::{Address as _, Ledger as _};
+use soroban_sdk::{Address, Env, Symbol};
+
+const COOLDOWN_SECS: u64 = 1;
+
+fn setup() -> (Env, Address, CalloraHotClient<'static>) {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let signer = Address::generate(&env);
+    let contract_id = env.register(CalloraHot, ());
+    let client = CalloraHotClient::new(&env, &contract_id);
+    client.init(&admin, &signer, &Some(COOLDOWN_SECS));
+    (env, admin, client)
+}
+
+fn bench_is_paused(c: &mut Criterion) {
+    let (_env, _admin, client) = setup();
+    c.bench_function("hot/is_paused", |b| b.iter(|| client.is_paused()));
+}
+
+fn bench_get_admin(c: &mut Criterion) {
+    let (_env, _admin, client) = setup();
+    c.bench_function("hot/get_admin", |b| {
+        b.iter(|| criterion::black_box(client.get_admin()))
+    });
+}
+
+fn bench_get_signer(c: &mut Criterion) {
+    let (_env, _admin, client) = setup();
+    c.bench_function("hot/get_signer", |b| {
+        b.iter(|| criterion::black_box(client.get_signer()))
+    });
+}
+
+fn bench_get_cooldown(c: &mut Criterion) {
+    let (_env, _admin, client) = setup();
+    c.bench_function("hot/get_cooldown", |b| {
+        b.iter(|| criterion::black_box(client.get_cooldown()))
+    });
+}
+
+fn bench_get_pending_admin(c: &mut Criterion) {
+    let (_env, _admin, client) = setup();
+    c.bench_function("hot/get_pending_admin", |b| {
+        b.iter(|| criterion::black_box(client.get_pending_admin()))
+    });
+}
+
+fn bench_cooldown_remaining(c: &mut Criterion) {
+    let (env, _admin, client) = setup();
+    let action = Symbol::new(&env, ACTION_PAUSE);
+    c.bench_function("hot/cooldown_remaining", |b| {
+        b.iter(|| criterion::black_box(client.cooldown_remaining(&action)))
+    });
+}
+
+fn bench_is_ready(c: &mut Criterion) {
+    let (env, _admin, client) = setup();
+    let action = Symbol::new(&env, ACTION_PAUSE);
+    c.bench_function("hot/is_ready", |b| {
+        b.iter(|| criterion::black_box(client.is_ready(&action)))
+    });
+}
+
+fn bench_pause(c: &mut Criterion) {
+    let (env, admin, client) = setup();
+    c.bench_function("hot/pause", |b| {
+        b.iter(|| {
+            env.ledger()
+                .set_timestamp(env.ledger().timestamp() + COOLDOWN_SECS + 1);
+            client.pause(&admin)
+        })
+    });
+}
+
+fn bench_unpause(c: &mut Criterion) {
+    let (env, admin, client) = setup();
+    c.bench_function("hot/unpause", |b| {
+        b.iter(|| {
+            env.ledger()
+                .set_timestamp(env.ledger().timestamp() + COOLDOWN_SECS + 1);
+            client.unpause(&admin)
+        })
+    });
+}
+
+fn bench_rotate_signer(c: &mut Criterion) {
+    let (env, admin, client) = setup();
+    c.bench_function("hot/rotate_signer", |b| {
+        b.iter(|| {
+            env.ledger()
+                .set_timestamp(env.ledger().timestamp() + COOLDOWN_SECS + 1);
+            let new_signer = Address::generate(&env);
+            client.rotate_signer(&admin, &new_signer)
+        })
+    });
+}
+
+fn bench_set_cooldown(c: &mut Criterion) {
+    let (_env, admin, client) = setup();
+    c.bench_function("hot/set_cooldown", |b| {
+        b.iter(|| client.set_cooldown(&admin, &60))
+    });
+}
+
+fn bench_set_admin(c: &mut Criterion) {
+    let (env, admin, client) = setup();
+    c.bench_function("hot/set_admin", |b| {
+        b.iter(|| {
+            let new_admin = Address::generate(&env);
+            client.set_admin(&admin, &new_admin)
+        })
+    });
+}
+
+fn bench_accept_admin(c: &mut Criterion) {
+    let (env, admin, client) = setup();
+    let mut current_admin = admin;
+    let mut new_admin = Address::generate(&env);
+    c.bench_function("hot/accept_admin", |b| {
+        b.iter(|| {
+            client.set_admin(&current_admin, &new_admin);
+            client.accept_admin(&new_admin);
+            current_admin = new_admin.clone();
+            new_admin = Address::generate(&env);
+        })
+    });
+}
+
+criterion_group!(
+    benches,
+    bench_is_paused,
+    bench_get_admin,
+    bench_get_signer,
+    bench_get_cooldown,
+    bench_get_pending_admin,
+    bench_cooldown_remaining,
+    bench_is_ready,
+    bench_pause,
+    bench_unpause,
+    bench_rotate_signer,
+    bench_set_cooldown,
+    bench_set_admin,
+    bench_accept_admin,
+);
+criterion_main!(benches);

--- a/contracts/hot/src/test.rs
+++ b/contracts/hot/src/test.rs
@@ -278,3 +278,47 @@ fn test_new_admin_controls_cooldown_after_rotation() {
     client.set_cooldown(&new_admin, &120);
     assert_eq!(client.get_cooldown(), 120);
 }
+
+// ===========================================================================
+// Benchmark setup smoke-test (validates benches/main.rs entrypoints)
+// ===========================================================================
+
+#[test]
+fn test_bench_setup_exercises_all_hot_entrypoints() {
+    let (env, admin, _signer, client) = setup(Some(60));
+
+    // Views
+    assert!(!client.is_paused());
+    assert_eq!(client.get_admin(), admin);
+    assert_eq!(client.get_signer(), client.get_signer());
+    assert_eq!(client.get_cooldown(), 60);
+    assert_eq!(client.get_pending_admin(), None);
+
+    let pause = Symbol::new(&env, ACTION_PAUSE);
+    assert_eq!(client.cooldown_remaining(&pause), 0);
+    assert!(client.is_ready(&pause));
+
+    // Critical action with cooldown
+    client.pause(&admin);
+    assert!(client.is_paused());
+
+    advance(&env, 61);
+    assert!(client.is_ready(&pause));
+    client.unpause(&admin);
+    assert!(!client.is_paused());
+
+    advance(&env, 61);
+    let new_signer = Address::generate(&env);
+    client.rotate_signer(&admin, &new_signer);
+    assert_eq!(client.get_signer(), new_signer);
+
+    // Admin config (no cooldown)
+    client.set_cooldown(&admin, &120);
+    assert_eq!(client.get_cooldown(), 120);
+
+    let new_admin = Address::generate(&env);
+    client.set_admin(&admin, &new_admin);
+    assert_eq!(client.get_pending_admin(), Some(new_admin.clone()));
+    client.accept_admin(&new_admin);
+    assert_eq!(client.get_admin(), new_admin);
+}


### PR DESCRIPTION
- Add criterion 0.5 dev-dependency and [[bench]] target in Cargo.toml
- Add benches/main.rs covering all hot entrypoints (views, critical actions, admin config); cooldown-guarded actions advance ledger timestamp between iterations
- Add test_bench_setup_exercises_all_hot_entrypoints smoke test
- Document benchmark targets and usage in BENCHMARKS.md

Closes #884