### PR TITLE
fix: Add auth-context tests for reflector [b#018]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -299,6 +299,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "callora-reflector"
+version = "0.1.0"
+dependencies = [
+ "soroban-sdk",
+]
+
+[[package]]
 name = "callora-registry"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ members = [
     "contracts/registry",
     "contracts/hot",
     "contracts/yield",
+    "contracts/reflector",
 ]
 default-members = [
     "contracts/revenue_pool",
@@ -36,6 +37,7 @@ default-members = [
     "contracts/hot",    "contracts/admin",
     "contracts/validators",
     "contracts/yield",
+    "contracts/reflector",
 ]
 
 [workspace.dependencies]

--- a/contracts/reflector/Cargo.toml
+++ b/contracts/reflector/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "callora-reflector"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[dependencies]
+soroban-sdk = { workspace = true }
+
+[dev-dependencies]
+soroban-sdk = { workspace = true, features = ["testutils"] }

--- a/contracts/reflector/src/lib.rs
+++ b/contracts/reflector/src/lib.rs
@@ -1,0 +1,51 @@
+#![no_std]
+
+use soroban_sdk::{contract, contracterror, contractimpl, contracttype, Address, Env};
+
+/// The storage key used to store the last authenticated signer.
+#[contracttype]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum StorageKey {
+    /// Stores the address of the last caller who executed `reflect_auth`.
+    LastSigner,
+}
+
+/// Errors returned by the Reflector contract.
+#[contracterror]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+#[repr(u32)]
+pub enum Error {
+    /// An unexpected overflow occurred.
+    Overflow = 1,
+}
+
+#[contract]
+pub struct ReflectorContract;
+
+#[contractimpl]
+impl ReflectorContract {
+    /// A state-changing entrypoint that requires authorization from the provided `signer`.
+    /// Captures and stores the signer's identity in instance storage.
+    ///
+    /// # Parameters
+    /// - `env`: The contract environment.
+    /// - `signer`: The address of the caller attempting the action.
+    ///
+    /// # Returns
+    /// - `Result<(), Error>`: Ok on success.
+    pub fn reflect_auth(env: Env, signer: Address) -> Result<(), Error> {
+        // Enforce authorization for the signer.
+        signer.require_auth();
+
+        // Capture the authenticated identity in storage.
+        env.storage().instance().set(&StorageKey::LastSigner, &signer);
+
+        Ok(())
+    }
+
+    /// View function returning the last authenticated signer.
+    pub fn get_last_signer(env: Env) -> Option<Address> {
+        env.storage().instance().get(&StorageKey::LastSigner)
+    }
+}
+

--- a/contracts/reflector/tests/auth.rs
+++ b/contracts/reflector/tests/auth.rs
@@ -1,0 +1,66 @@
+#![cfg(test)]
+
+use callora_reflector::{ReflectorContract, ReflectorContractClient};
+use soroban_sdk::{
+    testutils::{Address as _, AuthorizedFunction, AuthorizedInvocation},
+    Address, Env, IntoVal, Symbol,
+};
+
+#[test]
+fn test_mock_all_auths() {
+    let env = Env::default();
+    env.mock_all_auths(); // Harness 1: mock all auths (e.g. happy path without strict verification)
+
+    let contract_id = env.register(ReflectorContract, ());
+    let client = ReflectorContractClient::new(&env, &contract_id);
+
+    let signer = Address::generate(&env);
+    
+    // Act
+    client.reflect_auth(&signer);
+
+    // Assert identity is captured
+    assert_eq!(client.get_last_signer(), Some(signer.clone()));
+}
+
+#[test]
+fn test_strict_auth_harness() {
+    let env = Env::default();
+    
+    let contract_id = env.register(ReflectorContract, ());
+    let client = ReflectorContractClient::new(&env, &contract_id);
+
+    let signer = Address::generate(&env);
+
+    // Harness 2: strict require_auth flow (mocking the exact invocation)
+    env.mock_auths(&[soroban_sdk::testutils::MockAuth {
+        address: &signer,
+        invoke: &soroban_sdk::testutils::MockAuthInvoke {
+            contract: &contract_id,
+            fn_name: "reflect_auth",
+            args: (&signer,).into_val(&env),
+            sub_invokes: &[],
+        },
+    }]);
+
+    // Act
+    client.reflect_auth(&signer);
+
+    // Assert identity is captured
+    assert_eq!(client.get_last_signer(), Some(signer.clone()));
+}
+
+#[test]
+#[should_panic(expected = "HostError: Error(Auth, InvalidAction)")]
+fn test_missing_auth_panics() {
+    let env = Env::default();
+    
+    let contract_id = env.register(ReflectorContract, ());
+    let client = ReflectorContractClient::new(&env, &contract_id);
+
+    let signer = Address::generate(&env);
+
+    // Harness 3: no auth mocked at all.
+    // The `signer.require_auth()` call inside the contract will trigger a panic in the host.
+    client.reflect_auth(&signer);
+}


### PR DESCRIPTION
### Description
This PR addresses issue #1108 for the GrantFox FWC26 campaign. It implements a simplified `reflector` contract alongside comprehensive tests verifying Soroban's authentication workflows, specifically capturing the signer's identity under multiple auth harnesses.

### Changes Included
- **Reflector Contract**: Created the `callora-reflector` package with a single `reflect_auth` entrypoint.
- **Strict Authorization**: `require_auth()` is enforced on the state-changing entrypoint, capturing the caller's `Address` in Instance storage (`StorageKey::LastSigner`). No `unwrap()` on fallible paths.
- **Auth-Context Test Suites** (`contracts/reflector/tests/auth.rs`):
  - `test_mock_all_auths`: Verifies state mutations process cleanly using `env.mock_all_auths()`.
  - `test_strict_auth_harness`: Uses `env.mock_auths()` with an exact `MockAuthInvoke` payload to rigorously verify the signer identity is captured correctly.
  - `test_missing_auth_panics`: Confirms the contract triggers a host-level auth error when no authorization is provided.
- **NatSpec**: Clear `/// rustdoc` inline documentation on all public items.

### Verification
- `cargo test -p callora-reflector` passes with 3/3 tests passing, no failures.
- Code style aligned with repository linting configuration.

Closes #1108