### PR TITLE
feat(distribute): add pause/resume mechanism for batch operations

### DIFF
--- a/contracts/distribute/src/lib.rs
+++ b/contracts/distribute/src/lib.rs
@@ -22,6 +22,7 @@
 pub mod errors;
 pub mod events;
 pub mod limits;
+pub mod pause;
 
 use soroban_sdk::{contract, contractimpl, contracttype, Address, BytesN, Env, Symbol, Vec};
 
@@ -126,11 +127,10 @@ impl CalloraDistribute {
     }
 
     /// Return `true` if the contract is currently paused.
+    ///
+    /// Delegates to [`pause::is_paused`] for the actual storage read.
     pub fn is_paused(env: Env) -> bool {
-        env.storage()
-            .instance()
-            .get::<_, bool>(&StorageKey::Paused)
-            .unwrap_or(false)
+        pause::is_paused(&env)
     }
 
     /// Return the pending admin address, or `None` if no transfer is in progress.
@@ -339,14 +339,16 @@ impl CalloraDistribute {
 
     /// Pause the contract, blocking `open`, `close`, `batch_open`, `batch_close`.
     ///
+    /// Delegates storage write to [`pause::pause`].
+    ///
     /// Admin only.
     pub fn pause(env: Env, caller: Address) -> Result<(), DistributeError> {
         caller.require_auth();
         Self::require_admin(&env, &caller)?;
-        if Self::is_paused(env.clone()) {
+        if pause::is_paused(&env) {
             return Err(DistributeError::Paused);
         }
-        env.storage().instance().set(&StorageKey::Paused, &true);
+        pause::pause(&env, &caller);
         env.events()
             .publish((events::event_paused(&env), caller), ());
         Ok(())
@@ -354,14 +356,16 @@ impl CalloraDistribute {
 
     /// Unpause the contract, restoring `open` / `close` operations.
     ///
+    /// Delegates storage write to [`pause::resume`].
+    ///
     /// Admin only.
     pub fn unpause(env: Env, caller: Address) -> Result<(), DistributeError> {
         caller.require_auth();
         Self::require_admin(&env, &caller)?;
-        if !Self::is_paused(env.clone()) {
+        if !pause::is_paused(&env) {
             return Err(DistributeError::Paused);
         }
-        env.storage().instance().set(&StorageKey::Paused, &false);
+        pause::resume(&env, &caller);
         env.events()
             .publish((events::event_unpaused(&env), caller), ());
         Ok(())
@@ -492,12 +496,7 @@ impl CalloraDistribute {
     }
 
     fn require_not_paused(env: &Env) -> Result<(), DistributeError> {
-        if env
-            .storage()
-            .instance()
-            .get::<_, bool>(&StorageKey::Paused)
-            .unwrap_or(false)
-        {
+        if pause::is_paused(env) {
             return Err(DistributeError::Paused);
         }
         Ok(())

--- a/contracts/distribute/src/pause.rs
+++ b/contracts/distribute/src/pause.rs
@@ -1,51 +1,74 @@
 //! Administrative pause control for distribution entrypoints.
 //!
-//! The pause flag is stored in instance storage. State-changing pause controls
-//! require authorization from the supplied caller and verify that caller is
-//! the configured contract administrator. Read-only inspection does not require
-//! authorization.
+//! The pause flag is stored in instance storage using the contract's canonical
+//! [`StorageKey::Paused`](crate::limits::StorageKey::Paused). State-changing
+//! pause controls require authorization from the supplied caller and verify
+//! that caller is the configured contract administrator. Read-only inspection
+//! does not require authorization.
+//!
+//! # Integration
+//!
+//! This module is re-exported as `pub mod pause` in the crate root and may be
+//! used by contract methods or by external consumers who need low-level pause
+//! access without going through the full [`CalloraDistribute`] contract API.
 
-use soroban_sdk::{symbol_short, Address, Env};
+use soroban_sdk::{Address, Env};
 
-const ADMIN_KEY: soroban_sdk::Symbol = symbol_short!("admin");
-const PAUSED_KEY: soroban_sdk::Symbol = symbol_short!("paused");
+use crate::limits::StorageKey;
 
 /// Pauses distribution state changes.
 ///
 /// The caller must authenticate and must equal the administrator stored during
-/// contract initialization. Calling this function more than once is harmless.
+/// contract initialization. Calling this function more than once is harmless
+/// (idempotent — the flag remains `true`).
+///
+/// # Panics
+/// - If the caller has not authorized the invocation (`require_auth`).
+/// - If the caller is not the configured admin (`"unauthorized"`).
+/// - If the contract has not been initialized (`"contract is not initialized"`).
 pub fn pause(env: &Env, caller: &Address) {
     caller.require_auth();
     require_admin(env, caller);
-    env.storage().instance().set(&PAUSED_KEY, &true);
+    env.storage().instance().set(&StorageKey::Paused, &true);
 }
 
 /// Resumes distribution state changes.
 ///
 /// The caller must authenticate and must equal the configured administrator.
-/// Calling this function while the contract is already active is harmless.
+/// Calling this function while the contract is already active is harmless
+/// (idempotent — the flag remains `false`).
+///
+/// # Panics
+/// - If the caller has not authorized the invocation.
+/// - If the caller is not the configured admin (`"unauthorized"`).
+/// - If the contract has not been initialized.
 pub fn resume(env: &Env, caller: &Address) {
     caller.require_auth();
     require_admin(env, caller);
-    env.storage().instance().set(&PAUSED_KEY, &false);
+    env.storage().instance().set(&StorageKey::Paused, &false);
 }
 
 /// Returns whether distribution state changes are currently paused.
 ///
 /// This view does not require authorization and remains available while the
-/// contract is paused.
+/// contract is paused. Returns `false` if the flag has never been set (i.e.
+/// before `init` or in the default unpaused state).
 pub fn is_paused(env: &Env) -> bool {
     env.storage()
         .instance()
-        .get(&PAUSED_KEY)
+        .get(&StorageKey::Paused)
         .unwrap_or(false)
 }
 
 /// Rejects a state-changing distribution operation while paused.
 ///
-/// `batch_distribute` must invoke this guard before performing any transfer or
-/// other persistent state mutation. The guard performs no authorization check;
-/// authorization remains the responsibility of the distribution entrypoint.
+/// `batch_open`, `batch_close`, and individual `open`/`close` must invoke this
+/// guard before performing any persistent state mutation. The guard performs
+/// no authorization check; authorization remains the responsibility of the
+/// calling entrypoint.
+///
+/// # Panics
+/// - `"contract is paused"` — the circuit breaker is active.
 pub fn require_not_paused(env: &Env) {
     if is_paused(env) {
         panic!("contract is paused");
@@ -56,7 +79,7 @@ fn require_admin(env: &Env, caller: &Address) {
     let admin = env
         .storage()
         .instance()
-        .get::<_, Address>(&ADMIN_KEY)
+        .get::<_, Address>(&StorageKey::Admin)
         .unwrap_or_else(|| panic!("contract is not initialized"));
 
     if admin != *caller {
@@ -73,7 +96,7 @@ mod tests {
 
     fn setup(env: &Env) -> Address {
         let admin = Address::generate(env);
-        env.storage().instance().set(&ADMIN_KEY, &admin);
+        env.storage().instance().set(&StorageKey::Admin, &admin);
         admin
     }
 
@@ -135,4 +158,52 @@ mod tests {
         resume(&env, &admin);
         assert!(std::panic::catch_unwind(|| require_not_paused(&env)).is_ok());
     }
+
+    /// Verify that the pause module uses the same storage key as the contract's
+    /// `CalloraDistribute` implementation. This test writes via the module and
+    /// confirms `StorageKey::Paused` is set (the contract reads from this key).
+    #[test]
+    fn uses_same_storage_key_as_contract() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let admin = setup(&env);
+
+        pause(&env, &admin);
+        // Read via StorageKey::Paused — the key the contract methods use.
+        let from_contract_key: bool = env
+            .storage()
+            .instance()
+            .get(&StorageKey::Paused)
+            .unwrap_or(false);
+        assert!(from_contract_key, "pause.rs must write to StorageKey::Paused");
+
+        // Read via the module's own is_paused helper.
+        assert!(is_paused(&env));
+    }
+
+    /// Verify idempotent pause: calling pause when already paused does not panic.
+    #[test]
+    fn double_pause_is_idempotent() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let admin = setup(&env);
+
+        pause(&env, &admin);
+        // Second pause should not panic (idempotent).
+        assert!(std::panic::catch_unwind(|| pause(&env, &admin)).is_ok());
+        assert!(is_paused(&env));
+    }
+
+    /// Verify idempotent resume: calling resume when not paused does not panic.
+    #[test]
+    fn double_resume_is_idempotent() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let admin = setup(&env);
+
+        // First resume when unpaused — should be harmless.
+        assert!(std::panic::catch_unwind(|| resume(&env, &admin)).is_ok());
+        assert!(!is_paused(&env));
+    }
 }
+

--- a/contracts/distribute/src/test.rs
+++ b/contracts/distribute/src/test.rs
@@ -897,3 +897,162 @@ fn open_close_cycle_multiple_accounts_batch() {
     assert_eq!(client.get_account_count(&a), 0);
     assert_eq!(client.get_account_count(&b), 0);
 }
+
+// ===========================================================================
+// Pause/Resume — focused lifecycle tests for batch operations
+// ===========================================================================
+
+/// Pause blocks batch_open; unpause restores it.
+#[test]
+fn batch_open_blocked_while_paused_unpause_restores() {
+    let env = Env::default();
+    let (admin, client) = setup(&env);
+    let account = Address::generate(&env);
+    let cat = Symbol::new(&env, "bet");
+
+    // Initially works
+    let items = Vec::from_array(
+        &env,
+        [BatchItem {
+            account: account.clone(),
+            category: cat.clone(),
+        }],
+    );
+    client.batch_open(&admin, &items);
+    assert_eq!(client.get_account_count(&account), 1);
+
+    // Pause -> blocked
+    client.pause(&admin);
+    let items2 = Vec::from_array(
+        &env,
+        [BatchItem {
+            account: account.clone(),
+            category: cat.clone(),
+        }],
+    );
+    let err = client.try_batch_open(&admin, &items2).unwrap_err();
+    assert_eq!(err, Ok(DistributeError::Paused));
+    assert_eq!(client.get_account_count(&account), 1, "count unchanged while paused");
+
+    // Unpause -> restored
+    client.unpause(&admin);
+    let items3 = Vec::from_array(
+        &env,
+        [BatchItem {
+            account: account.clone(),
+            category: cat.clone(),
+        }],
+    );
+    client.batch_open(&admin, &items3);
+    assert_eq!(client.get_account_count(&account), 2);
+}
+
+/// Pause blocks batch_close; unpause restores it.
+#[test]
+fn batch_close_blocked_while_paused_unpause_restores() {
+    let env = Env::default();
+    let (admin, client) = setup(&env);
+    let account = Address::generate(&env);
+    let cat = Symbol::new(&env, "bet");
+
+    let items = Vec::from_array(
+        &env,
+        [BatchItem {
+            account: account.clone(),
+            category: cat.clone(),
+        }],
+    );
+    client.batch_open(&admin, &items);
+    assert_eq!(client.get_account_count(&account), 1);
+
+    // Pause -> blocked
+    client.pause(&admin);
+    let close_items = Vec::from_array(
+        &env,
+        [BatchItem {
+            account: account.clone(),
+            category: cat.clone(),
+        }],
+    );
+    let err = client.try_batch_close(&admin, &close_items).unwrap_err();
+    assert_eq!(err, Ok(DistributeError::Paused));
+    assert_eq!(client.get_account_count(&account), 1, "count unchanged while paused");
+
+    // Unpause -> restored
+    client.unpause(&admin);
+    client.batch_close(&admin, &close_items);
+    assert_eq!(client.get_account_count(&account), 0);
+}
+
+/// Admin-set_global_cap remains available while paused (admin config functions).
+#[test]
+fn admin_config_available_while_paused() {
+    let env = Env::default();
+    let (admin, client) = setup(&env);
+
+    client.pause(&admin);
+    assert!(client.is_paused());
+
+    // Admin config should work
+    client.set_global_cap(&admin, &20);
+    assert_eq!(client.get_global_cap(), 20);
+}
+
+/// Pause → unpause → pause cycle works correctly.
+#[test]
+fn multiple_pause_unpause_cycles() {
+    let env = Env::default();
+    let (admin, client) = setup(&env);
+    let account = Address::generate(&env);
+    let cat = Symbol::new(&env, "bet");
+
+    // Cycle 1
+    client.pause(&admin);
+    assert!(client.is_paused());
+    client.unpause(&admin);
+    assert!(!client.is_paused());
+
+    // batch_open works after cycle 1
+    let items = Vec::from_array(
+        &env,
+        [BatchItem {
+            account: account.clone(),
+            category: cat.clone(),
+        }],
+    );
+    client.batch_open(&admin, &items);
+    assert_eq!(client.get_account_count(&account), 1);
+
+    // Cycle 2
+    client.pause(&admin);
+    assert!(client.is_paused());
+    let err = client.try_batch_open(&admin, &items).unwrap_err();
+    assert_eq!(err, Ok(DistributeError::Paused));
+
+    client.unpause(&admin);
+    assert!(!client.is_paused());
+    client.batch_open(&admin, &items);
+    assert_eq!(client.get_account_count(&account), 2);
+}
+
+/// Read-only views remain accessible while paused.
+#[test]
+fn reads_work_while_paused() {
+    let env = Env::default();
+    let (admin, client) = setup(&env);
+    let account = Address::generate(&env);
+    let cat = Symbol::new(&env, "bet");
+
+    client.open(&admin, &account, &cat);
+    client.open(&admin, &account, &cat);
+
+    client.pause(&admin);
+    assert!(client.is_paused());
+
+    // All reads must work while paused
+    assert_eq!(client.get_account_count(&account), 2);
+    assert_eq!(client.get_account_category_count(&account, &cat), 2);
+    assert_eq!(client.get_global_cap(), 10);
+    assert!(client.is_paused());
+    assert_eq!(client.get_admin(), admin);
+}


### PR DESCRIPTION
## Summary

Integrates the standalone `pause.rs` module into the `CalloraDistribute` contract and adds a comprehensive pause/resume lifecycle for batch operations (`batch_open` / `batch_close`).

### Changes

- **`contracts/distribute/src/pause.rs`**: Fixed storage keys to use canonical `StorageKey::Paused` and `StorageKey::Admin` from `limits.rs` instead of raw `symbol_short!` symbols, ensuring consistency with the rest of the contract. Added unit tests for idempotency and storage-key alignment.

- **`contracts/distribute/src/lib.rs`**:
  - Added `pub mod pause;` declaration to include the module
  - Refactored `is_paused()` to delegate to `pause::is_paused()`
  - Refactored `pause()` / `unpause()` to delegate storage writes to `pause::pause()` / `pause::resume()` while retaining their own auth checks, pre-validation, and event emission
  - Refactored `require_not_paused()` to use `pause::is_paused()`

- **`contracts/distribute/src/test.rs`**: Added 5 focused lifecycle tests:
  - `batch_open_blocked_while_paused_unpause_restores`
  - `batch_close_blocked_while_paused_unpause_restores`
  - `admin_config_available_while_paused`
  - `multiple_pause_unpause_cycles`
  - `reads_work_while_paused`

### Design

The `pause` module provides low-level helper functions (`pause`, `resume`, `is_paused`, `require_not_paused`) that handle storage reads/writes. The contract methods (`pause()`, `unpause()`) retain responsibility for authentication, pre-validation, and event emission, delegating only the storage operation to the module.

Closes #861