### PR TITLE
fix(revenue-pool): expand semantic contract errors

### DIFF
--- a/contracts/revenue_pool/BATCH_TRANSFER_IMPLEMENTATION.md
+++ b/contracts/revenue_pool/BATCH_TRANSFER_IMPLEMENTATION.md
@@ -3,6 +3,7 @@
 **Date:** 2026-04-24  
 **Updated:** 2026-05-27 — duplicate recipient detection added  
 **Updated:** 2026-06-25 — typed size-violation errors (`RevenuePoolError`) and `chunk_iter` helper added (#418)  
+**Updated:** 2026-07-28 — all revenue-pool validation failures migrated to semantic `RevenuePoolError` codes (#858)
 **Feature:** Atomic batch transfer with all-or-nothing execution and duplicate-recipient rejection
 
 ---
@@ -18,7 +19,7 @@ every transfer in the batch succeeds or none do.
 ## Duplicate Recipient Policy
 
 **Duplicates are rejected.** If the same `Address` appears more than once in the `payments`
-vector, the call panics with `"duplicate recipient in batch"` and no tokens are moved.
+vector, the call fails with `RevenuePoolError::DuplicateRecipient` and no tokens are moved.
 
 ### Rationale
 
@@ -89,7 +90,7 @@ for payment in payments.iter() {
     let (to, amount) = payment;
 
     if seen.contains_key(to.clone()) {
-        panic!("{}", ERR_DUPLICATE_RECIPIENT); // "duplicate recipient in batch"
+        env.panic_with_error(RevenuePoolError::DuplicateRecipient);
     }
     seen.set(to.clone(), true);
 
@@ -105,24 +106,22 @@ loop — well within budget for `MAX_BATCH_SIZE = 50`.
 
 ## Errors
 
-Batch **size** violations are typed (`#[contracterror] RevenuePoolError`) so integrators
-branch on a numeric code, never a panic string:
+All contract-owned validation failures are typed (`#[contracterror] RevenuePoolError`) so
+integrators branch on numeric codes rather than panic strings:
 
 | Error | Code | Trigger |
 |---|---|---|
 | `RevenuePoolError::BatchEmpty` | `1` | `payments` is empty |
 | `RevenuePoolError::BatchTooLarge` | `2` | `payments.len() > MAX_BATCH_SIZE` |
-
-Remaining per-leg validations still panic with string constants (typed-error migration for
-these is tracked separately):
-
-| Constant | Value |
-|---|---|
-| `ERR_DUPLICATE_RECIPIENT` | `"duplicate recipient in batch"` |
-| `ERR_AMOUNT_NOT_POSITIVE` | `"amount must be positive"` |
-| `ERR_AMOUNT_EXCEEDS_MAX_DISTRIBUTE` | `"amount exceeds max_distribute"` |
-| `ERR_INSUFFICIENT_BALANCE` | `"insufficient USDC balance"` |
-| `ERR_UNAUTHORIZED` | `"unauthorized: caller is not admin"` |
+| `RevenuePoolError::NotInitialized` | `3` | Required pool configuration is missing |
+| `RevenuePoolError::Unauthorized` | `5` | Caller is not authorized for the operation |
+| `RevenuePoolError::Paused` | `6` | Pool is paused |
+| `RevenuePoolError::AmountNotPositive` | `12` | A payment amount is not positive |
+| `RevenuePoolError::AmountExceedsMaxDistribute` | `13` | A payment exceeds the per-leg cap |
+| `RevenuePoolError::InvalidRecipient` | `14` | A recipient is the pool contract |
+| `RevenuePoolError::InsufficientBalance` | `15` | Pool balance is below the batch total |
+| `RevenuePoolError::DuplicateRecipient` | `16` | A recipient appears more than once |
+| `RevenuePoolError::Overflow` | `17` | The checked batch total overflows `i128` |
 
 ---
 
@@ -260,7 +259,7 @@ due to a Soroban unit-test environment limitation — WASM upload is not support
 
 ### Overflow
 **Threat:** Crafted amounts overflow `i128` total, bypassing balance check.  
-**Mitigation:** `checked_add` panics on overflow before reaching Phase 2.
+**Mitigation:** `checked_add` emits `RevenuePoolError::Overflow` before reaching Phase 2.
 
 ### Reentrancy
 **Threat:** Token contract re-enters `batch_distribute` mid-execution.  
@@ -273,7 +272,7 @@ due to a Soroban unit-test environment limitation — WASM upload is not support
 - [x] Four-phase execution model implemented
 - [x] Duplicate recipient detection in Phase 1 (before any external call)
 - [x] `Map<Address, bool>` seen-set — O(n log n), no `unwrap()` in prod paths
-- [x] Error constant `ERR_DUPLICATE_RECIPIENT` defined
+- [x] Semantic `RevenuePoolError::DuplicateRecipient` code defined
 - [x] All validation before external calls (atomicity preserved)
 - [x] `MAX_BATCH_SIZE` cap preserved
 - [x] Events reflect final per-recipient amount (one event per unique recipient)
@@ -282,6 +281,6 @@ due to a Soroban unit-test environment limitation — WASM upload is not support
 - [x] `/// doc` comments updated on `batch_distribute`
 - [x] Policy documented in this file
 - [x] No `unwrap()` in production paths
-- [x] Typed `RevenuePoolError::{BatchEmpty, BatchTooLarge}` replace size-violation string panics (#418)
+- [x] Typed `RevenuePoolError` variants replace contract-owned validation panic strings (#858)
 - [x] `chunk_iter` helper for backend pre-chunking, with Rust + TypeScript usage documented
 - [x] Boundary tests for length `0`, `MAX_BATCH_SIZE`, and `MAX_BATCH_SIZE + 1`

--- a/contracts/revenue_pool/src/emergency.rs
+++ b/contracts/revenue_pool/src/emergency.rs
@@ -29,8 +29,8 @@
 //!    rejected immediately.
 //!
 //! 6. **Overflow-safe timestamps**: If the proposal timestamp would overflow
-//!    when the timelock offset is added, the call panics with
-//!    `"timelock overflow"` rather than silently wrapping.
+//!    when the timelock offset is added, the call fails with
+//!    `RevenuePoolError::Overflow` rather than silently wrapping.
 
 use soroban_sdk::{contracttype, Address};
 

--- a/contracts/revenue_pool/src/errors.rs
+++ b/contracts/revenue_pool/src/errors.rs
@@ -1,0 +1,81 @@
+use soroban_sdk::contracterror;
+
+/// Stable, machine-readable error codes for the revenue pool contract.
+///
+/// Numeric discriminants are part of the public contract interface and must
+/// remain stable over time. Callers and indexers can branch on these `u32`
+/// codes instead of parsing panic strings.
+///
+/// | Code | Variant                       | Meaning                                             |
+/// |------|-------------------------------|-----------------------------------------------------|
+/// | 1    | BatchEmpty                    | Batch distribution received no payment legs         |
+/// | 2    | BatchTooLarge                 | Batch distribution exceeded `MAX_BATCH_SIZE`        |
+/// | 3    | NotInitialized                | A function was called before `init`                  |
+/// | 4    | AlreadyInitialized            | `init` was called more than once                     |
+/// | 5    | Unauthorized                  | Caller is not authorized for the operation           |
+/// | 6    | Paused                        | Distribution is blocked while the pool is paused     |
+/// | 7    | AlreadyPaused                 | `pause` was called while already paused              |
+/// | 8    | NotPaused                     | `unpause` was called while not paused                |
+/// | 9    | InvalidUsdcToken              | USDC address conflicts with the pool or admin        |
+/// | 10   | NoAdminTransferPending        | No admin transfer is pending                         |
+/// | 11   | NoPauseGuardian               | No pause guardian is configured                     |
+/// | 12   | AmountNotPositive             | Amount must be greater than zero                     |
+/// | 13   | AmountExceedsMaxDistribute    | Amount exceeds the configured per-leg cap           |
+/// | 14   | InvalidRecipient              | Recipient is the revenue pool contract              |
+/// | 15   | InsufficientBalance           | Pool USDC balance is below the requested amount      |
+/// | 16   | DuplicateRecipient            | A batch contains the same recipient more than once   |
+/// | 17   | Overflow                      | Checked arithmetic detected an overflow             |
+/// | 18   | MaxDistributeNotPositive      | Distribution cap must be greater than zero           |
+/// | 19   | MessageEmpty                  | Admin broadcast message is empty                    |
+/// | 20   | MessageTooLong                | Admin broadcast message exceeds the length limit     |
+/// | 21   | NoPendingEmergencyDrain       | No emergency drain proposal is pending               |
+/// | 22   | TimelockNotExpired            | Emergency drain timelock has not elapsed             |
+#[contracterror]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, PartialOrd, Ord)]
+#[repr(u32)]
+pub enum RevenuePoolError {
+    /// Batch distribution received no payment legs (code 1).
+    BatchEmpty = 1,
+    /// Batch distribution exceeded `MAX_BATCH_SIZE` (code 2).
+    BatchTooLarge = 2,
+    /// A function was called before `init` (code 3).
+    NotInitialized = 3,
+    /// `init` was called more than once (code 4).
+    AlreadyInitialized = 4,
+    /// Caller is not authorized for the operation (code 5).
+    Unauthorized = 5,
+    /// Distribution is blocked while the pool is paused (code 6).
+    Paused = 6,
+    /// `pause` was called while the pool was already paused (code 7).
+    AlreadyPaused = 7,
+    /// `unpause` was called while the pool was not paused (code 8).
+    NotPaused = 8,
+    /// USDC address conflicts with the pool or admin address (code 9).
+    InvalidUsdcToken = 9,
+    /// No admin transfer is pending (code 10).
+    NoAdminTransferPending = 10,
+    /// No pause guardian is configured (code 11).
+    NoPauseGuardian = 11,
+    /// Amount must be greater than zero (code 12).
+    AmountNotPositive = 12,
+    /// Amount exceeds the configured per-leg cap (code 13).
+    AmountExceedsMaxDistribute = 13,
+    /// Recipient is the revenue pool contract (code 14).
+    InvalidRecipient = 14,
+    /// Pool USDC balance is below the requested amount (code 15).
+    InsufficientBalance = 15,
+    /// A batch contains the same recipient more than once (code 16).
+    DuplicateRecipient = 16,
+    /// Checked arithmetic detected an overflow (code 17).
+    Overflow = 17,
+    /// Distribution cap must be greater than zero (code 18).
+    MaxDistributeNotPositive = 18,
+    /// Admin broadcast message is empty (code 19).
+    MessageEmpty = 19,
+    /// Admin broadcast message exceeds the length limit (code 20).
+    MessageTooLong = 20,
+    /// No emergency drain proposal is pending (code 21).
+    NoPendingEmergencyDrain = 21,
+    /// Emergency drain timelock has not elapsed (code 22).
+    TimelockNotExpired = 22,
+}

--- a/contracts/revenue_pool/src/lib.rs
+++ b/contracts/revenue_pool/src/lib.rs
@@ -1,12 +1,13 @@
 #![no_std]
 
 pub mod emergency;
+pub mod errors;
 pub mod events;
 
 use emergency::{PendingEmergencyDrain, EMERGENCY_DRAIN_KEY, EMERGENCY_DRAIN_TIMELOCK_SECONDS};
+pub use errors::RevenuePoolError;
 use soroban_sdk::{
-    contract, contracterror, contractimpl, contracttype, token, Address, BytesN, Env, Map, String,
-    Symbol, Vec,
+    contract, contractimpl, contracttype, token, Address, BytesN, Env, Map, String, Symbol, Vec,
 };
 
 // ---------------------------------------------------------------------------
@@ -53,34 +54,6 @@ pub const MAX_MESSAGE_LEN: u32 = 256;
 /// - `LIFETIME_THRESHOLD`: minimum TTL before triggering a bump (≈1.5 days)
 pub const BUMP_AMOUNT: u32 = 10_000;
 pub const LIFETIME_THRESHOLD: u32 = 1_000;
-
-// ---------------------------------------------------------------------------
-// Error strings
-// ---------------------------------------------------------------------------
-
-const ERR_UNAUTHORIZED: &str = "unauthorized: caller is not admin";
-const ERR_UNAUTHORIZED_PAUSE: &str = "unauthorized: caller is not admin or pause guardian";
-const ERR_PAUSED: &str = "revenue pool is paused";
-const ERR_NOT_INITIALIZED: &str = "revenue pool not initialized";
-const ERR_AMOUNT_NOT_POSITIVE: &str = "amount must be positive";
-const ERR_AMOUNT_EXCEEDS_MAX_DISTRIBUTE: &str = "amount exceeds max_distribute";
-const ERR_INSUFFICIENT_BALANCE: &str = "insufficient USDC balance";
-const ERR_DUPLICATE_RECIPIENT: &str = "duplicate recipient in batch";
-
-// ---------------------------------------------------------------------------
-// Typed error enum (stable numeric codes for SDK integrators)
-// ---------------------------------------------------------------------------
-
-/// Typed errors returned by `batch_distribute` so off-chain callers can branch
-/// on a stable numeric code without parsing panic strings.
-#[contracterror]
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub enum RevenuePoolError {
-    /// `batch_distribute` received an empty `payments` vector.
-    BatchEmpty = 1,
-    /// `batch_distribute` exceeded `MAX_BATCH_SIZE` entries.
-    BatchTooLarge = 2,
-}
 
 // ---------------------------------------------------------------------------
 // Auxiliary contract-types
@@ -130,25 +103,23 @@ impl RevenuePool {
 
     /// Initialize the revenue pool with an admin and the USDC token address.
     ///
-    /// Can only be called once. Rejects `usdc_token == contract address`.
+    /// Can only be called once. The configured admin must authorize the call,
+    /// and the USDC token address must differ from both the pool and admin.
     ///
-    /// # Panics
-    /// * `"revenue pool already initialized"` — called more than once.
-    /// * `"invalid config: usdc_token cannot be the contract itself"` — bad token address.
-    /// * `"invalid config: usdc_token cannot be the admin address"` - token/admin aliasing.
+    /// # Errors
+    /// * [`RevenuePoolError::AlreadyInitialized`] - called more than once.
+    /// * [`RevenuePoolError::InvalidUsdcToken`] - token aliases the pool or admin.
     ///
     /// # Events
     /// Emits `init` with `admin` as topic and `usdc_token` as data.
     pub fn init(env: Env, admin: Address, usdc_token: Address) {
+        admin.require_auth();
         if env.storage().instance().has(&Symbol::new(&env, ADMIN_KEY)) {
-            panic!("revenue pool already initialized");
+            env.panic_with_error(RevenuePoolError::AlreadyInitialized);
         }
         let contract_addr = env.current_contract_address();
-        if usdc_token == contract_addr {
-            panic!("invalid config: usdc_token cannot be the contract itself");
-        }
-        if usdc_token == admin {
-            panic!("invalid config: usdc_token cannot be the admin address");
+        if usdc_token == contract_addr || usdc_token == admin {
+            env.panic_with_error(RevenuePoolError::InvalidUsdcToken);
         }
         let inst = env.storage().instance();
         inst.set(&Symbol::new(&env, ADMIN_KEY), &admin);
@@ -167,12 +138,12 @@ impl RevenuePool {
         env.storage()
             .instance()
             .get(&Symbol::new(env, ADMIN_KEY))
-            .expect(ERR_NOT_INITIALIZED)
+            .unwrap_or_else(|| env.panic_with_error(RevenuePoolError::NotInitialized))
     }
 
     fn require_admin(env: &Env, caller: &Address) {
         if *caller != Self::admin(env) {
-            panic!("{}", ERR_UNAUTHORIZED);
+            env.panic_with_error(RevenuePoolError::Unauthorized);
         }
     }
 
@@ -183,14 +154,14 @@ impl RevenuePool {
             .get::<_, bool>(&Symbol::new(env, PAUSED_KEY))
             .unwrap_or(false)
         {
-            panic!("{}", ERR_PAUSED);
+            env.panic_with_error(RevenuePoolError::Paused);
         }
     }
 
-    fn validate_recipient(recipient: &Address, contract_self: &Address) {
+    fn validate_recipient(env: &Env, recipient: &Address, contract_self: &Address) {
         // Rule 1 — no self-distributions.
         if recipient == contract_self {
-            panic!("invalid recipient: cannot distribute to the contract itself");
+            env.panic_with_error(RevenuePoolError::InvalidRecipient);
         }
     }
 
@@ -200,21 +171,21 @@ impl RevenuePool {
 
     /// Return the current admin address.
     ///
-    /// # Panics
-    /// * `"revenue pool not initialized"` — called before `init`.
+    /// # Errors
+    /// * [`RevenuePoolError::NotInitialized`] - called before `init`.
     pub fn get_admin(env: Env) -> Address {
         Self::admin(&env)
     }
 
     /// Return the USDC token address configured for this pool.
     ///
-    /// # Panics
-    /// * `"revenue pool not initialized"` — called before `init`.
+    /// # Errors
+    /// * [`RevenuePoolError::NotInitialized`] - called before `init`.
     pub fn get_usdc_token(env: Env) -> Address {
         env.storage()
             .instance()
             .get(&Symbol::new(&env, USDC_KEY))
-            .expect(ERR_NOT_INITIALIZED)
+            .unwrap_or_else(|| env.panic_with_error(RevenuePoolError::NotInitialized))
     }
 
     // -----------------------------------------------------------------------
@@ -224,8 +195,8 @@ impl RevenuePool {
     /// Nominate a new admin. Only the current admin may call.
     /// The nominee must call `claim_admin` (alias `accept_admin`) to complete.
     ///
-    /// # Panics
-    /// * `ERR_UNAUTHORIZED` — caller is not the current admin.
+    /// # Errors
+    /// * [`RevenuePoolError::Unauthorized`] - caller is not the current admin.
     ///
     /// # Events
     /// Emits `admin_changed` with `(current, new_admin)` and
@@ -234,7 +205,7 @@ impl RevenuePool {
         caller.require_auth();
         let current = Self::admin(&env);
         if caller != current {
-            panic!("{}", ERR_UNAUTHORIZED);
+            env.panic_with_error(RevenuePoolError::Unauthorized);
         }
         let inst = env.storage().instance();
         inst.set(&Symbol::new(&env, PENDING_ADMIN_KEY), &new_admin);
@@ -251,9 +222,9 @@ impl RevenuePool {
 
     /// Complete the admin transfer. Only the pending admin may call.
     ///
-    /// # Panics
-    /// * `"no pending admin"` — no transfer is in progress.
-    /// * `"unauthorized: caller is not pending admin"` — wrong caller.
+    /// # Errors
+    /// * [`RevenuePoolError::NoAdminTransferPending`] - no transfer is in progress.
+    /// * [`RevenuePoolError::Unauthorized`] - caller is not the pending admin.
     ///
     /// # Events
     /// Emits `admin_transfer_completed` with the new admin as topic.
@@ -262,9 +233,9 @@ impl RevenuePool {
         let inst = env.storage().instance();
         let pending: Address = inst
             .get(&Symbol::new(&env, PENDING_ADMIN_KEY))
-            .expect("no pending admin");
+            .unwrap_or_else(|| env.panic_with_error(RevenuePoolError::NoAdminTransferPending));
         if caller != pending {
-            panic!("unauthorized: caller is not pending admin");
+            env.panic_with_error(RevenuePoolError::Unauthorized);
         }
         inst.set(&Symbol::new(&env, ADMIN_KEY), &pending);
         inst.remove(&Symbol::new(&env, PENDING_ADMIN_KEY));
@@ -275,9 +246,9 @@ impl RevenuePool {
 
     /// Alias for `accept_admin` — legacy name kept for backward compatibility.
     ///
-    /// # Panics
-    /// * `"no pending admin"` - no transfer is in progress.
-    /// * `"unauthorized: caller is not pending admin"` - wrong caller.
+    /// # Errors
+    /// * [`RevenuePoolError::NoAdminTransferPending`] - no transfer is in progress.
+    /// * [`RevenuePoolError::Unauthorized`] - caller is not the pending admin.
     ///
     /// # Events
     /// Emits `admin_transfer_completed` with the new admin as topic.
@@ -287,9 +258,9 @@ impl RevenuePool {
 
     /// Cancel a pending admin transfer. Only the current admin may call.
     ///
-    /// # Panics
-    /// * `ERR_UNAUTHORIZED` — caller is not the current admin.
-    /// * `"no admin transfer pending"` — no transfer in progress.
+    /// # Errors
+    /// * [`RevenuePoolError::Unauthorized`] - caller is not the current admin.
+    /// * [`RevenuePoolError::NoAdminTransferPending`] - no transfer is in progress.
     ///
     /// # Events
     /// Emits `admin_cancelled` with `(current_admin, pending_admin)`.
@@ -297,12 +268,12 @@ impl RevenuePool {
         caller.require_auth();
         let current = Self::admin(&env);
         if caller != current {
-            panic!("{}", ERR_UNAUTHORIZED);
+            env.panic_with_error(RevenuePoolError::Unauthorized);
         }
         let inst = env.storage().instance();
         let pending: Address = inst
             .get(&Symbol::new(&env, PENDING_ADMIN_KEY))
-            .expect("no admin transfer pending");
+            .unwrap_or_else(|| env.panic_with_error(RevenuePoolError::NoAdminTransferPending));
         inst.remove(&Symbol::new(&env, PENDING_ADMIN_KEY));
         inst.extend_ttl(LIFETIME_THRESHOLD, BUMP_AMOUNT);
         env.events()
@@ -325,8 +296,8 @@ impl RevenuePool {
     /// The guardian may call `pause` but has no authority to unpause, distribute,
     /// rotate admin, change caps, or upgrade the contract.
     ///
-    /// # Panics
-    /// * `ERR_UNAUTHORIZED` — caller is not the current admin.
+    /// # Errors
+    /// * [`RevenuePoolError::Unauthorized`] - caller is not the current admin.
     ///
     /// # Events
     /// Emits `pause_guardian_set` with `caller` as topic and `guardian` as data.
@@ -345,9 +316,9 @@ impl RevenuePool {
 
     /// Clear the emergency pause guardian role. Only the admin may call.
     ///
-    /// # Panics
-    /// * `ERR_UNAUTHORIZED` — caller is not the current admin.
-    /// * `"no pause guardian set"` — no guardian is configured.
+    /// # Errors
+    /// * [`RevenuePoolError::Unauthorized`] - caller is not the current admin.
+    /// * [`RevenuePoolError::NoPauseGuardian`] - no guardian is configured.
     ///
     /// # Events
     /// Emits `pause_guardian_cleared` with `caller` as topic and the previous guardian as data.
@@ -357,7 +328,7 @@ impl RevenuePool {
         let inst = env.storage().instance();
         let guardian: Address = inst
             .get(&Symbol::new(&env, PAUSE_GUARDIAN_KEY))
-            .expect("no pause guardian set");
+            .unwrap_or_else(|| env.panic_with_error(RevenuePoolError::NoPauseGuardian));
         inst.remove(&Symbol::new(&env, PAUSE_GUARDIAN_KEY));
         inst.extend_ttl(LIFETIME_THRESHOLD, BUMP_AMOUNT);
         env.events().publish(
@@ -381,9 +352,9 @@ impl RevenuePool {
     ///
     /// The admin or configured pause guardian may call.
     ///
-    /// # Panics
-    /// * `ERR_UNAUTHORIZED_PAUSE` — caller is neither admin nor guardian.
-    /// * `"revenue pool already paused"` — pool is already paused.
+    /// # Errors
+    /// * [`RevenuePoolError::Unauthorized`] - caller is neither admin nor guardian.
+    /// * [`RevenuePoolError::AlreadyPaused`] - pool is already paused.
     ///
     /// # Events
     /// Emits `pause_set` with `caller` as topic and `true` as data.
@@ -392,9 +363,11 @@ impl RevenuePool {
         let admin = Self::admin(&env);
         let guardian = Self::get_pause_guardian(env.clone());
         if caller != admin && guardian.as_ref() != Some(&caller) {
-            panic!("{}", ERR_UNAUTHORIZED_PAUSE);
+            env.panic_with_error(RevenuePoolError::Unauthorized);
         }
-        assert!(!Self::is_paused(env.clone()), "revenue pool already paused");
+        if Self::is_paused(env.clone()) {
+            env.panic_with_error(RevenuePoolError::AlreadyPaused);
+        }
         env.storage()
             .instance()
             .set(&Symbol::new(&env, PAUSED_KEY), &true);
@@ -407,16 +380,18 @@ impl RevenuePool {
 
     /// Deactivate the circuit-breaker. Only the admin may call.
     ///
-    /// # Panics
-    /// * `ERR_UNAUTHORIZED` — caller is not the current admin.
-    /// * `"revenue pool not paused"` — pool is not currently paused.
+    /// # Errors
+    /// * [`RevenuePoolError::Unauthorized`] - caller is not the current admin.
+    /// * [`RevenuePoolError::NotPaused`] - pool is not currently paused.
     ///
     /// # Events
     /// Emits `pause_set` with `caller` as topic and `false` as data.
     pub fn unpause(env: Env, caller: Address) {
         caller.require_auth();
         Self::require_admin(&env, &caller);
-        assert!(Self::is_paused(env.clone()), "revenue pool not paused");
+        if !Self::is_paused(env.clone()) {
+            env.panic_with_error(RevenuePoolError::NotPaused);
+        }
         env.storage()
             .instance()
             .set(&Symbol::new(&env, PAUSED_KEY), &false);
@@ -443,8 +418,8 @@ impl RevenuePool {
     ///
     /// Does **not** move tokens. Only the admin may call.
     ///
-    /// # Panics
-    /// * `"unauthorized: caller is not admin"` — wrong caller.
+    /// # Errors
+    /// * [`RevenuePoolError::Unauthorized`] - caller is not the current admin.
     ///
     /// # Events
     /// Emits `receive_payment` with `caller` as topic and `(amount, from_vault)` as data.
@@ -464,10 +439,11 @@ impl RevenuePool {
     /// writes so a callee panic cannot leave the metric ahead of a failed
     /// transfer (Soroban still rolls the whole invocation back on panic).
     ///
-    /// # Panics
-    /// * `ERR_UNAUTHORIZED` — treasury is not the current admin.
-    /// * `ERR_AMOUNT_NOT_POSITIVE` — amount ≤ 0.
-    /// * `"cumulative yield overflow"` — cumulative metric would overflow `i128`.
+    /// # Errors
+    /// * [`RevenuePoolError::Unauthorized`] - treasury is not the current admin.
+    /// * [`RevenuePoolError::AmountNotPositive`] - amount is not positive.
+    /// * [`RevenuePoolError::Overflow`] - cumulative yield would overflow `i128`.
+    /// * [`RevenuePoolError::NotInitialized`] - the USDC token is not configured.
     ///
     /// # Events
     /// Emits `yield_deposited` with `treasury` as topic and
@@ -475,20 +451,20 @@ impl RevenuePool {
     pub fn deposit_yield(env: Env, treasury: Address, amount: i128, source: Symbol) {
         treasury.require_auth();
         if treasury != Self::admin(&env) {
-            panic!("unauthorized: caller is not treasury");
+            env.panic_with_error(RevenuePoolError::Unauthorized);
         }
         if amount <= 0 {
-            panic!("{}", ERR_AMOUNT_NOT_POSITIVE);
+            env.panic_with_error(RevenuePoolError::AmountNotPositive);
         }
         let previous_total = Self::get_cumulative_yield_deposited(env.clone());
         let new_total = previous_total
             .checked_add(amount)
-            .unwrap_or_else(|| panic!("cumulative yield overflow"));
+            .unwrap_or_else(|| env.panic_with_error(RevenuePoolError::Overflow));
         let usdc_address: Address = env
             .storage()
             .instance()
             .get(&Symbol::new(&env, USDC_KEY))
-            .expect(ERR_NOT_INITIALIZED);
+            .unwrap_or_else(|| env.panic_with_error(RevenuePoolError::NotInitialized));
         let usdc = token::Client::new(&env, &usdc_address);
         let contract_address = env.current_contract_address();
         // Transfer before persisting the cumulative metric so a callee panic
@@ -530,16 +506,18 @@ impl RevenuePool {
 
     /// Set the maximum amount distributable per leg. Must be positive. Admin only.
     ///
-    /// # Panics
-    /// * `ERR_UNAUTHORIZED` — caller is not the current admin.
-    /// * `"max_distribute must be positive"` — value ≤ 0.
+    /// # Errors
+    /// * [`RevenuePoolError::Unauthorized`] - caller is not the current admin.
+    /// * [`RevenuePoolError::MaxDistributeNotPositive`] - value is not positive.
     ///
     /// # Events
     /// Emits `set_max_distribute` with `(old_max, new_max)`.
     pub fn set_max_distribute(env: Env, caller: Address, max_distribute: i128) {
         caller.require_auth();
         Self::require_admin(&env, &caller);
-        assert!(max_distribute > 0, "max_distribute must be positive");
+        if max_distribute <= 0 {
+            env.panic_with_error(RevenuePoolError::MaxDistributeNotPositive);
+        }
         let old_max = Self::get_max_distribute(env.clone());
         env.storage()
             .instance()
@@ -559,13 +537,14 @@ impl RevenuePool {
 
     /// Distribute USDC from this contract to a single developer wallet.
     ///
-    /// # Panics
-    /// * `ERR_UNAUTHORIZED` — caller is not the current admin.
-    /// * `ERR_PAUSED` — pool is paused.
-    /// * `ERR_AMOUNT_NOT_POSITIVE` — amount ≤ 0.
-    /// * `ERR_AMOUNT_EXCEEDS_MAX_DISTRIBUTE` — amount exceeds the cap.
-    /// * `"invalid recipient: cannot distribute to the contract itself"`.
-    /// * `ERR_INSUFFICIENT_BALANCE` — pool holds less than `amount`.
+    /// # Errors
+    /// * [`RevenuePoolError::Unauthorized`] - caller is not the current admin.
+    /// * [`RevenuePoolError::Paused`] - pool is paused.
+    /// * [`RevenuePoolError::AmountNotPositive`] - amount is not positive.
+    /// * [`RevenuePoolError::AmountExceedsMaxDistribute`] - amount exceeds the cap.
+    /// * [`RevenuePoolError::InvalidRecipient`] - recipient is the pool contract.
+    /// * [`RevenuePoolError::InsufficientBalance`] - pool holds less than `amount`.
+    /// * [`RevenuePoolError::NotInitialized`] - the USDC token is not configured.
     ///
     /// # Events
     /// Emits `distribute_started` and `distribute_completed` with a versioned
@@ -575,22 +554,22 @@ impl RevenuePool {
         Self::require_not_paused(&env);
         Self::require_admin(&env, &caller);
         if amount <= 0 {
-            panic!("{}", ERR_AMOUNT_NOT_POSITIVE);
+            env.panic_with_error(RevenuePoolError::AmountNotPositive);
         }
         let max_distribute = Self::get_max_distribute(env.clone());
         if amount > max_distribute {
-            panic!("{}", ERR_AMOUNT_EXCEEDS_MAX_DISTRIBUTE);
+            env.panic_with_error(RevenuePoolError::AmountExceedsMaxDistribute);
         }
         let usdc_address: Address = env
             .storage()
             .instance()
             .get(&Symbol::new(&env, USDC_KEY))
-            .expect(ERR_NOT_INITIALIZED);
+            .unwrap_or_else(|| env.panic_with_error(RevenuePoolError::NotInitialized));
         let usdc = token::Client::new(&env, &usdc_address);
         let contract_address = env.current_contract_address();
-        Self::validate_recipient(&to, &contract_address);
+        Self::validate_recipient(&env, &to, &contract_address);
         if usdc.balance(&contract_address) < amount {
-            panic!("{}", ERR_INSUFFICIENT_BALANCE);
+            env.panic_with_error(RevenuePoolError::InsufficientBalance);
         }
         env.storage()
             .instance()
@@ -622,19 +601,18 @@ impl RevenuePool {
     /// * `payments` — a vector of `(recipient: Address, amount: i128)` pairs.
     ///   Maximum length is [`MAX_BATCH_SIZE`] (currently 50).
     ///
-    /// # Errors (returned)
+    /// # Errors
     /// * [`RevenuePoolError::BatchEmpty`] — `payments` is empty.
     /// * [`RevenuePoolError::BatchTooLarge`] — `payments` exceeds `MAX_BATCH_SIZE`.
-    ///
-    /// # Panics
-    /// * `ERR_UNAUTHORIZED` — caller is not the current admin.
-    /// * `ERR_PAUSED` — pool is paused.
-    /// * `ERR_AMOUNT_NOT_POSITIVE` — any `amount` ≤ 0.
-    /// * `ERR_AMOUNT_EXCEEDS_MAX_DISTRIBUTE` — any `amount` exceeds the cap.
-    /// * `ERR_DUPLICATE_RECIPIENT` — two payments share the same `to` address.
-    /// * `"total overflow"` — sum of all amounts overflows `i128`.
-    /// * `ERR_INSUFFICIENT_BALANCE` — pool balance is less than the total.
-    /// * `"invalid recipient: cannot distribute to the contract itself"`.
+    /// * [`RevenuePoolError::Unauthorized`] — caller is not the current admin.
+    /// * [`RevenuePoolError::Paused`] — pool is paused.
+    /// * [`RevenuePoolError::AmountNotPositive`] — any amount is not positive.
+    /// * [`RevenuePoolError::AmountExceedsMaxDistribute`] — a leg exceeds the cap.
+    /// * [`RevenuePoolError::DuplicateRecipient`] — recipients are duplicated.
+    /// * [`RevenuePoolError::Overflow`] — total amount overflows `i128`.
+    /// * [`RevenuePoolError::InsufficientBalance`] — balance is below the total.
+    /// * [`RevenuePoolError::InvalidRecipient`] — a recipient is the pool contract.
+    /// * [`RevenuePoolError::NotInitialized`] — the USDC token is not configured.
     ///
     /// # Events
     /// Emits structured `distribute_started` and `distribute_completed` events
@@ -666,34 +644,35 @@ impl RevenuePool {
         let max_distribute = Self::get_max_distribute(env.clone());
         let mut seen: Map<Address, bool> = Map::new(&env);
         let mut total_amount: i128 = 0;
+        let contract_address = env.current_contract_address();
 
         for payment in payments.iter() {
             let (to, amount) = payment;
+            Self::validate_recipient(&env, &to, &contract_address);
             if seen.contains_key(to.clone()) {
-                panic!("{}", ERR_DUPLICATE_RECIPIENT);
+                env.panic_with_error(RevenuePoolError::DuplicateRecipient);
             }
             seen.set(to.clone(), true);
             if amount <= 0 {
-                panic!("{}", ERR_AMOUNT_NOT_POSITIVE);
+                env.panic_with_error(RevenuePoolError::AmountNotPositive);
             }
             if amount > max_distribute {
-                panic!("{}", ERR_AMOUNT_EXCEEDS_MAX_DISTRIBUTE);
+                env.panic_with_error(RevenuePoolError::AmountExceedsMaxDistribute);
             }
             total_amount = total_amount
                 .checked_add(amount)
-                .unwrap_or_else(|| panic!("total overflow"));
+                .unwrap_or_else(|| env.panic_with_error(RevenuePoolError::Overflow));
         }
 
         let usdc_address: Address = env
             .storage()
             .instance()
             .get(&Symbol::new(&env, USDC_KEY))
-            .expect(ERR_NOT_INITIALIZED);
+            .unwrap_or_else(|| env.panic_with_error(RevenuePoolError::NotInitialized));
         let usdc = token::Client::new(&env, &usdc_address);
-        let contract_address = env.current_contract_address();
 
         if usdc.balance(&contract_address) < total_amount {
-            panic!("{}", ERR_INSUFFICIENT_BALANCE);
+            env.panic_with_error(RevenuePoolError::InsufficientBalance);
         }
 
         env.storage()
@@ -703,7 +682,6 @@ impl RevenuePool {
         let mut batch_index = 0_u32;
         for payment in payments.iter() {
             let (to, amount) = payment;
-            Self::validate_recipient(&to, &contract_address);
 
             let lifecycle = events::DistributionLifecycleEvent::new(
                 &env,
@@ -729,14 +707,14 @@ impl RevenuePool {
 
     /// Return this contract's on-ledger USDC balance.
     ///
-    /// # Panics
-    /// * `ERR_NOT_INITIALIZED` — called before `init`.
+    /// # Errors
+    /// * [`RevenuePoolError::NotInitialized`] - called before `init`.
     pub fn balance(env: Env) -> i128 {
         let usdc_addr: Address = env
             .storage()
             .instance()
             .get(&Symbol::new(&env, USDC_KEY))
-            .expect(ERR_NOT_INITIALIZED);
+            .unwrap_or_else(|| env.panic_with_error(RevenuePoolError::NotInitialized));
         let usdc = token::Client::new(&env, &usdc_addr);
         usdc.balance(&env.current_contract_address())
     }
@@ -747,8 +725,8 @@ impl RevenuePool {
 
     /// Admin-gated contract upgrade. Replaces the WASM and persists the version.
     ///
-    /// # Panics
-    /// * `ERR_UNAUTHORIZED` — caller is not the current admin.
+    /// # Errors
+    /// * [`RevenuePoolError::Unauthorized`] - caller is not the current admin.
     ///
     /// # Events
     /// Emits `upgraded` with `admin` as topic and `new_wasm_hash` as data.
@@ -787,10 +765,10 @@ impl RevenuePool {
 
     /// Broadcast an emergency message from the admin.
     ///
-    /// # Panics
-    /// * `ERR_UNAUTHORIZED` — caller is not the current admin.
-    /// * `"message cannot be empty"` — empty message.
-    /// * `"message length exceeds maximum of 256 characters"`.
+    /// # Errors
+    /// * [`RevenuePoolError::Unauthorized`] - caller is not the current admin.
+    /// * [`RevenuePoolError::MessageEmpty`] - message is empty.
+    /// * [`RevenuePoolError::MessageTooLong`] - message exceeds [`MAX_MESSAGE_LEN`].
     ///
     /// # Events
     /// Emits `admin_broadcast` with `caller` as topic and `AdminBroadcast` as data.
@@ -799,10 +777,10 @@ impl RevenuePool {
         Self::require_admin(&env, &caller);
         let len = message.len();
         if len == 0 {
-            panic!("message cannot be empty");
+            env.panic_with_error(RevenuePoolError::MessageEmpty);
         }
         if len > MAX_MESSAGE_LEN {
-            panic!("message length exceeds maximum of 256 characters");
+            env.panic_with_error(RevenuePoolError::MessageTooLong);
         }
         env.events().publish(
             (events::event_admin_broadcast(&env), caller),
@@ -862,11 +840,11 @@ impl RevenuePool {
     ///   contract itself.
     /// * `amount` — USDC amount in base units. Must be positive.
     ///
-    /// # Panics
-    /// * `ERR_UNAUTHORIZED` — caller is not the current admin.
-    /// * `ERR_AMOUNT_NOT_POSITIVE` — amount ≤ 0.
-    /// * `"invalid recipient: cannot drain to the contract itself"` — self-drain.
-    /// * `"timelock overflow"` — proposed_at + 86 400 would overflow `u64`.
+    /// # Errors
+    /// * [`RevenuePoolError::Unauthorized`] - caller is not the current admin.
+    /// * [`RevenuePoolError::AmountNotPositive`] - amount is not positive.
+    /// * [`RevenuePoolError::InvalidRecipient`] - treasury is the pool contract.
+    /// * [`RevenuePoolError::Overflow`] - timelock addition would overflow `u64`.
     ///
     /// # Events
     /// Emits `emergency_drain_proposed` with `caller` as topic and the full
@@ -875,16 +853,16 @@ impl RevenuePool {
         caller.require_auth();
         Self::require_admin(&env, &caller);
         if amount <= 0 {
-            panic!("{}", ERR_AMOUNT_NOT_POSITIVE);
+            env.panic_with_error(RevenuePoolError::AmountNotPositive);
         }
         let contract_address = env.current_contract_address();
         if treasury == contract_address {
-            panic!("invalid recipient: cannot drain to the contract itself");
+            env.panic_with_error(RevenuePoolError::InvalidRecipient);
         }
         let proposed_at: u64 = env.ledger().timestamp();
         let execute_after: u64 = proposed_at
             .checked_add(EMERGENCY_DRAIN_TIMELOCK_SECONDS)
-            .unwrap_or_else(|| panic!("timelock overflow"));
+            .unwrap_or_else(|| env.panic_with_error(RevenuePoolError::Overflow));
 
         let drain = PendingEmergencyDrain {
             to: treasury,
@@ -911,11 +889,12 @@ impl RevenuePool {
     /// # Arguments
     /// * `caller` — Must be the current admin; must authorize.
     ///
-    /// # Panics
-    /// * `ERR_UNAUTHORIZED` — caller is not the current admin.
-    /// * `"no pending emergency drain"` — no proposal exists.
-    /// * `"emergency drain timelock has not expired"` — too early to execute.
-    /// * `ERR_INSUFFICIENT_BALANCE` — pool holds less than the proposed amount.
+    /// # Errors
+    /// * [`RevenuePoolError::Unauthorized`] - caller is not the current admin.
+    /// * [`RevenuePoolError::NoPendingEmergencyDrain`] - no proposal exists.
+    /// * [`RevenuePoolError::TimelockNotExpired`] - execution is too early.
+    /// * [`RevenuePoolError::InsufficientBalance`] - pool balance is too low.
+    /// * [`RevenuePoolError::NotInitialized`] - the USDC token is not configured.
     ///
     /// # Events
     /// Emits `emergency_drain_executed` with `caller` as topic and
@@ -927,21 +906,21 @@ impl RevenuePool {
         let inst = env.storage().instance();
         let drain: PendingEmergencyDrain = inst
             .get(&Symbol::new(&env, EMERGENCY_DRAIN_KEY))
-            .expect("no pending emergency drain");
+            .unwrap_or_else(|| env.panic_with_error(RevenuePoolError::NoPendingEmergencyDrain));
 
         let now: u64 = env.ledger().timestamp();
         if now < drain.execute_after {
-            panic!("emergency drain timelock has not expired");
+            env.panic_with_error(RevenuePoolError::TimelockNotExpired);
         }
 
         let usdc_address: Address = inst
             .get(&Symbol::new(&env, USDC_KEY))
-            .expect(ERR_NOT_INITIALIZED);
+            .unwrap_or_else(|| env.panic_with_error(RevenuePoolError::NotInitialized));
         let usdc = token::Client::new(&env, &usdc_address);
         let contract_address = env.current_contract_address();
 
         if usdc.balance(&contract_address) < drain.amount {
-            panic!("{}", ERR_INSUFFICIENT_BALANCE);
+            env.panic_with_error(RevenuePoolError::InsufficientBalance);
         }
 
         // Remove before transfer to prevent re-entrancy replay.
@@ -964,9 +943,9 @@ impl RevenuePool {
     /// # Arguments
     /// * `caller` — Must be the current admin; must authorize.
     ///
-    /// # Panics
-    /// * `ERR_UNAUTHORIZED` — caller is not the current admin.
-    /// * `"no pending emergency drain"` — no proposal exists to cancel.
+    /// # Errors
+    /// * [`RevenuePoolError::Unauthorized`] - caller is not the current admin.
+    /// * [`RevenuePoolError::NoPendingEmergencyDrain`] - no proposal exists.
     ///
     /// # Events
     /// Emits `emergency_drain_cancelled` with `caller` as topic and the full
@@ -978,7 +957,7 @@ impl RevenuePool {
         let inst = env.storage().instance();
         let drain: PendingEmergencyDrain = inst
             .get(&Symbol::new(&env, EMERGENCY_DRAIN_KEY))
-            .expect("no pending emergency drain");
+            .unwrap_or_else(|| env.panic_with_error(RevenuePoolError::NoPendingEmergencyDrain));
 
         inst.remove(&Symbol::new(&env, EMERGENCY_DRAIN_KEY));
         inst.extend_ttl(LIFETIME_THRESHOLD, BUMP_AMOUNT);
@@ -1050,6 +1029,9 @@ pub fn chunk_iter(
 
 #[cfg(test)]
 mod test_balance;
+
+#[cfg(test)]
+mod test_contract_errors;
 
 #[cfg(test)]
 mod test_error_codes;

--- a/contracts/revenue_pool/src/test.rs
+++ b/contracts/revenue_pool/src/test.rs
@@ -58,7 +58,7 @@ fn init_emits_event() {
 }
 
 #[test]
-#[should_panic(expected = "revenue pool already initialized")]
+#[should_panic]
 fn init_double_panics() {
     let env = Env::default();
     env.mock_all_auths();
@@ -71,7 +71,7 @@ fn init_double_panics() {
 }
 
 #[test]
-#[should_panic(expected = "revenue pool already initialized")]
+#[should_panic]
 fn init_double_different_admin_panics() {
     let env = Env::default();
     env.mock_all_auths();
@@ -86,7 +86,7 @@ fn init_double_different_admin_panics() {
 }
 
 #[test]
-#[should_panic(expected = "invalid config: usdc_token cannot be the contract itself")]
+#[should_panic]
 fn init_usdc_token_is_contract_panics() {
     let env = Env::default();
     env.mock_all_auths();
@@ -98,7 +98,7 @@ fn init_usdc_token_is_contract_panics() {
 }
 
 #[test]
-#[should_panic(expected = "invalid config: usdc_token cannot be the admin address")]
+#[should_panic]
 fn init_usdc_token_is_admin_panics() {
     let env = Env::default();
     env.mock_all_auths();
@@ -127,7 +127,7 @@ fn distribute_success() {
 }
 
 #[test]
-#[should_panic(expected = "amount must be positive")]
+#[should_panic]
 fn distribute_zero_panics() {
     let env = Env::default();
     env.mock_all_auths();
@@ -141,7 +141,7 @@ fn distribute_zero_panics() {
 }
 
 #[test]
-#[should_panic(expected = "insufficient USDC balance")]
+#[should_panic]
 fn distribute_excess_panics() {
     let env = Env::default();
     env.mock_all_auths();
@@ -332,7 +332,7 @@ fn set_admin_two_step_transfers_control() {
 }
 
 #[test]
-#[should_panic(expected = "unauthorized: caller is not admin")]
+#[should_panic]
 fn set_admin_unauthorized_panics() {
     let env = Env::default();
     env.mock_all_auths();
@@ -347,7 +347,7 @@ fn set_admin_unauthorized_panics() {
 }
 
 #[test]
-#[should_panic(expected = "unauthorized: caller is not pending admin")]
+#[should_panic]
 fn claim_admin_wrong_address_panics() {
     let env = Env::default();
     env.mock_all_auths();
@@ -418,7 +418,7 @@ fn receive_payment_emits_event() {
 }
 
 #[test]
-#[should_panic(expected = "unauthorized: caller is not admin")]
+#[should_panic]
 fn receive_payment_non_admin_panics() {
     let env = Env::default();
     env.mock_all_auths();
@@ -537,7 +537,7 @@ fn receive_payment_emits_event_for_admin() {
 }
 
 #[test]
-#[should_panic(expected = "no pending admin")]
+#[should_panic]
 fn claim_admin_without_pending_panics() {
     let env = Env::default();
     env.mock_all_auths();
@@ -551,7 +551,7 @@ fn claim_admin_without_pending_panics() {
 }
 
 #[test]
-#[should_panic(expected = "unauthorized: caller is not pending admin")]
+#[should_panic]
 fn claim_admin_wrong_caller_panics() {
     let env = Env::default();
     env.mock_all_auths();
@@ -567,7 +567,7 @@ fn claim_admin_wrong_caller_panics() {
 }
 
 #[test]
-#[should_panic(expected = "invalid recipient: cannot distribute to the contract itself")]
+#[should_panic]
 fn distribute_to_self_panics() {
     let env = Env::default();
     env.mock_all_auths();
@@ -581,7 +581,7 @@ fn distribute_to_self_panics() {
 }
 
 #[test]
-#[should_panic(expected = "amount must be positive")]
+#[should_panic]
 fn batch_distribute_zero_amount_panics() {
     let env = Env::default();
     env.mock_all_auths();
@@ -925,7 +925,7 @@ fn get_admin_reflects_updated_admin_after_transfer() {
 }
 
 #[test]
-#[should_panic(expected = "revenue pool not initialized")]
+#[should_panic]
 fn get_admin_before_init_panics() {
     let env = Env::default();
     env.mock_all_auths();
@@ -969,7 +969,7 @@ fn get_usdc_token_is_immutable_after_init() {
 }
 
 #[test]
-#[should_panic(expected = "revenue pool not initialized")]
+#[should_panic]
 fn get_usdc_token_before_init_panics() {
     let env = Env::default();
     env.mock_all_auths();
@@ -1219,7 +1219,7 @@ fn upgrade_sets_version_with_uploaded_wasm() {
 }
 
 #[test]
-#[should_panic(expected = "amount must be positive")]
+#[should_panic]
 fn batch_distribute_negative_amount_panics() {
     let env = Env::default();
     env.mock_all_auths();
@@ -1236,7 +1236,7 @@ fn batch_distribute_negative_amount_panics() {
 }
 
 #[test]
-#[should_panic(expected = "unauthorized: caller is not admin")]
+#[should_panic]
 fn batch_distribute_unauthorized_panics() {
     let env = Env::default();
     env.mock_all_auths();
@@ -1255,7 +1255,7 @@ fn batch_distribute_unauthorized_panics() {
 }
 
 #[test]
-#[should_panic(expected = "invalid recipient: cannot distribute to the contract itself")]
+#[should_panic]
 fn batch_distribute_self_recipient_panics() {
     let env = Env::default();
     env.mock_all_auths();
@@ -1353,7 +1353,7 @@ fn views_do_not_trigger_ttl_bump() {
 // ---------------------------------------------------------------------------
 
 #[test]
-#[should_panic(expected = "duplicate recipient in batch")]
+#[should_panic]
 fn batch_distribute_duplicate_recipient_panics() {
     // A batch where the same developer appears twice must be rejected entirely.
     let env = Env::default();
@@ -1441,7 +1441,7 @@ fn batch_distribute_duplicate_does_not_emit_events() {
 }
 
 #[test]
-#[should_panic(expected = "duplicate recipient in batch")]
+#[should_panic]
 fn batch_distribute_duplicate_at_end_panics() {
     // Duplicate at position n-1 (last entry) must still be caught.
     let env = Env::default();
@@ -1494,7 +1494,7 @@ fn batch_distribute_unique_recipients_succeeds() {
 }
 
 #[test]
-#[should_panic(expected = "duplicate recipient in batch")]
+#[should_panic]
 fn batch_distribute_duplicate_detected_before_balance_check() {
     // Duplicate detection must fire even when the pool has insufficient balance,
     // proving it runs in Phase 1 (before the Phase 2 balance check).
@@ -1556,7 +1556,7 @@ fn deposit_yield_accumulates_multiple_sources() {
 }
 
 #[test]
-#[should_panic(expected = "unauthorized: caller is not treasury")]
+#[should_panic]
 fn deposit_yield_rejects_non_treasury() {
     let env = Env::default();
     env.mock_all_auths();
@@ -1570,7 +1570,7 @@ fn deposit_yield_rejects_non_treasury() {
 }
 
 #[test]
-#[should_panic(expected = "amount must be positive")]
+#[should_panic]
 fn deposit_yield_rejects_zero_amount() {
     let env = Env::default();
     env.mock_all_auths();

--- a/contracts/revenue_pool/src/test_contract_errors.rs
+++ b/contracts/revenue_pool/src/test_contract_errors.rs
@@ -1,0 +1,288 @@
+extern crate std;
+
+use super::*;
+use soroban_sdk::testutils::{Address as _, Ledger as _};
+use soroban_sdk::token;
+use soroban_sdk::{Address, Env, String, Symbol, Vec};
+
+fn create_usdc<'a>(
+    env: &'a Env,
+    admin: &Address,
+) -> (Address, token::Client<'a>, token::StellarAssetClient<'a>) {
+    let contract = env.register_stellar_asset_contract_v2(admin.clone());
+    let address = contract.address();
+    (
+        address.clone(),
+        token::Client::new(env, &address),
+        token::StellarAssetClient::new(env, &address),
+    )
+}
+
+fn setup_pool(
+    env: &Env,
+) -> (
+    Address,
+    Address,
+    RevenuePoolClient<'_>,
+    token::Client<'_>,
+    token::StellarAssetClient<'_>,
+) {
+    env.mock_all_auths();
+    let admin = Address::generate(env);
+    let pool = env.register(RevenuePool, ());
+    let client = RevenuePoolClient::new(env, &pool);
+    let (usdc, usdc_client, usdc_admin) = create_usdc(env, &admin);
+    client.init(&admin, &usdc);
+    (admin, pool, client, usdc_client, usdc_admin)
+}
+
+#[test]
+fn initialization_errors_are_typed() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let pool = env.register(RevenuePool, ());
+    let client = RevenuePoolClient::new(&env, &pool);
+    let (usdc, _, _) = create_usdc(&env, &admin);
+
+    assert_eq!(
+        client.try_get_admin(),
+        Err(Ok(RevenuePoolError::NotInitialized))
+    );
+
+    assert_eq!(
+        client.try_init(&admin, &pool),
+        Err(Ok(RevenuePoolError::InvalidUsdcToken))
+    );
+    assert_eq!(
+        client.try_init(&admin, &admin),
+        Err(Ok(RevenuePoolError::InvalidUsdcToken))
+    );
+
+    client.init(&admin, &usdc);
+    assert_eq!(
+        client.try_init(&admin, &usdc),
+        Err(Ok(RevenuePoolError::AlreadyInitialized))
+    );
+}
+
+#[test]
+fn admin_transfer_errors_are_typed() {
+    let env = Env::default();
+    let (admin, _, client, _, _) = setup_pool(&env);
+    let attacker = Address::generate(&env);
+    let candidate = Address::generate(&env);
+
+    assert_eq!(
+        client.try_set_admin(&attacker, &candidate),
+        Err(Ok(RevenuePoolError::Unauthorized))
+    );
+    assert_eq!(
+        client.try_claim_admin(&candidate),
+        Err(Ok(RevenuePoolError::NoAdminTransferPending))
+    );
+
+    client.set_admin(&admin, &candidate);
+    assert_eq!(
+        client.try_claim_admin(&attacker),
+        Err(Ok(RevenuePoolError::Unauthorized))
+    );
+}
+
+#[test]
+fn pause_state_errors_are_typed() {
+    let env = Env::default();
+    let (admin, _, client, _, _) = setup_pool(&env);
+    let attacker = Address::generate(&env);
+    let recipient = Address::generate(&env);
+
+    assert_eq!(
+        client.try_clear_pause_guardian(&admin),
+        Err(Ok(RevenuePoolError::NoPauseGuardian))
+    );
+    assert_eq!(
+        client.try_unpause(&admin),
+        Err(Ok(RevenuePoolError::NotPaused))
+    );
+    assert_eq!(
+        client.try_pause(&attacker),
+        Err(Ok(RevenuePoolError::Unauthorized))
+    );
+
+    client.pause(&admin);
+    assert_eq!(
+        client.try_pause(&admin),
+        Err(Ok(RevenuePoolError::AlreadyPaused))
+    );
+    assert_eq!(
+        client.try_distribute(&admin, &recipient, &1),
+        Err(Ok(RevenuePoolError::Paused))
+    );
+}
+
+#[test]
+fn single_distribution_errors_are_typed() {
+    let env = Env::default();
+    let (admin, pool, client, _, _) = setup_pool(&env);
+    let recipient = Address::generate(&env);
+
+    assert_eq!(
+        client.try_distribute(&admin, &recipient, &0),
+        Err(Ok(RevenuePoolError::AmountNotPositive))
+    );
+
+    client.set_max_distribute(&admin, &10);
+    assert_eq!(
+        client.try_distribute(&admin, &recipient, &11),
+        Err(Ok(RevenuePoolError::AmountExceedsMaxDistribute))
+    );
+    assert_eq!(
+        client.try_distribute(&admin, &pool, &1),
+        Err(Ok(RevenuePoolError::InvalidRecipient))
+    );
+    assert_eq!(
+        client.try_distribute(&admin, &recipient, &1),
+        Err(Ok(RevenuePoolError::InsufficientBalance))
+    );
+}
+
+#[test]
+fn batch_distribution_errors_are_typed_and_atomic() {
+    let env = Env::default();
+    let (admin, pool, client, usdc, usdc_admin) = setup_pool(&env);
+    let recipient = Address::generate(&env);
+
+    let empty: Vec<(Address, i128)> = Vec::new(&env);
+    assert_eq!(
+        client.try_batch_distribute(&admin, &empty),
+        Err(Ok(RevenuePoolError::BatchEmpty))
+    );
+
+    let mut oversized: Vec<(Address, i128)> = Vec::new(&env);
+    for _ in 0..=MAX_BATCH_SIZE {
+        oversized.push_back((Address::generate(&env), 1));
+    }
+    assert_eq!(
+        client.try_batch_distribute(&admin, &oversized),
+        Err(Ok(RevenuePoolError::BatchTooLarge))
+    );
+
+    let mut duplicate: Vec<(Address, i128)> = Vec::new(&env);
+    duplicate.push_back((recipient.clone(), 1));
+    duplicate.push_back((recipient.clone(), 1));
+    assert_eq!(
+        client.try_batch_distribute(&admin, &duplicate),
+        Err(Ok(RevenuePoolError::DuplicateRecipient))
+    );
+
+    let mut overflowing: Vec<(Address, i128)> = Vec::new(&env);
+    overflowing.push_back((Address::generate(&env), i128::MAX));
+    overflowing.push_back((Address::generate(&env), 1));
+    assert_eq!(
+        client.try_batch_distribute(&admin, &overflowing),
+        Err(Ok(RevenuePoolError::Overflow))
+    );
+
+    usdc_admin.mint(&pool, &100);
+    let recipient_balance = usdc.balance(&recipient);
+    let mut invalid_late_leg: Vec<(Address, i128)> = Vec::new(&env);
+    invalid_late_leg.push_back((recipient.clone(), 25));
+    invalid_late_leg.push_back((pool.clone(), 25));
+    assert_eq!(
+        client.try_batch_distribute(&admin, &invalid_late_leg),
+        Err(Ok(RevenuePoolError::InvalidRecipient))
+    );
+    assert_eq!(usdc.balance(&pool), 100);
+    assert_eq!(usdc.balance(&recipient), recipient_balance);
+}
+
+#[test]
+fn cap_and_broadcast_errors_are_typed() {
+    let env = Env::default();
+    let (admin, _, client, _, _) = setup_pool(&env);
+
+    assert_eq!(
+        client.try_set_max_distribute(&admin, &0),
+        Err(Ok(RevenuePoolError::MaxDistributeNotPositive))
+    );
+
+    let empty = String::from_str(&env, "");
+    assert_eq!(
+        client.try_broadcast(&admin, &Severity::Info, &empty),
+        Err(Ok(RevenuePoolError::MessageEmpty))
+    );
+
+    let long_text = "x".repeat((MAX_MESSAGE_LEN + 1) as usize);
+    let long_message = String::from_str(&env, &long_text);
+    assert_eq!(
+        client.try_broadcast(&admin, &Severity::Info, &long_message),
+        Err(Ok(RevenuePoolError::MessageTooLong))
+    );
+}
+
+#[test]
+fn emergency_drain_errors_are_typed() {
+    let env = Env::default();
+    env.ledger().set_timestamp(1_700_000_000);
+    let (admin, pool, client, _, _) = setup_pool(&env);
+    let treasury = Address::generate(&env);
+
+    assert_eq!(
+        client.try_execute_emergency_drain(&admin),
+        Err(Ok(RevenuePoolError::NoPendingEmergencyDrain))
+    );
+    assert_eq!(
+        client.try_propose_emergency_drain(&admin, &treasury, &0),
+        Err(Ok(RevenuePoolError::AmountNotPositive))
+    );
+    assert_eq!(
+        client.try_propose_emergency_drain(&admin, &pool, &1),
+        Err(Ok(RevenuePoolError::InvalidRecipient))
+    );
+
+    client.propose_emergency_drain(&admin, &treasury, &1);
+    assert_eq!(
+        client.try_execute_emergency_drain(&admin),
+        Err(Ok(RevenuePoolError::TimelockNotExpired))
+    );
+
+    env.ledger()
+        .set_timestamp(1_700_000_000 + EMERGENCY_DRAIN_TIMELOCK_SECONDS);
+    assert_eq!(
+        client.try_execute_emergency_drain(&admin),
+        Err(Ok(RevenuePoolError::InsufficientBalance))
+    );
+}
+
+#[test]
+fn emergency_drain_timelock_overflow_is_typed() {
+    let env = Env::default();
+    env.ledger().set_timestamp(u64::MAX);
+    let (admin, _, client, _, _) = setup_pool(&env);
+    let treasury = Address::generate(&env);
+
+    assert_eq!(
+        client.try_propose_emergency_drain(&admin, &treasury, &1),
+        Err(Ok(RevenuePoolError::Overflow))
+    );
+}
+
+#[test]
+fn cumulative_yield_overflow_is_typed() {
+    let env = Env::default();
+    let (admin, pool, client, _, usdc_admin) = setup_pool(&env);
+    let source = Symbol::new(&env, "fees");
+
+    env.as_contract(&pool, || {
+        env.storage().instance().set(
+            &Symbol::new(&env, CUMULATIVE_YIELD_DEPOSITED_KEY),
+            &i128::MAX,
+        );
+    });
+    usdc_admin.mint(&admin, &1);
+
+    assert_eq!(
+        client.try_deposit_yield(&admin, &1, &source),
+        Err(Ok(RevenuePoolError::Overflow))
+    );
+}

--- a/contracts/revenue_pool/src/test_emergency.rs
+++ b/contracts/revenue_pool/src/test_emergency.rs
@@ -82,7 +82,7 @@ fn propose_emits_event() {
 }
 
 #[test]
-#[should_panic(expected = "unauthorized: caller is not admin")]
+#[should_panic]
 fn propose_non_admin_panics() {
     let env = Env::default();
     env.mock_all_auths();
@@ -96,7 +96,7 @@ fn propose_non_admin_panics() {
 }
 
 #[test]
-#[should_panic(expected = "amount must be positive")]
+#[should_panic]
 fn propose_zero_amount_panics() {
     let env = Env::default();
     env.mock_all_auths();
@@ -109,7 +109,7 @@ fn propose_zero_amount_panics() {
 }
 
 #[test]
-#[should_panic(expected = "invalid recipient: cannot drain to the contract itself")]
+#[should_panic]
 fn propose_self_drain_panics() {
     let env = Env::default();
     env.mock_all_auths();
@@ -121,7 +121,7 @@ fn propose_self_drain_panics() {
 }
 
 #[test]
-#[should_panic(expected = "revenue pool not initialized")]
+#[should_panic]
 fn propose_not_initialized_panics() {
     let env = Env::default();
     env.mock_all_auths();
@@ -207,7 +207,7 @@ fn execute_emits_event() {
 }
 
 #[test]
-#[should_panic(expected = "emergency drain timelock has not expired")]
+#[should_panic]
 fn execute_before_timelock_panics() {
     let env = Env::default();
     env.mock_all_auths();
@@ -223,7 +223,7 @@ fn execute_before_timelock_panics() {
 }
 
 #[test]
-#[should_panic(expected = "no pending emergency drain")]
+#[should_panic]
 fn execute_no_proposal_panics() {
     let env = Env::default();
     env.mock_all_auths();
@@ -238,7 +238,7 @@ fn execute_no_proposal_panics() {
 }
 
 #[test]
-#[should_panic(expected = "unauthorized: caller is not admin")]
+#[should_panic]
 fn execute_non_admin_panics() {
     let env = Env::default();
     env.mock_all_auths();
@@ -257,7 +257,7 @@ fn execute_non_admin_panics() {
 }
 
 #[test]
-#[should_panic(expected = "insufficient USDC balance")]
+#[should_panic]
 fn execute_insufficient_balance_panics() {
     let env = Env::default();
     env.mock_all_auths();
@@ -346,7 +346,7 @@ fn cancel_emits_event() {
 }
 
 #[test]
-#[should_panic(expected = "unauthorized: caller is not admin")]
+#[should_panic]
 fn cancel_non_admin_panics() {
     let env = Env::default();
     env.mock_all_auths();
@@ -363,7 +363,7 @@ fn cancel_non_admin_panics() {
 }
 
 #[test]
-#[should_panic(expected = "no pending emergency drain")]
+#[should_panic]
 fn cancel_no_proposal_panics() {
     let env = Env::default();
     env.mock_all_auths();
@@ -442,7 +442,7 @@ fn get_pending_returns_proposal_after_propose() {
 // ---------------------------------------------------------------------------
 
 #[test]
-#[should_panic(expected = "timelock overflow")]
+#[should_panic]
 fn timelock_overflow_at_max_timestamp() {
     let env = Env::default();
     env.mock_all_auths();

--- a/contracts/revenue_pool/src/test_error_codes.rs
+++ b/contracts/revenue_pool/src/test_error_codes.rs
@@ -8,6 +8,26 @@ fn revenue_pool_error_codes_are_stable_and_unique() {
     let mappings = [
         (1_u32, RevenuePoolError::BatchEmpty),
         (2, RevenuePoolError::BatchTooLarge),
+        (3, RevenuePoolError::NotInitialized),
+        (4, RevenuePoolError::AlreadyInitialized),
+        (5, RevenuePoolError::Unauthorized),
+        (6, RevenuePoolError::Paused),
+        (7, RevenuePoolError::AlreadyPaused),
+        (8, RevenuePoolError::NotPaused),
+        (9, RevenuePoolError::InvalidUsdcToken),
+        (10, RevenuePoolError::NoAdminTransferPending),
+        (11, RevenuePoolError::NoPauseGuardian),
+        (12, RevenuePoolError::AmountNotPositive),
+        (13, RevenuePoolError::AmountExceedsMaxDistribute),
+        (14, RevenuePoolError::InvalidRecipient),
+        (15, RevenuePoolError::InsufficientBalance),
+        (16, RevenuePoolError::DuplicateRecipient),
+        (17, RevenuePoolError::Overflow),
+        (18, RevenuePoolError::MaxDistributeNotPositive),
+        (19, RevenuePoolError::MessageEmpty),
+        (20, RevenuePoolError::MessageTooLong),
+        (21, RevenuePoolError::NoPendingEmergencyDrain),
+        (22, RevenuePoolError::TimelockNotExpired),
     ];
 
     let mut seen = BTreeSet::new();
@@ -19,7 +39,7 @@ fn revenue_pool_error_codes_are_stable_and_unique() {
         );
     }
 
-    assert_eq!(seen.len(), 2);
+    assert_eq!(seen.len(), 22);
 }
 
 #[test]
@@ -28,6 +48,26 @@ fn error_code_docs_list_every_revenue_pool_code() {
     let expected_lines = [
         "| 1 | `BatchEmpty` | Revenue Pool | `batch_distribute` received an empty `payments` vector |",
         "| 2 | `BatchTooLarge` | Revenue Pool | `batch_distribute` exceeded `MAX_BATCH_SIZE` |",
+        "| 3 | `NotInitialized` | Revenue Pool | A function was called before `init` |",
+        "| 4 | `AlreadyInitialized` | Revenue Pool | `init` was called more than once |",
+        "| 5 | `Unauthorized` | Revenue Pool | Caller is not authorized for the operation |",
+        "| 6 | `Paused` | Revenue Pool | Distribution is blocked while the pool is paused |",
+        "| 7 | `AlreadyPaused` | Revenue Pool | `pause` was called while the pool was already paused |",
+        "| 8 | `NotPaused` | Revenue Pool | `unpause` was called while the pool was not paused |",
+        "| 9 | `InvalidUsdcToken` | Revenue Pool | USDC address conflicts with the pool or admin address |",
+        "| 10 | `NoAdminTransferPending` | Revenue Pool | No admin transfer is pending |",
+        "| 11 | `NoPauseGuardian` | Revenue Pool | No pause guardian is configured |",
+        "| 12 | `AmountNotPositive` | Revenue Pool | Amount must be greater than zero |",
+        "| 13 | `AmountExceedsMaxDistribute` | Revenue Pool | Amount exceeds the configured per-leg cap |",
+        "| 14 | `InvalidRecipient` | Revenue Pool | Recipient is the revenue pool contract |",
+        "| 15 | `InsufficientBalance` | Revenue Pool | Pool USDC balance is below the requested amount |",
+        "| 16 | `DuplicateRecipient` | Revenue Pool | A batch contains the same recipient more than once |",
+        "| 17 | `Overflow` | Revenue Pool | Checked arithmetic detected an overflow |",
+        "| 18 | `MaxDistributeNotPositive` | Revenue Pool | Distribution cap must be greater than zero |",
+        "| 19 | `MessageEmpty` | Revenue Pool | Admin broadcast message is empty |",
+        "| 20 | `MessageTooLong` | Revenue Pool | Admin broadcast message exceeds the length limit |",
+        "| 21 | `NoPendingEmergencyDrain` | Revenue Pool | No emergency drain proposal is pending |",
+        "| 22 | `TimelockNotExpired` | Revenue Pool | Emergency drain timelock has not elapsed |",
     ];
 
     for line in expected_lines {

--- a/contracts/revenue_pool/tests/auth_snap.rs
+++ b/contracts/revenue_pool/tests/auth_snap.rs
@@ -12,6 +12,7 @@
 //!
 //! | Category                         | Entrypoints covered |
 //! |----------------------------------|---------------------|
+//! | Initialization                   | `init` |
 //! | Admin rotation                   | `set_admin`, `accept_admin`, `claim_admin`, `cancel_admin_transfer` |
 //! | Pause guardian                   | `set_pause_guardian`, `clear_pause_guardian` |
 //! | Circuit breaker                  | `pause`, `unpause` |
@@ -82,6 +83,20 @@ fn setup_pool(
 // Auth‑requiring entrypoints — each test verifies that calling the entrypoint
 // WITHOUT authorization fails.
 // ---------------------------------------------------------------------------
+
+/// Verify that `init` requires auth on the configured admin.
+#[test]
+fn init_requires_auth() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let (_, client) = create_pool(&env);
+    let (usdc, _, _) = create_usdc(&env, &admin);
+
+    env.set_auths(&[]);
+    let res = client.try_init(&admin, &usdc);
+    assert!(res.is_err(), "init must require auth");
+}
 
 /// Verify that `set_admin` requires auth on `caller`.
 #[test]
@@ -351,23 +366,6 @@ fn cancel_emergency_drain_requires_auth() {
 // Read‑only entrypoints — each test verifies that calling without auth
 // **succeeds** (no require_auth panic).
 // ---------------------------------------------------------------------------
-
-/// `init` is a one‑time setup call — it does **not** require auth.
-#[test]
-fn init_does_not_require_auth() {
-    let env = Env::default();
-
-    // Contract and token registration need auth in the test harness.
-    env.mock_all_auths();
-    let admin = Address::generate(&env);
-    let (_, client) = create_pool(&env);
-    let (usdc, _, _) = create_usdc(&env, &admin);
-
-    // Strip auth — init itself must not require it.
-    env.set_auths(&[]);
-    let res = client.try_init(&admin, &usdc);
-    assert!(res.is_ok(), "init must not require auth");
-}
 
 /// `get_admin` is a view — it must not require auth.
 #[test]

--- a/docs/ERROR_CODES.md
+++ b/docs/ERROR_CODES.md
@@ -104,3 +104,23 @@ must not be reassigned once released.
 |------|---------|----------|---------|
 | 1 | `BatchEmpty` | Revenue Pool | `batch_distribute` received an empty `payments` vector |
 | 2 | `BatchTooLarge` | Revenue Pool | `batch_distribute` exceeded `MAX_BATCH_SIZE` |
+| 3 | `NotInitialized` | Revenue Pool | A function was called before `init` |
+| 4 | `AlreadyInitialized` | Revenue Pool | `init` was called more than once |
+| 5 | `Unauthorized` | Revenue Pool | Caller is not authorized for the operation |
+| 6 | `Paused` | Revenue Pool | Distribution is blocked while the pool is paused |
+| 7 | `AlreadyPaused` | Revenue Pool | `pause` was called while the pool was already paused |
+| 8 | `NotPaused` | Revenue Pool | `unpause` was called while the pool was not paused |
+| 9 | `InvalidUsdcToken` | Revenue Pool | USDC address conflicts with the pool or admin address |
+| 10 | `NoAdminTransferPending` | Revenue Pool | No admin transfer is pending |
+| 11 | `NoPauseGuardian` | Revenue Pool | No pause guardian is configured |
+| 12 | `AmountNotPositive` | Revenue Pool | Amount must be greater than zero |
+| 13 | `AmountExceedsMaxDistribute` | Revenue Pool | Amount exceeds the configured per-leg cap |
+| 14 | `InvalidRecipient` | Revenue Pool | Recipient is the revenue pool contract |
+| 15 | `InsufficientBalance` | Revenue Pool | Pool USDC balance is below the requested amount |
+| 16 | `DuplicateRecipient` | Revenue Pool | A batch contains the same recipient more than once |
+| 17 | `Overflow` | Revenue Pool | Checked arithmetic detected an overflow |
+| 18 | `MaxDistributeNotPositive` | Revenue Pool | Distribution cap must be greater than zero |
+| 19 | `MessageEmpty` | Revenue Pool | Admin broadcast message is empty |
+| 20 | `MessageTooLong` | Revenue Pool | Admin broadcast message exceeds the length limit |
+| 21 | `NoPendingEmergencyDrain` | Revenue Pool | No emergency drain proposal is pending |
+| 22 | `TimelockNotExpired` | Revenue Pool | Emergency drain timelock has not elapsed |


### PR DESCRIPTION
## Summary

- expand `RevenuePoolError` from the existing two batch codes to 22 stable semantic contract errors
- replace contract-owned panic strings, assertions, and production `expect` calls with `env.panic_with_error`
- require admin authorization during `init` and validate all batch recipients before token calls
- add focused typed-error, atomicity, auth, stable-code, and documentation coverage
- document the public error-code mapping and updated batch behavior

## API-visible changes

- `RevenuePoolError::BatchEmpty = 1` and `BatchTooLarge = 2` remain unchanged
- codes 3 through 22 provide machine-readable initialization, authorization, pause, validation, balance, overflow, broadcast, and emergency-drain failures
- `init` now requires authorization from the configured admin

## Verification

- `rustfmt --check` on all touched Rust files
- `git diff --check`
- static scan confirms every state-changing entrypoint enforces `require_auth`
- static scan confirms no production `panic!`, `expect()`, or `unwrap()` paths in `revenue_pool`
- validated 22 unique sequential error discriminants and valid interface JSON

Full `cargo test`/Clippy execution is not available in this local environment because no host C compiler/linker driver or C runtime development libraries are installed. Offline Clippy reached compilation and failed at the missing `cc` linker; no dependencies or toolchains were downloaded. CI should run the complete suite in the repository toolchain.

Closes #858