### PR TITLE
Emit structured events for vault admin transfer

### DIFF
--- a/contracts/vault/src/lib.rs
+++ b/contracts/vault/src/lib.rs
@@ -1037,6 +1037,8 @@ impl CalloraVault {
             .instance()
             .set(&StorageKey::PendingAdmin, &new_admin);
         Self::bump_instance_ttl(&env);
+        env.events()
+            .publish((events::event_admin_nominated(&env), caller), new_admin);
         Ok(())
     }
 
@@ -1050,6 +1052,8 @@ impl CalloraVault {
         new_admin.require_auth();
         env.storage().instance().set(&StorageKey::Admin, &new_admin);
         env.storage().instance().remove(&StorageKey::PendingAdmin);
+        env.events()
+            .publish((events::event_admin_accepted(&env), new_admin), ());
         Ok(())
     }
 


### PR DESCRIPTION
- #652: Vault admin nomination (`set_admin`) and acceptance (`accept_admin`) now emit `admin_nominated` / `admin_accepted` structured events, using the event symbol constructors already defined in `events.rs` (previously unused). This mirrors the existing `transfer_ownership` / `accept_ownership` event pattern in the same file.

Closes #652

Manual verification: traced both call paths by reading the code. `events::event_admin_nominated` / `event_admin_accepted` were already defined in `contracts/vault/src/events.rs` but never invoked anywhere in `lib.rs`. The new `env.events().publish(...)` calls in `set_admin` and `accept_admin` follow the exact same shape (topic + subject address, unit/value data) as the working `transfer_ownership` / `accept_ownership` pair directly above them in the file. The repo's existing test suite (`test.rs`) does not compile against the current contract API independent of this change (e.g. mismatched `init` arg counts, calls to a nonexistent `cancel_admin_transfer`), so it was not run; this change was verified by manual code review only.