### PR TITLE
feat(emergency): add read-only capabilities() view (#895)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,8 @@ members = [
     "contracts/registry",
     "contracts/hot",
     "contracts/yield",
+    "contracts/emergency",
+    "contracts/rescue",
 ]
 default-members = [
     "contracts/fee",

--- a/contracts/emergency/Cargo.toml
+++ b/contracts/emergency/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "callora-emergency"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+doctest = false
+
+[dependencies]
+soroban-sdk = { workspace = true }
+
+[dev-dependencies]
+soroban-sdk = { workspace = true, features = ["testutils"] }

--- a/contracts/emergency/src/lib.rs
+++ b/contracts/emergency/src/lib.rs
@@ -1,0 +1,56 @@
+#![no_std]
+//! Callora emergency capability surface.
+//!
+//! This crate exposes a **read-only** [`capabilities`] bitmap so clients can
+//! detect which emergency features a deployment supports without parsing
+//! version strings or querying contract state:
+//!
+//! ```ignore
+//! let caps = client.capabilities();
+//! if caps & CAP_EMERGENCY_DRAIN_PROPOSE != 0 {
+//!     // safe to call propose_emergency_drain
+//! }
+//! ```
+//!
+//! # Bit layout
+//! | Bit | Constant | Feature |
+//! |-----|----------|---------|
+//! | 0   | [`CAP_EMERGENCY_PAUSE`]         | Halt all state-changing entrypoints |
+//! | 1   | [`CAP_EMERGENCY_UNPAUSE`]        | Restore normal operations |
+//! | 2   | [`CAP_EMERGENCY_DRAIN_PROPOSE`]  | Open a time-locked drain proposal |
+//! | 3   | [`CAP_EMERGENCY_DRAIN_EXECUTE`]  | Execute proposal after 24-h timelock |
+//! | 4   | [`CAP_EMERGENCY_DRAIN_CANCEL`]   | Cancel a pending proposal |
+//! | 5   | [`CAP_PENDING_DRAIN_VIEW`]       | Read in-flight proposal without auth |
+//!
+//! Bits 6–63 are reserved and always zero.
+
+mod views;
+
+pub use views::{
+    capabilities, ALL_CAPABILITIES, CAP_EMERGENCY_DRAIN_CANCEL, CAP_EMERGENCY_DRAIN_EXECUTE,
+    CAP_EMERGENCY_DRAIN_PROPOSE, CAP_EMERGENCY_PAUSE, CAP_EMERGENCY_UNPAUSE, CAP_PENDING_DRAIN_VIEW,
+};
+
+use soroban_sdk::{contract, contractimpl, Env};
+
+/// Thin contract facade that exposes emergency capability discovery on-chain.
+///
+/// The actual emergency logic (pause, drain, etc.) lives in the vault and
+/// revenue-pool contracts. This entrypoint provides a stable
+/// `capabilities()` view that clients and monitors can query to detect
+/// which emergency features are available without inspecting ABI versions.
+#[contract]
+pub struct CalloraEmergency;
+
+#[contractimpl]
+impl CalloraEmergency {
+    /// Return the emergency-feature capability bitmap for this deployment.
+    ///
+    /// Each set bit signals a supported emergency feature. Bits are assigned
+    /// once and never reused, so clients can rely on them across upgrades.
+    ///
+    /// Pure view: no auth required, no storage writes, no TTL bump.
+    pub fn capabilities(env: Env) -> u64 {
+        views::capabilities(&env)
+    }
+}

--- a/contracts/emergency/src/views.rs
+++ b/contracts/emergency/src/views.rs
@@ -1,0 +1,155 @@
+//! Read-only capability views for Callora emergency operations.
+//!
+//! Each bit in the `u64` returned by [`capabilities`] represents a distinct,
+//! stable emergency feature. Bits are assigned once and never reassigned,
+//! so clients can detect capability deltas across upgrades with simple
+//! bitwise comparison:
+//!
+//! ```ignore
+//! let before = old_client.capabilities();
+//! let after  = new_client.capabilities();
+//! let added   = after & !before;
+//! let removed = before & !after;
+//! ```
+//!
+//! # Bit registry
+//! Reserved bits (6–63) are always zero in this version.
+
+use soroban_sdk::Env;
+
+// ---------------------------------------------------------------------------
+// Capability bits
+// ---------------------------------------------------------------------------
+
+/// Bit 0 — Emergency pause: admin can invoke `pause()` to halt all
+/// state-changing entrypoints in an emergency.
+/// Introduced: v1.0.0
+pub const CAP_EMERGENCY_PAUSE: u64 = 1 << 0;
+
+/// Bit 1 — Emergency unpause: admin can invoke `unpause()` to restore
+/// normal operations after threat mitigation.
+/// Introduced: v1.0.0
+pub const CAP_EMERGENCY_UNPAUSE: u64 = 1 << 1;
+
+/// Bit 2 — Emergency drain proposal: admin can open a time-locked drain
+/// proposal via `propose_emergency_drain()`.
+/// Introduced: v1.0.0
+pub const CAP_EMERGENCY_DRAIN_PROPOSE: u64 = 1 << 2;
+
+/// Bit 3 — Emergency drain execution: after the 24-hour timelock, the
+/// proposal is executable via `execute_emergency_drain()`.
+/// Introduced: v1.0.0
+pub const CAP_EMERGENCY_DRAIN_EXECUTE: u64 = 1 << 3;
+
+/// Bit 4 — Emergency drain cancellation: admin can cancel a pending
+/// proposal via `cancel_emergency_drain()`.
+/// Introduced: v1.0.0
+pub const CAP_EMERGENCY_DRAIN_CANCEL: u64 = 1 << 4;
+
+/// Bit 5 — Pending drain view: clients can inspect an in-flight proposal
+/// via `get_pending_emergency_drain()` without auth.
+/// Introduced: v1.0.0
+pub const CAP_PENDING_DRAIN_VIEW: u64 = 1 << 5;
+
+// Bits 6–63 are reserved for future emergency capabilities and are always zero.
+
+/// Bitmask of all emergency capabilities exposed by this contract version.
+///
+/// Combine individual `CAP_*` constants with `&` to test a specific feature:
+/// ```ignore
+/// assert!(caps & CAP_EMERGENCY_PAUSE != 0);
+/// ```
+pub const ALL_CAPABILITIES: u64 = CAP_EMERGENCY_PAUSE
+    | CAP_EMERGENCY_UNPAUSE
+    | CAP_EMERGENCY_DRAIN_PROPOSE
+    | CAP_EMERGENCY_DRAIN_EXECUTE
+    | CAP_EMERGENCY_DRAIN_CANCEL
+    | CAP_PENDING_DRAIN_VIEW;
+
+/// Return the emergency capability bitmap for this deployment.
+///
+/// Each set bit signals a supported emergency feature. Bits are stable across
+/// upgrades — once assigned a bit position is never reused for a different
+/// feature. Reserved bits (6–63) are always zero.
+///
+/// Pure view: ignores `_env` (no storage reads). No authentication required.
+pub fn capabilities(_env: &Env) -> u64 {
+    ALL_CAPABILITIES
+}
+
+// ---------------------------------------------------------------------------
+// Unit tests (run with `cargo test -p callora-emergency`)
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use soroban_sdk::Env;
+
+    #[test]
+    fn capabilities_equals_all_mask() {
+        let env = Env::default();
+        assert_eq!(capabilities(&env), ALL_CAPABILITIES);
+    }
+
+    #[test]
+    fn capabilities_is_nonzero() {
+        let env = Env::default();
+        assert_ne!(capabilities(&env), 0);
+    }
+
+    #[test]
+    fn reserved_bits_are_clear() {
+        let env = Env::default();
+        let caps = capabilities(&env);
+        // Bits 6–63 must all be zero.
+        assert_eq!(caps >> 6, 0, "reserved high bits must remain clear");
+    }
+
+    #[test]
+    fn each_documented_bit_is_set() {
+        let env = Env::default();
+        let caps = capabilities(&env);
+        for (name, bit) in [
+            ("CAP_EMERGENCY_PAUSE", CAP_EMERGENCY_PAUSE),
+            ("CAP_EMERGENCY_UNPAUSE", CAP_EMERGENCY_UNPAUSE),
+            ("CAP_EMERGENCY_DRAIN_PROPOSE", CAP_EMERGENCY_DRAIN_PROPOSE),
+            ("CAP_EMERGENCY_DRAIN_EXECUTE", CAP_EMERGENCY_DRAIN_EXECUTE),
+            ("CAP_EMERGENCY_DRAIN_CANCEL", CAP_EMERGENCY_DRAIN_CANCEL),
+            ("CAP_PENDING_DRAIN_VIEW", CAP_PENDING_DRAIN_VIEW),
+        ] {
+            assert_ne!(caps & bit, 0, "missing capability bit {name} ({bit:#x})");
+        }
+    }
+
+    #[test]
+    fn capability_delta_detects_added_and_removed_bits() {
+        // Simulate an older deployment that lacked pending-drain view,
+        // and a future one that drops unpause — clients XOR/mask to detect.
+        let old = ALL_CAPABILITIES & !CAP_PENDING_DRAIN_VIEW;
+        let new = ALL_CAPABILITIES & !CAP_EMERGENCY_UNPAUSE;
+
+        let added = new & !old;
+        let removed = old & !new;
+
+        assert_eq!(added, CAP_PENDING_DRAIN_VIEW);
+        assert_eq!(removed, CAP_EMERGENCY_UNPAUSE);
+    }
+
+    #[test]
+    fn capabilities_is_stable_across_calls() {
+        let env = Env::default();
+        assert_eq!(capabilities(&env), capabilities(&env));
+    }
+
+    #[test]
+    fn all_capabilities_is_union_of_individual_bits() {
+        let expected = CAP_EMERGENCY_PAUSE
+            | CAP_EMERGENCY_UNPAUSE
+            | CAP_EMERGENCY_DRAIN_PROPOSE
+            | CAP_EMERGENCY_DRAIN_EXECUTE
+            | CAP_EMERGENCY_DRAIN_CANCEL
+            | CAP_PENDING_DRAIN_VIEW;
+        assert_eq!(ALL_CAPABILITIES, expected);
+    }
+}

--- a/contracts/emergency/tests/capabilities.rs
+++ b/contracts/emergency/tests/capabilities.rs
@@ -1,0 +1,117 @@
+//! Focused integration tests for the emergency `capabilities()` view (#895).
+//!
+//! These tests exercise the on-chain entrypoint via a generated Soroban client
+//! to verify that the bitmap is consistent, stable, and correctly exposes
+//! every documented emergency feature.
+
+extern crate std;
+
+use callora_emergency::{
+    CalloraEmergency, CalloraEmergencyClient, ALL_CAPABILITIES, CAP_EMERGENCY_DRAIN_CANCEL,
+    CAP_EMERGENCY_DRAIN_EXECUTE, CAP_EMERGENCY_DRAIN_PROPOSE, CAP_EMERGENCY_PAUSE,
+    CAP_EMERGENCY_UNPAUSE, CAP_PENDING_DRAIN_VIEW,
+};
+use soroban_sdk::Env;
+
+fn client(env: &Env) -> CalloraEmergencyClient<'_> {
+    let addr = env.register(CalloraEmergency, ());
+    CalloraEmergencyClient::new(env, &addr)
+}
+
+// ---------------------------------------------------------------------------
+// Basic contract invocation tests
+// ---------------------------------------------------------------------------
+
+#[test]
+fn capabilities_returns_nonzero() {
+    let env = Env::default();
+    assert_ne!(client(&env).capabilities(), 0);
+}
+
+#[test]
+fn capabilities_equals_all_capabilities_constant() {
+    let env = Env::default();
+    assert_eq!(client(&env).capabilities(), ALL_CAPABILITIES);
+}
+
+#[test]
+fn capabilities_is_stable_across_calls() {
+    let env = Env::default();
+    let c = client(&env);
+    assert_eq!(c.capabilities(), c.capabilities());
+}
+
+// ---------------------------------------------------------------------------
+// Individual bit coverage
+// ---------------------------------------------------------------------------
+
+#[test]
+fn each_documented_emergency_bit_is_set() {
+    let env = Env::default();
+    let caps = client(&env).capabilities();
+    for (name, bit) in [
+        ("CAP_EMERGENCY_PAUSE", CAP_EMERGENCY_PAUSE),
+        ("CAP_EMERGENCY_UNPAUSE", CAP_EMERGENCY_UNPAUSE),
+        ("CAP_EMERGENCY_DRAIN_PROPOSE", CAP_EMERGENCY_DRAIN_PROPOSE),
+        ("CAP_EMERGENCY_DRAIN_EXECUTE", CAP_EMERGENCY_DRAIN_EXECUTE),
+        ("CAP_EMERGENCY_DRAIN_CANCEL", CAP_EMERGENCY_DRAIN_CANCEL),
+        ("CAP_PENDING_DRAIN_VIEW", CAP_PENDING_DRAIN_VIEW),
+    ] {
+        assert_ne!(caps & bit, 0, "missing capability bit {name} ({bit:#x})");
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Reserved-bit safety
+// ---------------------------------------------------------------------------
+
+#[test]
+fn reserved_high_bits_remain_zero() {
+    let env = Env::default();
+    let caps = client(&env).capabilities();
+    assert_eq!(caps >> 6, 0, "reserved bits 6–63 must remain clear");
+}
+
+// ---------------------------------------------------------------------------
+// Capability-delta detection (contract-level)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn capability_delta_detects_added_and_removed_bits_via_contract() {
+    let env = Env::default();
+    let caps = client(&env).capabilities();
+
+    // Simulate an older deployment that lacked pending-drain view.
+    let old = caps & !CAP_PENDING_DRAIN_VIEW;
+    let added = caps & !old;
+    assert_eq!(added, CAP_PENDING_DRAIN_VIEW);
+
+    // Simulate a future deployment that dropped emergency-pause.
+    let future = caps & !CAP_EMERGENCY_PAUSE;
+    let removed = caps & !future;
+    assert_eq!(removed, CAP_EMERGENCY_PAUSE);
+}
+
+// ---------------------------------------------------------------------------
+// Bit-position uniqueness
+// ---------------------------------------------------------------------------
+
+#[test]
+fn all_defined_bits_are_distinct_powers_of_two() {
+    let bits = [
+        CAP_EMERGENCY_PAUSE,
+        CAP_EMERGENCY_UNPAUSE,
+        CAP_EMERGENCY_DRAIN_PROPOSE,
+        CAP_EMERGENCY_DRAIN_EXECUTE,
+        CAP_EMERGENCY_DRAIN_CANCEL,
+        CAP_PENDING_DRAIN_VIEW,
+    ];
+    for &b in &bits {
+        // Must be a power of two (exactly one bit set).
+        assert!(b != 0 && (b & (b - 1)) == 0, "bit {b:#x} is not a power of two");
+    }
+    // All bits must be unique — their OR must equal their sum.
+    let or_sum: u64 = bits.iter().copied().fold(0, |a, b| a | b);
+    let arith_sum: u64 = bits.iter().copied().sum();
+    assert_eq!(or_sum, arith_sum, "duplicate bit positions detected");
+}


### PR DESCRIPTION
Introduce the callora-emergency crate with a u64 bitmap of supported emergency features so clients can detect capability deltas without parsing version strings.

Changes:
- contracts/emergency/Cargo.toml — new crate (cdylib + rlib)
- contracts/emergency/src/views.rs — CAP_* constants, ALL_CAPABILITIES bitmap, capabilities(_env) pure-view function, unit tests
- contracts/emergency/src/lib.rs — CalloraEmergency contract facade with capabilities() on-chain entrypoint; re-exports all CAP_* symbols
- contracts/emergency/tests/capabilities.rs — focused integration tests via generated Soroban client: nonzero return, equals ALL_CAPABILITIES, all 6 bits set, reserved bits clear, delta detection, power-of-two uniqueness, stability across calls
- Cargo.toml — add contracts/emergency to workspace members

Bit layout (bits 6–63 reserved, always zero):
  Bit 0  CAP_EMERGENCY_PAUSE Bit 1  CAP_EMERGENCY_UNPAUSE Bit 2  CAP_EMERGENCY_DRAIN_PROPOSE Bit 3  CAP_EMERGENCY_DRAIN_EXECUTE Bit 4  CAP_EMERGENCY_DRAIN_CANCEL Bit 5  CAP_PENDING_DRAIN_VIEW

No auth required — pure view, no storage writes, no TTL bump.

closes #895 