### PR TITLE
fix: TTL bump on revenue_pool

### DIFF
--- a/contracts/revenue_pool/src/lib.rs
+++ b/contracts/revenue_pool/src/lib.rs
@@ -176,6 +176,15 @@ impl RevenuePool {
         }
     }
 
+    /// Extend instance storage TTL on hot read paths so frequently-queried
+    /// getters do not silently archive while only being read.
+    #[inline]
+    fn bump_instance_ttl(env: &Env) {
+        env.storage()
+            .instance()
+            .extend_ttl(LIFETIME_THRESHOLD, BUMP_AMOUNT);
+    }
+
     fn require_not_paused(env: &Env) {
         if env
             .storage()
@@ -203,6 +212,7 @@ impl RevenuePool {
     /// # Panics
     /// * `"revenue pool not initialized"` — called before `init`.
     pub fn get_admin(env: Env) -> Address {
+        Self::bump_instance_ttl(&env);
         Self::admin(&env)
     }
 
@@ -211,6 +221,7 @@ impl RevenuePool {
     /// # Panics
     /// * `"revenue pool not initialized"` — called before `init`.
     pub fn get_usdc_token(env: Env) -> Address {
+        Self::bump_instance_ttl(&env);
         env.storage()
             .instance()
             .get(&Symbol::new(&env, USDC_KEY))
@@ -311,6 +322,7 @@ impl RevenuePool {
 
     /// Return the pending admin address, or `None` if no transfer is in progress.
     pub fn get_pending_admin(env: Env) -> Option<Address> {
+        Self::bump_instance_ttl(&env);
         env.storage()
             .instance()
             .get(&Symbol::new(&env, PENDING_ADMIN_KEY))
@@ -368,6 +380,7 @@ impl RevenuePool {
 
     /// Return the configured pause guardian, or `None` if unset.
     pub fn get_pause_guardian(env: Env) -> Option<Address> {
+        Self::bump_instance_ttl(&env);
         env.storage()
             .instance()
             .get(&Symbol::new(&env, PAUSE_GUARDIAN_KEY))
@@ -429,6 +442,7 @@ impl RevenuePool {
 
     /// Return `true` if the revenue pool is currently paused.
     pub fn is_paused(env: Env) -> bool {
+        Self::bump_instance_ttl(&env);
         env.storage()
             .instance()
             .get::<_, bool>(&Symbol::new(&env, PAUSED_KEY))
@@ -510,6 +524,7 @@ impl RevenuePool {
 
     /// Return the cumulative USDC yield deposited via `deposit_yield`. Defaults to 0.
     pub fn get_cumulative_yield_deposited(env: Env) -> i128 {
+        Self::bump_instance_ttl(&env);
         env.storage()
             .instance()
             .get(&Symbol::new(&env, CUMULATIVE_YIELD_DEPOSITED_KEY))
@@ -522,6 +537,7 @@ impl RevenuePool {
 
     /// Return the per-leg distribution cap. Defaults to `i128::MAX` when unset.
     pub fn get_max_distribute(env: Env) -> i128 {
+        Self::bump_instance_ttl(&env);
         env.storage()
             .instance()
             .get(&Symbol::new(&env, MAX_DISTRIBUTE_KEY))
@@ -732,6 +748,7 @@ impl RevenuePool {
     /// # Panics
     /// * `ERR_NOT_INITIALIZED` — called before `init`.
     pub fn balance(env: Env) -> i128 {
+        Self::bump_instance_ttl(&env);
         let usdc_addr: Address = env
             .storage()
             .instance()
@@ -771,6 +788,7 @@ impl RevenuePool {
 
     /// Return the stored WASM version hash, or `None` if never upgraded.
     pub fn get_version(env: Env) -> Option<BytesN<32>> {
+        Self::bump_instance_ttl(&env);
         env.storage()
             .instance()
             .get(&Symbol::new(&env, VERSION_KEY))

--- a/contracts/revenue_pool/src/test.rs
+++ b/contracts/revenue_pool/src/test.rs
@@ -1,7 +1,7 @@
 extern crate std;
 
 use super::*;
-use soroban_sdk::testutils::{Address as _, Events as _};
+use soroban_sdk::testutils::{storage::Instance as _, Address as _, Events as _, Ledger as _};
 use soroban_sdk::token;
 use soroban_sdk::BytesN;
 use soroban_sdk::TryFromVal;
@@ -1275,6 +1275,30 @@ fn batch_distribute_self_recipient_panics() {
 // TTL bump tests (Issue #342)
 // Tests that state persists after simulated ledger advance and views don't trigger TTL bump
 // ---------------------------------------------------------------------------
+
+#[test]
+fn view_getters_bump_instance_ttl_on_read_path() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let (_, client) = create_pool(&env);
+    let (usdc, _, _) = create_usdc(&env, &admin);
+
+    client.init(&admin, &usdc);
+
+    let seq = env.ledger().sequence();
+    env.ledger().set_sequence_number(seq + LIFETIME_THRESHOLD - 1);
+
+    let initial_ttl = env.storage().instance().get_ttl();
+    assert!(initial_ttl < BUMP_AMOUNT, "TTL should be near expiry before bump");
+
+    let _ = client.get_admin();
+    let _ = client.get_usdc_token();
+    let _ = client.is_paused();
+
+    let bumped_ttl = env.storage().instance().get_ttl();
+    assert!(bumped_ttl > initial_ttl, "view getters should bump instance TTL");
+}
 
 #[test]
 fn state_persists_after_ledger_advance() {


### PR DESCRIPTION
closes #664 

✅ Revenue pool TTL bump on read paths implemented
The revenue pool now bumps instance storage TTL on its hot read getters so frequently-read state does not archive just because it is queried rather than rewritten.