### PR TITLE
Fix #712: add per-entrypoint gas snapshot tests for callora-migrate

### DIFF
--- a/contracts/migrate/tests/gas_snap.rs
+++ b/contracts/migrate/tests/gas_snap.rs
@@ -1,0 +1,145 @@
+//! Gas Budget Regression Tests — `callora-migrate`
+//!
+//! Snapshots CPU/memory cost for every public migration entrypoint exposed
+//! by `callora-settlement`'s V1→V2 storage migration, re-exported through the
+//! `callora-migrate` crate (see `contracts/migrate/src/lib.rs`).
+//!
+//! Each test exercises one entrypoint, then reads the host's CPU and memory
+//! counters via `env.cost_estimate().resources()` and prints a single JSON
+//! line to stdout:
+//!
+//! ```json
+//! {"contract":"callora-migrate","entrypoint":"migrate_v1_to_v2","cpu":341234,"mem":33210}
+//! ```
+//!
+//! `scripts/gas-regression.sh` harvests those lines, compares them against
+//! `contracts/.gas-baseline.json`, and fails CI when any metric grows by more
+//! than 5 %.
+
+#[cfg(test)]
+mod gas_budget {
+    extern crate std;
+    use std::println;
+
+    use soroban_sdk::testutils::Address as _;
+    use soroban_sdk::{Address, Env};
+
+    use callora_settlement::{CalloraSettlement, CalloraSettlementClient, StorageKey};
+
+    fn create_settlement(env: &Env) -> (Address, CalloraSettlementClient<'_>) {
+        let address = env.register(CalloraSettlement, ());
+        (address.clone(), CalloraSettlementClient::new(env, &address))
+    }
+
+    fn setup_initialized(env: &Env) -> (Address, CalloraSettlementClient<'_>, Address, Address) {
+        let (address, client) = create_settlement(env);
+        let admin = Address::generate(env);
+        let vault = Address::generate(env);
+        let usdc = env
+            .register_stellar_asset_contract_v2(admin.clone())
+            .address();
+        client.init(&admin, &vault);
+        client.set_usdc_token(&admin, &usdc);
+        (address, client, admin, usdc)
+    }
+
+    /// Seed a single developer's V1 balance directly into persistent storage,
+    /// mirroring the pre-migration state a real deployment would have.
+    fn seed_v1_developer(env: &Env, contract: &Address, dev: &Address, balance: i128) {
+        env.as_contract(contract, || {
+            let inst = env.storage().instance();
+            let mut index: soroban_sdk::Vec<Address> = inst
+                .get(&StorageKey::DeveloperIndex)
+                .unwrap_or_else(|| soroban_sdk::Vec::new(env));
+            if !index.iter().any(|a| a == *dev) {
+                index.push_back(dev.clone());
+            }
+            inst.set(&StorageKey::DeveloperIndex, &index);
+            env.storage()
+                .persistent()
+                .set(&StorageKey::DeveloperBalanceV1(dev.clone()), &balance);
+        });
+    }
+
+    fn emit(entrypoint: &str, cpu: u64, mem: u64) {
+        println!(
+            "{{\"contract\":\"callora-migrate\",\"entrypoint\":\"{entrypoint}\",\"cpu\":{cpu},\"mem\":{mem}}}"
+        );
+    }
+
+    macro_rules! measure {
+        ($env:expr, $ep:literal, $body:expr) => {{
+            $body;
+            let res = $env.cost_estimate().resources();
+            let cpu = res.instructions as u64;
+            let mem = res.read_bytes as u64 + res.write_bytes as u64;
+            emit($ep, cpu, mem);
+        }};
+    }
+
+    #[test]
+    fn gas_budget_migrate_v1_to_v2() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (address, client, admin, _usdc) = setup_initialized(&env);
+        let dev = Address::generate(&env);
+        seed_v1_developer(&env, &address, &dev, 1_000);
+
+        measure!(env, "migrate_v1_to_v2", {
+            client.migrate_v1_to_v2(&admin);
+        });
+    }
+
+    #[test]
+    fn gas_budget_migrate_v1_to_v2_page() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (address, client, admin, _usdc) = setup_initialized(&env);
+        for _ in 0..10 {
+            let dev = Address::generate(&env);
+            seed_v1_developer(&env, &address, &dev, 1_000);
+        }
+
+        measure!(env, "migrate_v1_to_v2_page", {
+            client.migrate_v1_to_v2_page(&admin, &0u32, &10u32);
+        });
+    }
+
+    #[test]
+    fn gas_budget_migrate_developer_balance() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (address, client, admin, _usdc) = setup_initialized(&env);
+        let dev = Address::generate(&env);
+        seed_v1_developer(&env, &address, &dev, 1_000);
+
+        measure!(env, "migrate_developer_balance", {
+            client.migrate_developer_balance(&admin, &dev);
+        });
+    }
+
+    #[test]
+    fn gas_budget_migration_storage_version() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (_address, client, _admin, _usdc) = setup_initialized(&env);
+
+        measure!(env, "migration_storage_version", {
+            let _ = client.migration_storage_version();
+        });
+    }
+
+    /// Sanity: verify budget API returns non-zero values after a real call.
+    #[test]
+    fn gas_budget_sanity_nonzero() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (address, client, admin, _usdc) = setup_initialized(&env);
+        let dev = Address::generate(&env);
+        seed_v1_developer(&env, &address, &dev, 1_000);
+        client.migrate_v1_to_v2(&admin);
+        let res = env.cost_estimate().resources();
+        assert!(res.instructions > 0, "CPU must be >0");
+        assert!(res.read_bytes + res.write_bytes > 0, "mem must be >0");
+    }
+}

--- a/scripts/gas-regression.sh
+++ b/scripts/gas-regression.sh
@@ -45,8 +45,10 @@ cargo build --workspace 2>&1 | tail -5
 log "Running gas measurement tests..."
 mkdir -p "${REPO_ROOT}/target"
 
-cargo test -p callora-vault -- gas_budget --nocapture 2>/dev/null \
-  | grep '^{"contract"' \
+{
+  cargo test -p callora-vault -- gas_budget --nocapture 2>/dev/null
+  cargo test -p callora-migrate -- gas_budget --nocapture 2>/dev/null
+} | grep '^{"contract"' \
   > "${MEASUREMENTS_PATH}" || true
 
 if [[ ! -s "${MEASUREMENTS_PATH}" ]]; then


### PR DESCRIPTION
Closes #712

## What does this PR do?
Adds gas budget regression tests for callora-migrate's entrypoints, following the exact pattern already established in callora-vault's tests/gas_snap.rs (measure! macro, JSON-line output consumed by scripts/gas-regression.sh, cpu/mem via env.cost_estimate().resources()).

callora-migrate is a thin re-export crate (see contracts/migrate/src/lib.rs) around callora-settlement's V1→V2 storage migration API, so the tests exercise callora-settlement's actual entrypoints through that re-export:
- migrate_v1_to_v2
- migrate_v1_to_v2_page
- migrate_developer_balance
- migration_storage_version

## Changes
- contracts/migrate/tests/gas_snap.rs (new) — 5 gas_budget_* tests
- scripts/gas-regression.sh — now also runs `cargo test -p callora-migrate -- gas_budget` alongside the existing callora-vault run, so migrate's snapshots are harvested into the same measurement pipeline

## Outstanding / needs maintainer help
1. I could not run cargo test locally — this environment's Rust toolchain is 1.81.0, and the workspace requires edition2024 (~1.85+). I was unable to update due to unstable internet during this session. The test file was written by closely mirroring the vault test's structure and the existing fuzz target's call signatures (contracts/migrate/fuzz/fuzz_targets/migrate.rs), but it has not been compiled or run.
2. contracts/.gas-baseline.json does not yet have entries for callora-migrate. These need to be generated by running `./scripts/gas-regression.sh --update-baseline` once the test file is confirmed to compile and pass, then committed.

Flagging both clearly since I want to be upfront about what's verified vs. not — happy to fix quickly once I have a working toolchain or based on CI output.





The failing checks (Build release, Test, Test Nightly, Test Coverage, WASM Size Budget) all fail at the same step — `cargo build --package callora-settlement --target wasm32-unknown-unknown --release` — with:

error: package `contracts/checkpoint` is listed in default members but is not a member for workspace at `Cargo.toml`.

This is a workspace configuration issue in the root Cargo.toml (contracts/checkpoint listed as a default member without being a proper workspace member) — unrelated to the two files this PR touches (contracts/migrate/tests/gas_snap.rs, scripts/gas-regression.sh). Can confirm neither of those files reference or modify workspace membership. Happy to help fix that separately if useful, but wanted to flag it's a pre-existing issue rather than something introduced here.