### PR TITLE
feat(admin): add per-account limits enforcement (#862)

### DIFF
--- a/contracts/admin/src/errors.rs
+++ b/contracts/admin/src/errors.rs
@@ -1,0 +1,65 @@
+//! Typed error codes for the Callora Admin per-account limits surface.
+//!
+//! The numeric discriminants in this enum are part of the contract interface
+//! and must remain stable over time. Off-chain indexers and SDK integrators
+//! branch on these `u32` codes instead of parsing panic strings.
+//!
+//! | Code | Variant            | Meaning                                                     |
+//! |------|--------------------|-------------------------------------------------------------|
+//! | 1    | NotInitialized     | Admin contract has not been initialized yet                 |
+//! | 2    | Unauthorized       | Caller is not authorized for the requested operation        |
+//! | 3    | InvalidLimit       | One or more per-account caps exceeds [`MAX_CAP`]            |
+//! | 4    | BetsAtCap          | Account's open bet count is already at the configured cap   |
+//! | 5    | PositionsAtCap     | Account's open position count is already at the configured cap |
+//! | 6    | SubscriptionsAtCap | Account's active subscription count is at the configured cap |
+//! | 7    | CounterUnderflow   | `release_*` was called when the corresponding counter was 0 |
+//! | 8    | Overflow           | `checked_add` overflow detected on a counter increment      |
+//!
+//! All variants implement [`Copy`] + [`PartialEq`] so they can be returned by
+//! value or compared in tests without allocation.
+
+use soroban_sdk::contracterror;
+
+/// Stable, machine-readable error codes for the per-account admin limits
+/// surface.
+///
+/// Every public function in [`crate::limits`] that can fail returns one of
+/// these variants instead of panicking, giving callers a deterministic
+/// branch target.
+#[contracterror]
+#[repr(u32)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+pub enum AdminLimitError {
+    /// Admin contract has not been initialized yet (code 1).
+    NotInitialized = 1,
+    /// Caller is not authorized for the requested operation (code 2).
+    Unauthorized = 2,
+    /// One or more per-account caps exceeds [`crate::limits::MAX_CAP`] or is
+    /// otherwise invalid (code 3).
+    InvalidLimit = 3,
+    /// Account's open bet count is already at the configured cap (code 4).
+    ///
+    /// Returned by [`crate::limits::consume_bet`] when an increment would
+    /// push the account's bet counter above `max_bets`.
+    BetsAtCap = 4,
+    /// Account's open position count is already at the configured cap (code 5).
+    ///
+    /// Returned by [`crate::limits::consume_position`] when an increment
+    /// would push the account's position counter above `max_positions`.
+    PositionsAtCap = 5,
+    /// Account's active subscription count is already at the configured cap (code 6).
+    ///
+    /// Returned by [`crate::limits::consume_subscription`] when an increment
+    /// would push the account's subscription counter above
+    /// `max_subscriptions`.
+    SubscriptionsAtCap = 6,
+    /// `release_*` was called when the corresponding counter was already
+    /// zero (code 7).
+    CounterUnderflow = 7,
+    /// `checked_add` overflow detected on a counter increment (code 8).
+    ///
+    /// Returned in the (effectively unreachable) case that the per-account
+    /// counter arithmetic saturates `u32::MAX` — surfaces a stable error
+    /// rather than panicking so callers can handle the edge case gracefully.
+    Overflow = 8,
+}

--- a/contracts/admin/src/events.rs
+++ b/contracts/admin/src/events.rs
@@ -8,12 +8,21 @@
 //!
 //! ## Event Overview
 //!
-//! | Topic                | Trigger                                                       |
-//! |----------------------|---------------------------------------------------------------|
-//! | `"admin_init"`       | Contract initialized with the first admin (`init`)           |
-//! | `"admin_nominated"`  | Current admin proposes a successor (`set_admin`)             |
-//! | `"admin_changed"`    | Pending admin accepts the role and becomes the new admin     |
-//! | `"admin_cancelled"`  | Current admin revokes a pending nomination                   |
+//! | Topic                       | Trigger                                                       |
+//! |-----------------------------|---------------------------------------------------------------|
+//! | `"admin_init"`              | Contract initialized with the first admin (`init`)           |
+//! | `"admin_nominated"`         | Current admin proposes a successor (`set_admin`)             |
+//! | `"admin_changed"`           | Pending admin accepts the role and becomes the new admin     |
+//! | `"admin_cancelled"`         | Current admin revokes a pending nomination                   |
+//! | `"account_limits_set"`      | Admin sets per-account caps for a specific account           |
+//! | `"account_limits_cleared"`  | Admin clears per-account caps (fallback to global defaults)  |
+//! | `"default_limits_set"`      | Admin sets the global default caps                           |
+//! | `"bet_consumed"`            | Account consumed one bet slot                                |
+//! | `"bet_released"`            | Account released one bet slot                                |
+//! | `"position_consumed"`       | Account consumed one position slot                           |
+//! | `"position_released"`       | Account released one position slot                           |
+//! | `"subscription_consumed"`   | Account consumed one subscription slot                       |
+//! | `"subscription_released"`   | Account released one subscription slot                       |
 //!
 //! ## Topic Shape
 //!
@@ -82,6 +91,109 @@ pub fn event_admin_cancelled(env: &Env) -> Symbol {
     Symbol::new(env, "admin_cancelled")
 }
 
+// ---------------------------------------------------------------------------
+// Per-account limits event topics
+// ---------------------------------------------------------------------------
+
+/// Returns the Symbol for the `"account_limits_set"` event topic.
+///
+/// Emitted when the admin sets (or overwrites) per-account caps via
+/// [`crate::limits::set_account_limits`].
+///
+/// Topics: `(account_limits_set, admin: Address)`
+/// Data:   `(account: Address, AccountLimits)`
+pub fn event_account_limits_set(env: &Env) -> Symbol {
+    Symbol::new(env, "account_limits_set")
+}
+
+/// Returns the Symbol for the `"account_limits_cleared"` event topic.
+///
+/// Emitted when the admin clears per-account caps via
+/// [`crate::limits::clear_account_limits`].
+///
+/// Topics: `(account_limits_cleared, admin: Address)`
+/// Data:   `account: Address`
+pub fn event_account_limits_cleared(env: &Env) -> Symbol {
+    Symbol::new(env, "account_limits_cleared")
+}
+
+/// Returns the Symbol for the `"default_limits_set"` event topic.
+///
+/// Emitted when the admin sets the global default caps via
+/// [`crate::limits::set_default_limits`].
+///
+/// Topics: `(default_limits_set, admin: Address)`
+/// Data:   `AccountLimits`
+pub fn event_default_limits_set(env: &Env) -> Symbol {
+    Symbol::new(env, "default_limits_set")
+}
+
+/// Returns the Symbol for the `"bet_consumed"` event topic.
+///
+/// Emitted when an account successfully consumes one bet slot via
+/// [`crate::limits::consume_bet`].
+///
+/// Topics: `(bet_consumed, account: Address)`
+/// Data:   `(new_count: u32, cap: u32)`
+pub fn event_bet_consumed(env: &Env) -> Symbol {
+    Symbol::new(env, "bet_consumed")
+}
+
+/// Returns the Symbol for the `"bet_released"` event topic.
+///
+/// Emitted when an account successfully releases one bet slot via
+/// [`crate::limits::release_bet`].
+///
+/// Topics: `(bet_released, account: Address)`
+/// Data:   `new_count: u32`
+pub fn event_bet_released(env: &Env) -> Symbol {
+    Symbol::new(env, "bet_released")
+}
+
+/// Returns the Symbol for the `"position_consumed"` event topic.
+///
+/// Emitted when an account successfully consumes one position slot via
+/// [`crate::limits::consume_position`].
+///
+/// Topics: `(position_consumed, account: Address)`
+/// Data:   `(new_count: u32, cap: u32)`
+pub fn event_position_consumed(env: &Env) -> Symbol {
+    Symbol::new(env, "position_consumed")
+}
+
+/// Returns the Symbol for the `"position_released"` event topic.
+///
+/// Emitted when an account successfully releases one position slot via
+/// [`crate::limits::release_position`].
+///
+/// Topics: `(position_released, account: Address)`
+/// Data:   `new_count: u32`
+pub fn event_position_released(env: &Env) -> Symbol {
+    Symbol::new(env, "position_released")
+}
+
+/// Returns the Symbol for the `"subscription_consumed"` event topic.
+///
+/// Emitted when an account successfully consumes one subscription slot via
+/// [`crate::limits::consume_subscription`].
+///
+/// Topics: `(subscription_consumed, account: Address)`
+/// Data:   `(new_count: u32, cap: u32)`
+pub fn event_subscription_consumed(env: &Env) -> Symbol {
+    Symbol::new(env, "subscription_consumed")
+}
+
+/// Returns the Symbol for the `"subscription_released"` event topic.
+///
+/// Emitted when an account successfully releases one subscription slot via
+/// [`crate::limits::release_subscription`].
+///
+/// Topics: `(subscription_released, account: Address)`
+/// Data:   `new_count: u32`
+pub fn event_subscription_released(env: &Env) -> Symbol {
+    Symbol::new(env, "subscription_released")
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -127,6 +239,105 @@ mod tests {
         assert_eq!(
             event_admin_cancelled(&env),
             Symbol::new(&env, "admin_cancelled")
+        );
+    }
+
+    /// Snapshot: proves `event_account_limits_set` maps to exactly
+    /// `"account_limits_set"`.
+    #[test]
+    fn test_event_account_limits_set_bytes() {
+        let env = Env::default();
+        assert_eq!(
+            event_account_limits_set(&env),
+            Symbol::new(&env, "account_limits_set")
+        );
+    }
+
+    /// Snapshot: proves `event_account_limits_cleared` maps to exactly
+    /// `"account_limits_cleared"`.
+    #[test]
+    fn test_event_account_limits_cleared_bytes() {
+        let env = Env::default();
+        assert_eq!(
+            event_account_limits_cleared(&env),
+            Symbol::new(&env, "account_limits_cleared")
+        );
+    }
+
+    /// Snapshot: proves `event_default_limits_set` maps to exactly
+    /// `"default_limits_set"`.
+    #[test]
+    fn test_event_default_limits_set_bytes() {
+        let env = Env::default();
+        assert_eq!(
+            event_default_limits_set(&env),
+            Symbol::new(&env, "default_limits_set")
+        );
+    }
+
+    /// Snapshot: proves `event_bet_consumed` maps to exactly
+    /// `"bet_consumed"`.
+    #[test]
+    fn test_event_bet_consumed_bytes() {
+        let env = Env::default();
+        assert_eq!(
+            event_bet_consumed(&env),
+            Symbol::new(&env, "bet_consumed")
+        );
+    }
+
+    /// Snapshot: proves `event_bet_released` maps to exactly
+    /// `"bet_released"`.
+    #[test]
+    fn test_event_bet_released_bytes() {
+        let env = Env::default();
+        assert_eq!(
+            event_bet_released(&env),
+            Symbol::new(&env, "bet_released")
+        );
+    }
+
+    /// Snapshot: proves `event_position_consumed` maps to exactly
+    /// `"position_consumed"`.
+    #[test]
+    fn test_event_position_consumed_bytes() {
+        let env = Env::default();
+        assert_eq!(
+            event_position_consumed(&env),
+            Symbol::new(&env, "position_consumed")
+        );
+    }
+
+    /// Snapshot: proves `event_position_released` maps to exactly
+    /// `"position_released"`.
+    #[test]
+    fn test_event_position_released_bytes() {
+        let env = Env::default();
+        assert_eq!(
+            event_position_released(&env),
+            Symbol::new(&env, "position_released")
+        );
+    }
+
+    /// Snapshot: proves `event_subscription_consumed` maps to exactly
+    /// `"subscription_consumed"`.
+    #[test]
+    fn test_event_subscription_consumed_bytes() {
+        let env = Env::default();
+        assert_eq!(
+            event_subscription_consumed(&env),
+            Symbol::new(&env, "subscription_consumed")
+        );
+    }
+
+    /// Snapshot: proves `event_subscription_released` maps to exactly
+    /// `"subscription_released"`.
+    #[test]
+    fn test_event_subscription_released_bytes() {
+        let env = Env::default();
+        assert_eq!(
+            event_subscription_released(&env),
+            Symbol::new(&env, "subscription_released")
         );
     }
 }

--- a/contracts/admin/src/lib.rs
+++ b/contracts/admin/src/lib.rs
@@ -1,6 +1,7 @@
 #![no_std]
 
 pub mod admin;
+pub mod errors;
 pub mod events;
 pub mod limits;
 

--- a/contracts/admin/src/limits.rs
+++ b/contracts/admin/src/limits.rs
@@ -1,76 +1,382 @@
-//! Per-account limits for bets, positions, and subscriptions.
+//! Per-account limits enforcement for bets, positions, and subscriptions.
 //!
-//! Limit configuration is admin-controlled. Usage increments are authenticated
-//! by the account whose state is being consumed and use checked arithmetic so
-//! exceeding a configured cap fails without modifying stored usage.
+//! # Problem
+//!
+//! Without per-account caps, a single account can open an unbounded number
+//! of bets, positions, and subscriptions, bloating persistent storage and
+//! degrading performance for every other participant. This module enforces
+//! per-account state caps to prevent abuse.
+//!
+//! # Architecture
+//!
+//! Two [`contracttype`] structs drive the limits surface:
+//!
+//! | Type              | Purpose                                                     |
+//! |-------------------|-------------------------------------------------------------|
+//! | [`AccountLimits`] | The configured `(max_bets, max_positions, max_subscriptions)` caps for an account. |
+//! | [`AccountUsage`]  | The current `(bets, positions, subscriptions)` counters for an account.           |
+//!
+//! # Storage Layout
+//!
+//! - [`AccountLimits`] are stored in **persistent** storage under
+//!   [`StorageKey::Limits`]`(Address)`. They are sparse overrides; an
+//!   account with no explicit override falls back to [`DEFAULT_LIMITS`].
+//!
+//! - [`AccountUsage`] counters are stored in **persistent** storage under
+//!   [`StorageKey::Usage`]`(Address)`.
+//!
+//! # Auth Model
+//!
+//! | Function                                                        | Authorized by                     |
+//! |-----------------------------------------------------------------|-----------------------------------|
+//! | `set_default_limits`, `set_account_limits`, `clear_account_limits` | admin (`caller == admin`)       |
+//! | `consume_bet`, `release_bet`, `consume_position`,               | account (their own counter)       |
+//! | `release_position`, `consume_subscription`, `release_subscription` | account (their own counter)     |
+//!
+//! Read-only views (`get_account_limits`, `get_account_usage`,
+//! `can_place_bet`, `can_open_position`, `can_subscribe`,
+//! `get_default_limits`) do **not** call `require_auth`.
+//!
+//! # Overflow Safety
+//!
+//! Every count mutation uses `u32::checked_add` / `u32::checked_sub`. The
+//! outcomes are folded into typed [`AdminLimitError`] variants so no
+//! production code path invokes `unwrap()` or `panic!()`.
 
 use soroban_sdk::{contracttype, Address, Env};
 
-#[derive(Clone, Debug, Eq, PartialEq)]
+use crate::errors::AdminLimitError;
+use crate::events;
+
+// ---------------------------------------------------------------------------
+// Constants — TTL and defaults
+// ---------------------------------------------------------------------------
+
+/// Per-day ledger count at a 5-second close cadence (matches vault).
+pub const LEDGERS_PER_DAY: u32 = 17_280;
+
+/// TTL bump threshold for persistent storage keys (`Usage`).
+///
+/// When the remaining TTL of the key falls below this value the contract
+/// re-extends the TTL on every increment / decrement so account counters do
+/// not silently archive.
+pub const STATE_BUMP_THRESHOLD: u32 = LEDGERS_PER_DAY * 7;
+
+/// TTL bump amount for persistent storage keys (`Usage`).
+pub const STATE_BUMP_AMOUNT: u32 = LEDGERS_PER_DAY * 30;
+
+/// TTL bump threshold for persistent storage keys (`Limits`).
+pub const LIMITS_BUMP_THRESHOLD: u32 = LEDGERS_PER_DAY * 7;
+
+/// TTL bump amount for persistent storage keys (`Limits`).
+pub const LIMITS_BUMP_AMOUNT: u32 = LEDGERS_PER_DAY * 30;
+
+/// Maximum allowable value for any single cap dimension.
+///
+/// Counts are stored as `u32`, so this matches the practical ceiling. The
+/// cap itself is never compared against `u32::MAX` so this is a conservative
+/// sanity ceiling rather than the absolute type ceiling.
+pub const MAX_CAP: u32 = 1_000_000;
+
+/// Global default per-account limits applied when no explicit override exists
+/// for an account.
+///
+/// # Default rationale
+///
+/// - `100` open bets caps the worst-case bet-farming at 100× per account.
+/// - `50` open positions caps positions similarly while leaving headroom for
+///   legitimate power-users.
+/// - `20` active subscriptions caps subscription-farming while still
+///   allowing routine usage.
+///
+/// These values are intentionally conservative so the contract is safe-by-default
+/// even before the admin sets explicit caps via
+/// [`set_account_limits`] or [`set_default_limits`].
+pub const DEFAULT_LIMITS: AccountLimits = AccountLimits {
+    max_bets: 100,
+    max_positions: 50,
+    max_subscriptions: 20,
+};
+
+// ---------------------------------------------------------------------------
+// Data structures
+// ---------------------------------------------------------------------------
+
+/// Per-account state caps configured by the admin.
+///
+/// Each field sets the maximum allowed concurrent state of that kind for a
+/// single account. A value of `0` disables that kind entirely (no new bets,
+/// positions, or subscriptions can be opened while the cap is `0`).
 #[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct AccountLimits {
+    /// Maximum concurrent open bets.
     pub max_bets: u32,
+    /// Maximum concurrent open positions.
     pub max_positions: u32,
+    /// Maximum concurrent active subscriptions.
     pub max_subscriptions: u32,
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
-#[contracttype]
-pub struct AccountUsage {
-    pub bets: u32,
-    pub positions: u32,
-    pub subscriptions: u32,
-}
+impl AccountLimits {
+    /// Construct a new [`AccountLimits`] with all three caps set to `count`.
+    pub const fn uniform(count: u32) -> Self {
+        Self {
+            max_bets: count,
+            max_positions: count,
+            max_subscriptions: count,
+        }
+    }
 
-#[derive(Clone)]
-#[contracttype]
-enum StorageKey {
-    Limits(Address),
-    Usage(Address),
-}
+    /// Return `true` if every individual cap is within the valid range
+    /// (`<= MAX_CAP`).
+    pub fn is_valid(&self) -> bool {
+        self.max_bets <= MAX_CAP
+            && self.max_positions <= MAX_CAP
+            && self.max_subscriptions <= MAX_CAP
+    }
 
-fn require_admin(env: &Env, caller: &Address) {
-    caller.require_auth();
-    let admin = crate::admin::get_admin(env)
-        .unwrap_or_else(|| panic!("admin contract not initialized"));
-    if *caller != admin {
-        panic!("unauthorized");
+    /// Return `true` if all caps are `0` (fully disabled account).
+    pub fn is_fully_disabled(&self) -> bool {
+        self.max_bets == 0 && self.max_positions == 0 && self.max_subscriptions == 0
     }
 }
 
-fn limits_for(env: &Env, account: &Address) -> AccountLimits {
-    env.storage()
-        .persistent()
-        .get(&StorageKey::Limits(account.clone()))
-        .unwrap_or(AccountLimits {
-            max_bets: u32::MAX,
-            max_positions: u32::MAX,
-            max_subscriptions: u32::MAX,
-        })
+/// Per-account live usage counters.
+///
+/// Only the contract mutates fields on this struct. Counter arithmetic is
+/// performed via `checked_add` / `checked_sub` so a buggy caller can never
+/// drive any field into `u32::MAX + 1`.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct AccountUsage {
+    /// Current number of open bets.
+    pub bets: u32,
+    /// Current number of open positions.
+    pub positions: u32,
+    /// Current number of active subscriptions.
+    pub subscriptions: u32,
 }
 
-fn usage_for(env: &Env, account: &Address) -> AccountUsage {
-    env.storage()
-        .persistent()
-        .get(&StorageKey::Usage(account.clone()))
-        .unwrap_or(AccountUsage {
+impl AccountUsage {
+    /// Return a zeroed [`AccountUsage`].
+    pub const fn zero() -> Self {
+        Self {
             bets: 0,
             positions: 0,
             subscriptions: 0,
-        })
+        }
+    }
+
+    /// Increment the bet counter using `checked_add`.
+    ///
+    /// # Errors
+    /// - [`AdminLimitError::Overflow`] — counter would saturate `u32::MAX`.
+    pub fn add_bet(&mut self) -> Result<(), AdminLimitError> {
+        self.bets = self.bets.checked_add(1).ok_or(AdminLimitError::Overflow)?;
+        Ok(())
+    }
+
+    /// Decrement the bet counter using `checked_sub`.
+    ///
+    /// # Errors
+    /// - [`AdminLimitError::CounterUnderflow`] — counter is already 0.
+    pub fn sub_bet(&mut self) -> Result<(), AdminLimitError> {
+        self.bets = self
+            .bets
+            .checked_sub(1)
+            .ok_or(AdminLimitError::CounterUnderflow)?;
+        Ok(())
+    }
+
+    /// Increment the position counter using `checked_add`.
+    pub fn add_position(&mut self) -> Result<(), AdminLimitError> {
+        self.positions = self
+            .positions
+            .checked_add(1)
+            .ok_or(AdminLimitError::Overflow)?;
+        Ok(())
+    }
+
+    /// Decrement the position counter using `checked_sub`.
+    pub fn sub_position(&mut self) -> Result<(), AdminLimitError> {
+        self.positions = self
+            .positions
+            .checked_sub(1)
+            .ok_or(AdminLimitError::CounterUnderflow)?;
+        Ok(())
+    }
+
+    /// Increment the subscription counter using `checked_add`.
+    pub fn add_subscription(&mut self) -> Result<(), AdminLimitError> {
+        self.subscriptions = self
+            .subscriptions
+            .checked_add(1)
+            .ok_or(AdminLimitError::Overflow)?;
+        Ok(())
+    }
+
+    /// Decrement the subscription counter using `checked_sub`.
+    pub fn sub_subscription(&mut self) -> Result<(), AdminLimitError> {
+        self.subscriptions = self
+            .subscriptions
+            .checked_sub(1)
+            .ok_or(AdminLimitError::CounterUnderflow)?;
+        Ok(())
+    }
 }
 
+/// Canonical storage keys for the admin limits module.
+#[contracttype]
+#[derive(Clone)]
+enum StorageKey {
+    /// Per-account caps override (persistent storage; sparse).
+    Limits(Address),
+    /// Per-account live usage counters (persistent storage).
+    Usage(Address),
+    /// Global default caps applied when an account has no explicit override.
+    DefaultLimits,
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers — auth
+// ---------------------------------------------------------------------------
+
+/// Assert `caller` equals the stored admin.
+///
+/// Runs `caller.require_auth()` first so misconfigured callers are rejected
+/// deterministically without consuming the underlying signature.
+///
+/// # Errors
+/// - [`AdminLimitError::Unauthorized`] — caller is not the stored admin.
+/// - [`AdminLimitError::NotInitialized`] — admin has never been set.
+fn require_admin(env: &Env, caller: &Address) -> Result<(), AdminLimitError> {
+    caller.require_auth();
+    let admin =
+        crate::admin::get_admin(env).ok_or(AdminLimitError::NotInitialized)?;
+    if *caller != admin {
+        return Err(AdminLimitError::Unauthorized);
+    }
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers — storage reads/writes
+// ---------------------------------------------------------------------------
+
+/// Read the per-account limits caps or fall back to [`get_default_limits`].
+fn limits_for(env: &Env, account: &Address) -> AccountLimits {
+    let key = StorageKey::Limits(account.clone());
+    let limits: Option<AccountLimits> = env.storage().persistent().get(&key);
+    if let Some(caps) = limits {
+        env.storage()
+            .persistent()
+            .extend_ttl(&key, LIMITS_BUMP_THRESHOLD, LIMITS_BUMP_AMOUNT);
+        return caps;
+    }
+    get_default_limits(env)
+}
+
+/// Read the live per-account usage counters, returning a zero struct if the
+/// account has no recorded state yet. Bumps persistent TTL on read.
+fn usage_for(env: &Env, account: &Address) -> AccountUsage {
+    let key = StorageKey::Usage(account.clone());
+    let usage: Option<AccountUsage> = env.storage().persistent().get(&key);
+    if let Some(u) = usage {
+        env.storage()
+            .persistent()
+            .extend_ttl(&key, STATE_BUMP_THRESHOLD, STATE_BUMP_AMOUNT);
+        return u;
+    }
+    AccountUsage::zero()
+}
+
+/// Persist the live per-account usage counters and bump persistent TTL.
 fn save_usage(env: &Env, account: &Address, usage: &AccountUsage) {
+    let key = StorageKey::Usage(account.clone());
+    env.storage().persistent().set(&key, usage);
     env.storage()
         .persistent()
-        .set(&StorageKey::Usage(account.clone()), usage);
+        .extend_ttl(&key, STATE_BUMP_THRESHOLD, STATE_BUMP_AMOUNT);
 }
 
-/// Set all per-account state caps.
+// ---------------------------------------------------------------------------
+// Public API — limits configuration
+// ---------------------------------------------------------------------------
+
+/// Read the global default caps or fall back to [`DEFAULT_LIMITS`].
+pub fn get_default_limits(env: &Env) -> AccountLimits {
+    env.storage()
+        .persistent()
+        .get(&StorageKey::DefaultLimits)
+        .unwrap_or(DEFAULT_LIMITS)
+}
+
+/// Set the global default caps (admin only).
+///
+/// # Arguments
+/// * `env` — Soroban environment.
+/// * `caller` — Must be the current admin; must authorize.
+/// * `max_bets` — Default maximum concurrent open bets per account.
+/// * `max_positions` — Default maximum concurrent open positions per account.
+/// * `max_subscriptions` — Default maximum concurrent subscriptions per account.
+///
+/// # Errors
+/// - [`AdminLimitError::NotInitialized`] — admin contract not initialized.
+/// - [`AdminLimitError::Unauthorized`] — `caller` is not the current admin.
+/// - [`AdminLimitError::InvalidLimit`] — any cap exceeds [`MAX_CAP`].
+///
+/// # Events
+/// Emits `default_limits_set` with `(default_limits_set, caller)` topics and
+/// the new `AccountLimits` as data.
+pub fn set_default_limits(
+    env: &Env,
+    caller: &Address,
+    max_bets: u32,
+    max_positions: u32,
+    max_subscriptions: u32,
+) -> Result<(), AdminLimitError> {
+    require_admin(env, caller)?;
+    let caps = AccountLimits {
+        max_bets,
+        max_positions,
+        max_subscriptions,
+    };
+    if !caps.is_valid() {
+        return Err(AdminLimitError::InvalidLimit);
+    }
+    env.storage()
+        .persistent()
+        .set(&StorageKey::DefaultLimits, &caps);
+    env.events().publish(
+        (events::event_default_limits_set(env), caller.clone(), caps.clone()),
+        caps,
+    );
+    Ok(())
+}
+
+/// Set all per-account state caps (admin only).
 ///
 /// Only the current admin may update limits. A zero value disables the
 /// corresponding category for the account; the default for an account with no
-/// configured limits is unlimited.
+/// configured limits falls back to [`get_default_limits`].
+///
+/// # Arguments
+/// * `env` — Soroban environment.
+/// * `caller` — Must be the current admin; must authorize.
+/// * `account` — Target account address.
+/// * `max_bets` — Maximum concurrent open bets.
+/// * `max_positions` — Maximum concurrent open positions.
+/// * `max_subscriptions` — Maximum concurrent subscriptions.
+///
+/// # Errors
+/// - [`AdminLimitError::NotInitialized`] — admin contract not initialized.
+/// - [`AdminLimitError::Unauthorized`] — `caller` is not the current admin.
+/// - [`AdminLimitError::InvalidLimit`] — any cap exceeds [`MAX_CAP`].
+///
+/// # Events
+/// Emits `account_limits_set` with `(account_limits_set, caller)` topics and
+/// `(account, AccountLimits)` as data.
 pub fn set_account_limits(
     env: &Env,
     caller: &Address,
@@ -78,75 +384,364 @@ pub fn set_account_limits(
     max_bets: u32,
     max_positions: u32,
     max_subscriptions: u32,
-) {
-    require_admin(env, caller);
-    env.storage().persistent().set(
-        &StorageKey::Limits(account.clone()),
-        &AccountLimits {
-            max_bets,
-            max_positions,
-            max_subscriptions,
-        },
+) -> Result<(), AdminLimitError> {
+    require_admin(env, caller)?;
+    let caps = AccountLimits {
+        max_bets,
+        max_positions,
+        max_subscriptions,
+    };
+    if !caps.is_valid() {
+        return Err(AdminLimitError::InvalidLimit);
+    }
+    let key = StorageKey::Limits(account.clone());
+    env.storage().persistent().set(&key, &caps);
+    env.storage()
+        .persistent()
+        .extend_ttl(&key, LIMITS_BUMP_THRESHOLD, LIMITS_BUMP_AMOUNT);
+    env.events().publish(
+        (
+            events::event_account_limits_set(env),
+            caller.clone(),
+            account.clone(),
+        ),
+        (account.clone(), caps),
     );
+    Ok(())
 }
 
+/// Remove any per-account caps override so the account falls back to the
+/// global default (admin only).
+///
+/// # Arguments
+/// * `env` — Soroban environment.
+/// * `caller` — Must be the current admin; must authorize.
+/// * `account` — Target account address.
+///
+/// # Errors
+/// - [`AdminLimitError::NotInitialized`] — admin contract not initialized.
+/// - [`AdminLimitError::Unauthorized`] — `caller` is not the current admin.
+///
+/// # Events
+/// Emits `account_limits_cleared` with `(account_limits_cleared, caller)`
+/// topics and the `account` address as data.
+pub fn clear_account_limits(
+    env: &Env,
+    caller: &Address,
+    account: &Address,
+) -> Result<(), AdminLimitError> {
+    require_admin(env, caller)?;
+    env.storage()
+        .persistent()
+        .remove(&StorageKey::Limits(account.clone()));
+    env.events().publish(
+        (
+            events::event_account_limits_cleared(env),
+            caller.clone(),
+            account.clone(),
+        ),
+        account.clone(),
+    );
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Public API — read-only views
+// ---------------------------------------------------------------------------
+
 /// Return the configured caps for an account.
+///
+/// Falls back to [`get_default_limits`] if no per-account override exists.
 pub fn get_account_limits(env: &Env, account: &Address) -> AccountLimits {
     limits_for(env, account)
 }
 
 /// Return the current tracked usage for an account.
+///
+/// Returns a zeroed [`AccountUsage`] if the account has no recorded usage.
 pub fn get_account_usage(env: &Env, account: &Address) -> AccountUsage {
     usage_for(env, account)
 }
+
+/// Return `true` if `account` can place another bet without exceeding caps.
+pub fn can_place_bet(env: &Env, account: &Address) -> bool {
+    let caps = limits_for(env, account);
+    let usage = usage_for(env, account);
+    usage.bets < caps.max_bets
+}
+
+/// Return `true` if `account` can open another position without exceeding caps.
+pub fn can_open_position(env: &Env, account: &Address) -> bool {
+    let caps = limits_for(env, account);
+    let usage = usage_for(env, account);
+    usage.positions < caps.max_positions
+}
+
+/// Return `true` if `account` can subscribe again without exceeding caps.
+pub fn can_subscribe(env: &Env, account: &Address) -> bool {
+    let caps = limits_for(env, account);
+    let usage = usage_for(env, account);
+    usage.subscriptions < caps.max_subscriptions
+}
+
+// ---------------------------------------------------------------------------
+// Public API — increment (consume) operations
+// ---------------------------------------------------------------------------
 
 /// Consume one bet slot for an account.
 ///
 /// The account must authorize the state change. The usage counter is updated
 /// only when the configured cap has not been reached.
-pub fn consume_bet(env: &Env, account: &Address) {
+///
+/// # Arguments
+/// * `env` — Soroban environment.
+/// * `account` — Account whose bet counter will be incremented; must authorize.
+///
+/// # Errors
+/// - [`AdminLimitError::BetsAtCap`] — account's open bet count is already at
+///   the configured cap.
+/// - [`AdminLimitError::Overflow`] — counter would saturate `u32::MAX`.
+///
+/// # Events
+/// Emits `bet_consumed` with `(bet_consumed, account)` topics and
+/// `(new_count, cap)` as data.
+pub fn consume_bet(env: &Env, account: &Address) -> Result<(), AdminLimitError> {
     account.require_auth();
-    let limits = limits_for(env, account);
+    let caps = limits_for(env, account);
     let mut usage = usage_for(env, account);
-    let next = usage
-        .bets
-        .checked_add(1)
-        .unwrap_or_else(|| panic!("bet usage overflow"));
-    if next > limits.max_bets {
-        panic!("bet limit exceeded");
+    if usage.bets >= caps.max_bets {
+        return Err(AdminLimitError::BetsAtCap);
     }
-    usage.bets = next;
+    usage.add_bet()?;
     save_usage(env, account, &usage);
+    env.events().publish(
+        (events::event_bet_consumed(env), account.clone()),
+        (usage.bets, caps.max_bets),
+    );
+    Ok(())
 }
 
 /// Consume one position slot for an account.
-pub fn consume_position(env: &Env, account: &Address) {
+///
+/// The account must authorize the state change.
+///
+/// # Errors
+/// - [`AdminLimitError::PositionsAtCap`] — account's open position count is
+///   already at the configured cap.
+/// - [`AdminLimitError::Overflow`] — counter would saturate `u32::MAX`.
+///
+/// # Events
+/// Emits `position_consumed` with `(position_consumed, account)` topics and
+/// `(new_count, cap)` as data.
+pub fn consume_position(env: &Env, account: &Address) -> Result<(), AdminLimitError> {
     account.require_auth();
-    let limits = limits_for(env, account);
+    let caps = limits_for(env, account);
     let mut usage = usage_for(env, account);
-    let next = usage
-        .positions
-        .checked_add(1)
-        .unwrap_or_else(|| panic!("position usage overflow"));
-    if next > limits.max_positions {
-        panic!("position limit exceeded");
+    if usage.positions >= caps.max_positions {
+        return Err(AdminLimitError::PositionsAtCap);
     }
-    usage.positions = next;
+    usage.add_position()?;
     save_usage(env, account, &usage);
+    env.events().publish(
+        (events::event_position_consumed(env), account.clone()),
+        (usage.positions, caps.max_positions),
+    );
+    Ok(())
 }
 
 /// Consume one subscription slot for an account.
-pub fn consume_subscription(env: &Env, account: &Address) {
+///
+/// The account must authorize the state change.
+///
+/// # Errors
+/// - [`AdminLimitError::SubscriptionsAtCap`] — account's subscription count
+///   is already at the configured cap.
+/// - [`AdminLimitError::Overflow`] — counter would saturate `u32::MAX`.
+///
+/// # Events
+/// Emits `subscription_consumed` with `(subscription_consumed, account)`
+/// topics and `(new_count, cap)` as data.
+pub fn consume_subscription(env: &Env, account: &Address) -> Result<(), AdminLimitError> {
     account.require_auth();
-    let limits = limits_for(env, account);
+    let caps = limits_for(env, account);
     let mut usage = usage_for(env, account);
-    let next = usage
-        .subscriptions
-        .checked_add(1)
-        .unwrap_or_else(|| panic!("subscription usage overflow"));
-    if next > limits.max_subscriptions {
-        panic!("subscription limit exceeded");
+    if usage.subscriptions >= caps.max_subscriptions {
+        return Err(AdminLimitError::SubscriptionsAtCap);
     }
-    usage.subscriptions = next;
+    usage.add_subscription()?;
     save_usage(env, account, &usage);
+    env.events().publish(
+        (events::event_subscription_consumed(env), account.clone()),
+        (usage.subscriptions, caps.max_subscriptions),
+    );
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Public API — decrement (release) operations
+// ---------------------------------------------------------------------------
+
+/// Release one bet slot for an account (decrement counter).
+///
+/// The account must authorize the state change. Rejects if the counter is
+/// already zero.
+///
+/// # Arguments
+/// * `env` — Soroban environment.
+/// * `account` — Account whose bet counter will be decremented; must authorize.
+///
+/// # Errors
+/// - [`AdminLimitError::CounterUnderflow`] — bet counter is already 0.
+///
+/// # Events
+/// Emits `bet_released` with `(bet_released, account)` topics and
+/// the new count as data.
+pub fn release_bet(env: &Env, account: &Address) -> Result<(), AdminLimitError> {
+    account.require_auth();
+    let mut usage = usage_for(env, account);
+    usage.sub_bet()?;
+    save_usage(env, account, &usage);
+    env.events().publish(
+        (events::event_bet_released(env), account.clone()),
+        usage.bets,
+    );
+    Ok(())
+}
+
+/// Release one position slot for an account (decrement counter).
+///
+/// The account must authorize the state change. Rejects if the counter is
+/// already zero.
+///
+/// # Errors
+/// - [`AdminLimitError::CounterUnderflow`] — position counter is already 0.
+///
+/// # Events
+/// Emits `position_released` with `(position_released, account)` topics and
+/// the new count as data.
+pub fn release_position(env: &Env, account: &Address) -> Result<(), AdminLimitError> {
+    account.require_auth();
+    let mut usage = usage_for(env, account);
+    usage.sub_position()?;
+    save_usage(env, account, &usage);
+    env.events().publish(
+        (events::event_position_released(env), account.clone()),
+        usage.positions,
+    );
+    Ok(())
+}
+
+/// Release one subscription slot for an account (decrement counter).
+///
+/// The account must authorize the state change. Rejects if the counter is
+/// already zero.
+///
+/// # Errors
+/// - [`AdminLimitError::CounterUnderflow`] — subscription counter is already 0.
+///
+/// # Events
+/// Emits `subscription_released` with `(subscription_released, account)`
+/// topics and the new count as data.
+pub fn release_subscription(env: &Env, account: &Address) -> Result<(), AdminLimitError> {
+    account.require_auth();
+    let mut usage = usage_for(env, account);
+    usage.sub_subscription()?;
+    save_usage(env, account, &usage);
+    env.events().publish(
+        (events::event_subscription_released(env), account.clone()),
+        usage.subscriptions,
+    );
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use soroban_sdk::testutils::Address as _;
+
+    /// `AccountLimits::uniform` sets all three caps to the same value.
+    #[test]
+    fn account_limits_uniform_constructor() {
+        let caps = AccountLimits::uniform(7);
+        assert_eq!(caps.max_bets, 7);
+        assert_eq!(caps.max_positions, 7);
+        assert_eq!(caps.max_subscriptions, 7);
+    }
+
+    /// `AccountLimits::is_valid` rejects caps exceeding `MAX_CAP`.
+    #[test]
+    fn account_limits_is_valid_rejects_oversized_caps() {
+        let bad = AccountLimits {
+            max_bets: MAX_CAP + 1,
+            max_positions: 0,
+            max_subscriptions: 0,
+        };
+        assert!(!bad.is_valid());
+    }
+
+    /// `AccountLimits::is_valid` accepts caps at and below `MAX_CAP`.
+    #[test]
+    fn account_limits_is_valid_accepts_max_cap() {
+        let ok = AccountLimits {
+            max_bets: MAX_CAP,
+            max_positions: MAX_CAP,
+            max_subscriptions: MAX_CAP,
+        };
+        assert!(ok.is_valid());
+    }
+
+    /// `AccountLimits::is_fully_disabled` returns `true` only when all caps
+    /// are 0.
+    #[test]
+    fn account_limits_is_fully_disabled() {
+        assert!(AccountLimits::uniform(0).is_fully_disabled());
+        assert!(!AccountLimits::uniform(1).is_fully_disabled());
+        assert!(!AccountLimits {
+            max_bets: 1,
+            max_positions: 0,
+            max_subscriptions: 0,
+        }
+        .is_fully_disabled());
+    }
+
+    /// `AccountUsage::zero` produces a struct with all counters at 0.
+    #[test]
+    fn account_usage_zero_has_all_counts_at_zero() {
+        let z = AccountUsage::zero();
+        assert_eq!(z.bets, 0);
+        assert_eq!(z.positions, 0);
+        assert_eq!(z.subscriptions, 0);
+    }
+
+    /// `DEFAULT_LIMITS` are conservative and non-zero.
+    #[test]
+    fn default_limits_are_conservative() {
+        assert!(DEFAULT_LIMITS.max_bets > 0);
+        assert!(DEFAULT_LIMITS.max_positions > 0);
+        assert!(DEFAULT_LIMITS.max_subscriptions > 0);
+        assert!(DEFAULT_LIMITS.max_bets <= 1000);
+        assert!(DEFAULT_LIMITS.max_positions <= 1000);
+        assert!(DEFAULT_LIMITS.max_subscriptions <= 1000);
+        assert!(DEFAULT_LIMITS.is_valid());
+    }
+
+    /// `MAX_CAP` is non-trivial.
+    #[test]
+    fn max_cap_is_reasonable() {
+        assert!(MAX_CAP > 0);
+        assert!(MAX_CAP <= 10_000_000);
+    }
+
+    /// TTL bump constants are internally consistent.
+    #[test]
+    fn bump_constants_are_sensible() {
+        const {
+            assert!(STATE_BUMP_AMOUNT > STATE_BUMP_THRESHOLD);
+            assert!(LIMITS_BUMP_AMOUNT > LIMITS_BUMP_THRESHOLD);
+        }
+    }
 }

--- a/contracts/admin/src/test.rs
+++ b/contracts/admin/src/test.rs
@@ -773,3 +773,740 @@ fn full_rotation_event_log_contains_exactly_three_events() {
         "full rotation must emit exactly three events (init + nominated + changed)"
     );
 }
+
+// ===========================================================================
+// Per-account limits — auth
+// ===========================================================================
+
+/// `set_account_limits` with `mock_all_auths` rejects a non-admin caller.
+///
+/// Host-level `require_auth()` panics without auth setup, matching the Soroban
+/// convention used across the admin contract. This test uses `mock_all_auths()`
+/// so the non-admin error surfaces as `Err(Unauthorized)`.
+#[test]
+fn limits_set_account_requires_admin_auth() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let alice = Address::generate(&env);
+    admin::init(&env, &admin);
+
+    let res = limits::set_account_limits(&env, &alice, &alice, 5, 5, 5);
+    assert_eq!(res, Err(errors::AdminLimitError::Unauthorized));
+}
+
+/// `set_account_limits` returns `NotInitialized` when no admin is set.
+#[test]
+fn limits_set_account_requires_initialization() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let caller = Address::generate(&env);
+    let target = Address::generate(&env);
+
+    let res = limits::set_account_limits(&env, &caller, &target, 5, 5, 5);
+    assert_eq!(res, Err(errors::AdminLimitError::NotInitialized));
+}
+
+/// `set_default_limits` returns `NotInitialized` when no admin is set.
+#[test]
+fn limits_set_default_requires_initialization() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let caller = Address::generate(&env);
+
+    let res = limits::set_default_limits(&env, &caller, 5, 5, 5);
+    assert_eq!(res, Err(errors::AdminLimitError::NotInitialized));
+}
+
+/// `clear_account_limits` returns `NotInitialized` when no admin is set.
+#[test]
+fn limits_clear_account_requires_initialization() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let caller = Address::generate(&env);
+    let target = Address::generate(&env);
+
+    let res = limits::clear_account_limits(&env, &caller, &target);
+    assert_eq!(res, Err(errors::AdminLimitError::NotInitialized));
+}
+
+/// `set_default_limits` rejects a non-admin caller even when authorized.
+#[test]
+fn limits_set_default_rejects_non_admin() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let intruder = Address::generate(&env);
+    admin::init(&env, &admin);
+
+    let res = limits::set_default_limits(&env, &intruder, 5, 5, 5);
+    assert_eq!(res, Err(errors::AdminLimitError::Unauthorized));
+}
+
+/// `clear_account_limits` rejects a non-admin caller.
+#[test]
+fn limits_clear_account_rejects_non_admin() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let intruder = Address::generate(&env);
+    let target = Address::generate(&env);
+    admin::init(&env, &admin);
+
+    let res = limits::clear_account_limits(&env, &intruder, &target);
+    assert_eq!(res, Err(errors::AdminLimitError::Unauthorized));
+}
+
+// ===========================================================================
+// Per-account limits — views (uninitialized)
+// ===========================================================================
+
+/// Views work without admin initialization (they have no auth requirement).
+#[test]
+fn limits_views_work_without_admin_init() {
+    let env = Env::default();
+    let alice = Address::generate(&env);
+
+    // get_default_limits returns DEFAULT_LIMITS
+    assert_eq!(limits::get_default_limits(&env), limits::DEFAULT_LIMITS);
+
+    // get_account_limits returns DEFAULT_LIMITS
+    let caps = limits::get_account_limits(&env, &alice);
+    assert_eq!(caps, limits::DEFAULT_LIMITS);
+
+    // get_account_usage returns zero
+    let usage = limits::get_account_usage(&env, &alice);
+    assert_eq!(usage.bets, 0);
+    assert_eq!(usage.positions, 0);
+    assert_eq!(usage.subscriptions, 0);
+
+    // can_* checks return true (default caps are non-zero)
+    assert!(limits::can_place_bet(&env, &alice));
+    assert!(limits::can_open_position(&env, &alice));
+    assert!(limits::can_subscribe(&env, &alice));
+}
+
+// ===========================================================================
+// Per-account limits — set / get caps
+// ===========================================================================
+
+/// `set_account_limits` persists caps and they are readable via
+/// `get_account_limits`.
+#[test]
+fn limits_set_account_persists_and_is_readable() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let alice = Address::generate(&env);
+    admin::init(&env, &admin);
+
+    let res = limits::set_account_limits(&env, &admin, &alice, 2, 3, 4);
+    assert_eq!(res, Ok(()));
+
+    let caps = limits::get_account_limits(&env, &alice);
+    assert_eq!(caps.max_bets, 2);
+    assert_eq!(caps.max_positions, 3);
+    assert_eq!(caps.max_subscriptions, 4);
+}
+
+/// `set_account_limits` emits an `account_limits_set` event.
+#[test]
+fn limits_set_account_emits_event() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let alice = Address::generate(&env);
+    admin::init(&env, &admin);
+
+    limits::set_account_limits(&env, &admin, &alice, 5, 6, 7).unwrap();
+
+    let matches = events_with_topic(&env, "account_limits_set");
+    assert_eq!(matches.len(), 1);
+}
+
+/// `set_default_limits` persists and `get_default_limits` reads it back.
+#[test]
+fn limits_set_default_persists() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    admin::init(&env, &admin);
+
+    limits::set_default_limits(&env, &admin, 10, 20, 30).unwrap();
+
+    let caps = limits::get_default_limits(&env);
+    assert_eq!(caps.max_bets, 10);
+    assert_eq!(caps.max_positions, 20);
+    assert_eq!(caps.max_subscriptions, 30);
+}
+
+/// `set_default_limits` emits a `default_limits_set` event.
+#[test]
+fn limits_set_default_emits_event() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    admin::init(&env, &admin);
+
+    limits::set_default_limits(&env, &admin, 10, 20, 30).unwrap();
+
+    let matches = events_with_topic(&env, "default_limits_set");
+    assert_eq!(matches.len(), 1);
+}
+
+/// `set_account_limits` rejects caps exceeding `MAX_CAP`.
+#[test]
+fn limits_set_account_rejects_invalid_caps() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let alice = Address::generate(&env);
+    admin::init(&env, &admin);
+
+    let bad_bets = limits::set_account_limits(
+        &env, &admin, &alice,
+        limits::MAX_CAP + 1, 0, 0,
+    );
+    assert_eq!(bad_bets, Err(errors::AdminLimitError::InvalidLimit));
+
+    let bad_positions = limits::set_account_limits(
+        &env, &admin, &alice,
+        0, limits::MAX_CAP + 1, 0,
+    );
+    assert_eq!(bad_positions, Err(errors::AdminLimitError::InvalidLimit));
+
+    let bad_subs = limits::set_account_limits(
+        &env, &admin, &alice,
+        0, 0, limits::MAX_CAP + 1,
+    );
+    assert_eq!(bad_subs, Err(errors::AdminLimitError::InvalidLimit));
+}
+
+/// `clear_account_limits` removes per-account override so `get_account_limits`
+/// falls back to the default.
+#[test]
+fn limits_clear_account_falls_back_to_default() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let alice = Address::generate(&env);
+    admin::init(&env, &admin);
+
+    // Set a per-account override then set a new global default.
+    limits::set_account_limits(&env, &admin, &alice, 1, 1, 1).unwrap();
+    limits::set_default_limits(&env, &admin, 11, 12, 13).unwrap();
+
+    // Per-account still shows the override.
+    assert_eq!(limits::get_account_limits(&env, &alice).max_bets, 1);
+
+    // Clear and verify fallback to global.
+    limits::clear_account_limits(&env, &admin, &alice).unwrap();
+    let caps = limits::get_account_limits(&env, &alice);
+    assert_eq!(caps.max_bets, 11);
+    assert_eq!(caps.max_positions, 12);
+    assert_eq!(caps.max_subscriptions, 13);
+}
+
+/// `clear_account_limits` emits an `account_limits_cleared` event.
+#[test]
+fn limits_clear_account_emits_event() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let alice = Address::generate(&env);
+    admin::init(&env, &admin);
+
+    limits::set_account_limits(&env, &admin, &alice, 1, 1, 1).unwrap();
+    limits::clear_account_limits(&env, &admin, &alice).unwrap();
+
+    let cleared = events_with_topic(&env, "account_limits_cleared");
+    assert_eq!(cleared.len(), 1);
+}
+
+// ===========================================================================
+// Per-account limits — consume operations
+// ===========================================================================
+
+/// `consume_bet` panics via `require_auth()` when the caller has not
+/// authorized. Uses `catch_unwind` matching the existing admin test pattern.
+#[test]
+fn limits_consume_bet_requires_account_auth() {
+    let env = Env::default();
+    let alice = Address::generate(&env);
+
+    let res = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        limits::consume_bet(&env, &alice);
+    }));
+    assert!(
+        res.is_err(),
+        "consume_bet must require auth and panic when caller does not authorize"
+    );
+}
+
+/// `consume_bet` succeeds when under cap.
+#[test]
+fn limits_consume_bet_succeeds_under_cap() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let alice = Address::generate(&env);
+    admin::init(&env, &admin);
+    limits::set_account_limits(&env, &admin, &alice, 3, 3, 3).unwrap();
+
+    // First two succeed.
+    assert_eq!(limits::consume_bet(&env, &alice), Ok(()));
+    assert_eq!(limits::consume_bet(&env, &alice), Ok(()));
+
+    let usage = limits::get_account_usage(&env, &alice);
+    assert_eq!(usage.bets, 2);
+}
+
+/// `consume_bet` emits `bet_consumed` event.
+#[test]
+fn limits_consume_bet_emits_event() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let alice = Address::generate(&env);
+    admin::init(&env, &admin);
+    limits::set_account_limits(&env, &admin, &alice, 3, 3, 3).unwrap();
+
+    limits::consume_bet(&env, &alice).unwrap();
+
+    let matches = events_with_topic(&env, "bet_consumed");
+    assert_eq!(matches.len(), 1);
+
+    let (topics, _data) = &matches[0];
+    assert_eq!(topics.len(), 2);
+    let topic1: Address = topics.get(1).unwrap().into_val(&env);
+    assert_eq!(topic1, alice);
+}
+
+/// `consume_bet` fails when at cap.
+#[test]
+fn limits_consume_bet_fails_at_cap() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let alice = Address::generate(&env);
+    admin::init(&env, &admin);
+    limits::set_account_limits(&env, &admin, &alice, 2, 3, 3).unwrap();
+
+    limits::consume_bet(&env, &alice).unwrap();
+    limits::consume_bet(&env, &alice).unwrap();
+    assert_eq!(
+        limits::consume_bet(&env, &alice),
+        Err(errors::AdminLimitError::BetsAtCap)
+    );
+
+    // No state change on failure.
+    let usage = limits::get_account_usage(&env, &alice);
+    assert_eq!(usage.bets, 2);
+}
+
+/// `consume_bet` fails when the account is fully disabled (cap 0).
+#[test]
+fn limits_consume_bet_fails_when_fully_disabled() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let alice = Address::generate(&env);
+    admin::init(&env, &admin);
+    limits::set_account_limits(&env, &admin, &alice, 0, 0, 0).unwrap();
+
+    assert_eq!(
+        limits::consume_bet(&env, &alice),
+        Err(errors::AdminLimitError::BetsAtCap)
+    );
+}
+
+/// `consume_position` succeeds under cap.
+#[test]
+fn limits_consume_position_succeeds_under_cap() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let alice = Address::generate(&env);
+    admin::init(&env, &admin);
+    limits::set_account_limits(&env, &admin, &alice, 3, 3, 3).unwrap();
+
+    limits::consume_position(&env, &alice).unwrap();
+    let usage = limits::get_account_usage(&env, &alice);
+    assert_eq!(usage.positions, 1);
+}
+
+/// `consume_position` fails at cap.
+#[test]
+fn limits_consume_position_fails_at_cap() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let alice = Address::generate(&env);
+    admin::init(&env, &admin);
+    limits::set_account_limits(&env, &admin, &alice, 3, 1, 3).unwrap();
+
+    limits::consume_position(&env, &alice).unwrap();
+    assert_eq!(
+        limits::consume_position(&env, &alice),
+        Err(errors::AdminLimitError::PositionsAtCap)
+    );
+}
+
+/// `consume_subscription` succeeds under cap and emits event.
+#[test]
+fn limits_consume_subscription_succeeds_and_emits() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let alice = Address::generate(&env);
+    admin::init(&env, &admin);
+    limits::set_account_limits(&env, &admin, &alice, 3, 3, 2).unwrap();
+
+    limits::consume_subscription(&env, &alice).unwrap();
+    let usage = limits::get_account_usage(&env, &alice);
+    assert_eq!(usage.subscriptions, 1);
+
+    let matches = events_with_topic(&env, "subscription_consumed");
+    assert_eq!(matches.len(), 1);
+}
+
+/// `consume_subscription` fails at cap.
+#[test]
+fn limits_consume_subscription_fails_at_cap() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let alice = Address::generate(&env);
+    admin::init(&env, &admin);
+    limits::set_account_limits(&env, &admin, &alice, 3, 3, 2).unwrap();
+
+    limits::consume_subscription(&env, &alice).unwrap();
+    limits::consume_subscription(&env, &alice).unwrap();
+    assert_eq!(
+        limits::consume_subscription(&env, &alice),
+        Err(errors::AdminLimitError::SubscriptionsAtCap)
+    );
+}
+
+// ===========================================================================
+// Per-account limits — release operations
+// ===========================================================================
+
+/// `release_bet` panics via `require_auth()` when the caller has not
+/// authorized. Uses `catch_unwind` matching the existing admin test pattern.
+#[test]
+fn limits_release_bet_requires_account_auth() {
+    let env = Env::default();
+    let alice = Address::generate(&env);
+
+    let res = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        limits::release_bet(&env, &alice);
+    }));
+    assert!(
+        res.is_err(),
+        "release_bet must require auth and panic when caller does not authorize"
+    );
+}
+
+/// `release_bet` decrements the counter and emits event.
+#[test]
+fn limits_release_bet_decrements_and_emits() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let alice = Address::generate(&env);
+    admin::init(&env, &admin);
+    limits::set_account_limits(&env, &admin, &alice, 5, 5, 5).unwrap();
+
+    limits::consume_bet(&env, &alice).unwrap();
+    limits::consume_bet(&env, &alice).unwrap();
+    limits::release_bet(&env, &alice).unwrap();
+
+    let usage = limits::get_account_usage(&env, &alice);
+    assert_eq!(usage.bets, 1);
+
+    let matches = events_with_topic(&env, "bet_released");
+    assert_eq!(matches.len(), 1);
+}
+
+/// `release_bet` fails when counter is zero.
+#[test]
+fn limits_release_bet_fails_on_underflow() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let alice = Address::generate(&env);
+
+    assert_eq!(
+        limits::release_bet(&env, &alice),
+        Err(errors::AdminLimitError::CounterUnderflow)
+    );
+}
+
+/// `release_position` decrements the counter.
+#[test]
+fn limits_release_position_decrements() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let alice = Address::generate(&env);
+    admin::init(&env, &admin);
+    limits::set_account_limits(&env, &admin, &alice, 5, 5, 5).unwrap();
+
+    limits::consume_position(&env, &alice).unwrap();
+    limits::consume_position(&env, &alice).unwrap();
+    limits::release_position(&env, &alice).unwrap();
+
+    let usage = limits::get_account_usage(&env, &alice);
+    assert_eq!(usage.positions, 1);
+}
+
+/// `release_position` fails on underflow.
+#[test]
+fn limits_release_position_fails_on_underflow() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let alice = Address::generate(&env);
+
+    assert_eq!(
+        limits::release_position(&env, &alice),
+        Err(errors::AdminLimitError::CounterUnderflow)
+    );
+}
+
+/// `release_subscription` decrements and emits.
+#[test]
+fn limits_release_subscription_decrements_and_emits() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let alice = Address::generate(&env);
+    admin::init(&env, &admin);
+    limits::set_account_limits(&env, &admin, &alice, 5, 5, 5).unwrap();
+
+    limits::consume_subscription(&env, &alice).unwrap();
+    limits::release_subscription(&env, &alice).unwrap();
+
+    let usage = limits::get_account_usage(&env, &alice);
+    assert_eq!(usage.subscriptions, 0);
+
+    let matches = events_with_topic(&env, "subscription_released");
+    assert_eq!(matches.len(), 1);
+}
+
+/// `release_subscription` fails on underflow.
+#[test]
+fn limits_release_subscription_fails_on_underflow() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let alice = Address::generate(&env);
+
+    assert_eq!(
+        limits::release_subscription(&env, &alice),
+        Err(errors::AdminLimitError::CounterUnderflow)
+    );
+}
+
+// ===========================================================================
+// Per-account limits — can_* dry-run checks
+// ===========================================================================
+
+/// `can_place_bet` returns `true` when under cap.
+#[test]
+fn limits_can_place_bet_returns_true_under_cap() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let alice = Address::generate(&env);
+    admin::init(&env, &admin);
+    limits::set_account_limits(&env, &admin, &alice, 2, 2, 2).unwrap();
+
+    assert!(limits::can_place_bet(&env, &alice));
+    limits::consume_bet(&env, &alice).unwrap();
+    assert!(limits::can_place_bet(&env, &alice));
+    limits::consume_bet(&env, &alice).unwrap();
+    assert!(!limits::can_place_bet(&env, &alice));
+}
+
+/// `can_open_position` returns `false` when at cap.
+#[test]
+fn limits_can_open_position_returns_false_at_cap() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let alice = Address::generate(&env);
+    admin::init(&env, &admin);
+    limits::set_account_limits(&env, &admin, &alice, 2, 1, 2).unwrap();
+
+    limits::consume_position(&env, &alice).unwrap();
+    assert!(!limits::can_open_position(&env, &alice));
+}
+
+/// `can_subscribe` returns `false` when at cap.
+#[test]
+fn limits_can_subscribe_returns_false_at_cap() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let alice = Address::generate(&env);
+    admin::init(&env, &admin);
+    limits::set_account_limits(&env, &admin, &alice, 2, 2, 1).unwrap();
+
+    limits::consume_subscription(&env, &alice).unwrap();
+    assert!(!limits::can_subscribe(&env, &alice));
+}
+
+/// `can_*` checks don't require auth or admin init.
+#[test]
+fn limits_can_checks_no_auth_required() {
+    let env = Env::default();
+    let alice = Address::generate(&env);
+
+    assert!(limits::can_place_bet(&env, &alice));
+    assert!(limits::can_open_position(&env, &alice));
+    assert!(limits::can_subscribe(&env, &alice));
+}
+
+// ===========================================================================
+// Per-account limits — isolated accounts
+// ===========================================================================
+
+/// Multiple accounts have independent counters.
+#[test]
+fn limits_accounts_are_independent() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let alice = Address::generate(&env);
+    let bob = Address::generate(&env);
+    admin::init(&env, &admin);
+    limits::set_account_limits(&env, &admin, &alice, 2, 2, 2).unwrap();
+    limits::set_account_limits(&env, &admin, &bob, 4, 4, 4).unwrap();
+
+    limits::consume_bet(&env, &alice).unwrap();
+    limits::consume_bet(&env, &bob).unwrap();
+    limits::consume_bet(&env, &bob).unwrap();
+
+    let alice_usage = limits::get_account_usage(&env, &alice);
+    let bob_usage = limits::get_account_usage(&env, &bob);
+    assert_eq!(alice_usage.bets, 1);
+    assert_eq!(bob_usage.bets, 2);
+
+    // Bob still has room, alice only has one more slot.
+    assert!(limits::can_place_bet(&env, &alice));
+    assert!(limits::can_place_bet(&env, &bob));
+    limits::consume_bet(&env, &bob).unwrap();
+    assert!(limits::can_place_bet(&env, &bob));
+}
+
+/// Setting limits after usage has accumulated correctly enforces new caps.
+#[test]
+fn limits_set_after_usage_enforces_new_caps() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let alice = Address::generate(&env);
+    admin::init(&env, &admin);
+
+    // Let alice accumulate under generous caps.
+    limits::set_account_limits(&env, &admin, &alice, 10, 10, 10).unwrap();
+    limits::consume_bet(&env, &alice).unwrap();
+    limits::consume_bet(&env, &alice).unwrap();
+    limits::consume_bet(&env, &alice).unwrap();
+
+    // Tighten the cap below current usage.
+    limits::set_account_limits(&env, &admin, &alice, 1, 10, 10).unwrap();
+
+    // alice already has 3 bets > new cap of 1 — next consume must fail.
+    assert_eq!(
+        limits::consume_bet(&env, &alice),
+        Err(errors::AdminLimitError::BetsAtCap)
+    );
+}
+
+// ===========================================================================
+// Per-account limits — default caps fallback
+// ===========================================================================
+
+/// When no per-account caps are set, accounts use the global default.
+#[test]
+fn limits_falls_back_to_default_when_no_override() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let alice = Address::generate(&env);
+    admin::init(&env, &admin);
+
+    // Set a non-trivial global default.
+    limits::set_default_limits(&env, &admin, 3, 3, 3).unwrap();
+
+    // Consume up to the default cap.
+    limits::consume_bet(&env, &alice).unwrap();
+    limits::consume_bet(&env, &alice).unwrap();
+    limits::consume_bet(&env, &alice).unwrap();
+
+    assert_eq!(
+        limits::consume_bet(&env, &alice),
+        Err(errors::AdminLimitError::BetsAtCap)
+    );
+}
+
+/// Changing the global default doesn't affect accounts with explicit overrides.
+#[test]
+fn limits_default_change_does_not_affect_overrides() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let alice = Address::generate(&env);
+    admin::init(&env, &admin);
+
+    limits::set_account_limits(&env, &admin, &alice, 5, 5, 5).unwrap();
+    limits::set_default_limits(&env, &admin, 1, 1, 1).unwrap();
+
+    // alice should still have her override of 5.
+    let caps = limits::get_account_limits(&env, &alice);
+    assert_eq!(caps.max_bets, 5);
+}
+
+// ===========================================================================
+// Per-account limits — consume → release → consume cycle
+// ===========================================================================
+
+/// A full consume/release cycle returns to zero and allows re-consumption.
+#[test]
+fn limits_consume_release_cycle() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let alice = Address::generate(&env);
+    admin::init(&env, &admin);
+    limits::set_account_limits(&env, &admin, &alice, 3, 3, 3).unwrap();
+
+    limits::consume_bet(&env, &alice).unwrap();
+    limits::consume_bet(&env, &alice).unwrap();
+    limits::consume_bet(&env, &alice).unwrap();
+    assert_eq!(
+        limits::consume_bet(&env, &alice),
+        Err(errors::AdminLimitError::BetsAtCap)
+    );
+
+    limits::release_bet(&env, &alice).unwrap();
+    limits::release_bet(&env, &alice).unwrap();
+
+    // Now we can consume again.
+    assert!(limits::can_place_bet(&env, &alice));
+    limits::consume_bet(&env, &alice).unwrap();
+    limits::consume_bet(&env, &alice).unwrap();
+    assert_eq!(
+        limits::consume_bet(&env, &alice),
+        Err(errors::AdminLimitError::BetsAtCap)
+    );
+}
+
+/// `AccountLimits::uniform` constructor simplifies test setup.
+#[test]
+fn limits_account_limits_uniform_constructor() {
+    let caps = limits::AccountLimits::uniform(7);
+    assert_eq!(caps.max_bets, 7);
+    assert_eq!(caps.max_positions, 7);
+    assert_eq!(caps.max_subscriptions, 7);
+}


### PR DESCRIPTION
## Summary

Implements per-account state caps on admin (bets, positions, subscriptions) to prevent abuse. Closes #862.

## Changes

### New: `contracts/admin/src/errors.rs`
- `AdminLimitError` contracterror with 8 stable numeric codes (NotInitialized, Unauthorized, InvalidLimit, BetsAtCap, PositionsAtCap, SubscriptionsAtCap, CounterUnderflow, Overflow)

### Updated: `contracts/admin/src/events.rs`
- Added 9 limit-related event topic constructors with snapshot tests

### Rewritten: `contracts/admin/src/limits.rs`
- No `panic!()` / `unwrap()` in production paths -- all errors return typed `AdminLimitError` variants
- Overflow-safe math via `checked_add`/`checked_sub` on every counter mutation
- **Release ops**: `release_bet`, `release_position`, `release_subscription` (decrement counters)
- **Default global caps**: `DEFAULT_LIMITS` + `set_default_limits`/`get_default_limits`
- **Per-account overrides**: `set_account_limits`, `clear_account_limits` with fallback to defaults
- **`can_*` dry-run checks**: `can_place_bet`, `can_open_position`, `can_subscribe` (no auth required)
- **TTL management**: bump thresholds/amounts on every read/write
- **NatSpec-style rustdoc** on all public functions and structs
- **Admin-gated auth**: `require_auth()` on all state-changing entrypoints

### Updated: `contracts/admin/src/lib.rs`
- Added `pub mod errors;`

### Updated: `contracts/admin/src/test.rs`
- 30+ new tests: auth enforcement, view behavior, caps persistence, consume/release cycles, cap limits, `can_*` checks, isolated accounts, default fallback, consume-release-consume round-trips
