### PR TITLE
Add per-entrypoint auth snapshot tests for views

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -259,6 +259,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "callora-admin"
+version = "0.0.0"
+dependencies = [
+ "soroban-sdk",
+]
+
+[[package]]
 name = "callora-checkpoint"
 version = "0.1.0"
 dependencies = [
@@ -301,7 +308,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "callora-fee"
+name = "callora-emergency"
 version = "0.1.0"
 dependencies = [
  "soroban-sdk",
@@ -324,6 +331,15 @@ name = "callora-hot"
 version = "0.1.0"
 dependencies = [
  "criterion",
+ "soroban-sdk",
+]
+
+[[package]]
+name = "callora-limits"
+version = "0.0.1"
+dependencies = [
+ "callora-revenue-pool",
+ "callora-settlement",
  "soroban-sdk",
 ]
 
@@ -378,6 +394,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "callora-stake"
+version = "0.1.0"
+dependencies = [
+ "soroban-sdk",
+]
+
+[[package]]
 name = "callora-upgrade"
 version = "0.0.0"
 dependencies = [
@@ -393,9 +416,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "callora-vault"
+version = "0.0.1"
+dependencies = [
+ "callora-revenue-pool",
+ "callora-settlement",
+ "callora-validators",
+ "rand 0.8.7",
+ "soroban-sdk",
+]
+
+[[package]]
 name = "callora-whitelist"
 version = "0.1.0"
 dependencies = [
+ "callora-vault",
+ "criterion",
  "soroban-sdk",
 ]
 
@@ -875,6 +911,7 @@ dependencies = [
 name = "errors"
 version = "0.1.0"
 dependencies = [
+ "proptest",
  "soroban-sdk",
 ]
 

--- a/contracts/cold/docs/storage.md
+++ b/contracts/cold/docs/storage.md
@@ -1,0 +1,30 @@
+# Cold Contract Storage Documentation
+
+This document outlines the storage keys used by the Cold storage feature, their storage tiers (Instance, Persistent, or Temporary), and the rationale behind each choice in accordance with Soroban best practices.
+
+Cold accounting is implemented in `contracts/vault/src/cold_storage.rs` as an accounting partition of the vault's tracked balance. The data types defined there serve as the storage schema for the hot/cold split, auto-rebalance, and multisig cold-sweep features.
+
+## Storage Tiers Overview
+
+- **Instance Storage**: Stored in the contract instance ledger entry. Automatically extended when the contract instance is invoked. Ideal for small, frequently accessed configuration data and global contract state.
+- **Persistent Storage**: Stored as independent ledger entries with their own Time-To-Live (TTL). Ideal for user-specific or data-heavy entries that require explicit TTL management.
+- **Temporary Storage**: Short-lived entries intended for transient data (e.g., reentrancy guards, short-lived scratchpads).
+
+---
+
+## Storage Keys
+
+### 1. `ColdConfig`
+- **Tier**: **Instance**
+- **Data Type**: `ColdConfig { hot_bps: u32, rebalance_threshold_bps: u32, cold_signers: Vec<Address>, cold_threshold: u32 }`
+- **Rationale**: The hot/cold split configuration is a singleton that governs all cold-storage behavior for the vault. It is read on every deposit (to evaluate rebalance) and on every cold-sweep proposal/approval. Because it is a global singleton with a lifetime matching the contract instance, instance storage is appropriate. It shares the contract instance TTL, avoiding the need for separate TTL management.
+
+### 2. `ColdBalances`
+- **Tier**: **Instance**
+- **Data Type**: `ColdBalances { hot: i128, cold: i128 }`
+- **Rationale**: The current hot/cold balance partition is the core accounting state of the cold feature. It is read and written on every deposit (potential rebalance) and on every cold-sweep execution. As a singleton balance record that must remain consistent with the vault's total tracked balance (`VaultMeta.balance`), instance storage ensures it shares the contract's lifecycle and is always available when the contract is invoked.
+
+### 3. `PendingColdSweep`
+- **Tier**: **Instance**
+- **Data Type**: `PendingColdSweep { amount: i128, destination: Address, approvals: Vec<Address>, proposed_at: u64 }`
+- **Rationale**: A pending multisig cold-sweep request. At most one sweep can be pending at a time per vault. It exists from the moment a cold signer proposes a sweep until the threshold is met and the sweep executes (or is cancelled). Instance storage is appropriate because this is a singleton temporary state tied to the vault's lifecycle; the entry is explicitly cleared after execution, so there is no long-term accumulation.

--- a/contracts/cold/tests/auth_snap.rs
+++ b/contracts/cold/tests/auth_snap.rs
@@ -1,0 +1,37 @@
+#![cfg(test)]
+
+extern crate std;
+
+use callora_cold::{CalloraCold, CalloraColdClient, ALL_CAPABILITIES};
+use soroban_sdk::Env;
+
+fn create_contract(env: &Env) -> CalloraColdClient<'_> {
+    let contract_id = env.register(CalloraCold, ());
+    CalloraColdClient::new(env, &contract_id)
+}
+
+#[test]
+fn capabilities_does_not_require_auth() {
+    let env = Env::default();
+    let client = create_contract(&env);
+
+    env.set_auths(&[]);
+    let caps = client.capabilities();
+    assert_eq!(caps, ALL_CAPABILITIES);
+}
+
+#[test]
+fn capabilities_returns_nonzero() {
+    let env = Env::default();
+    let client = create_contract(&env);
+
+    assert_ne!(client.capabilities(), 0);
+}
+
+#[test]
+fn capabilities_equals_all_capabilities_constant() {
+    let env = Env::default();
+    let client = create_contract(&env);
+
+    assert_eq!(client.capabilities(), ALL_CAPABILITIES);
+}

--- a/contracts/distribute/tests/auth_snap.rs
+++ b/contracts/distribute/tests/auth_snap.rs
@@ -1,0 +1,230 @@
+#![cfg(test)]
+
+extern crate std;
+
+use callora_distribute::{
+    CalloraDistribute, CalloraDistributeClient, DistributeError, BatchItem,
+};
+use soroban_sdk::testutils::Address as _;
+use soroban_sdk::{Address, BytesN, Env, Symbol, Vec};
+
+fn create_contract(env: &Env) -> CalloraDistributeClient<'_> {
+    let contract_id = env.register(CalloraDistribute, ());
+    CalloraDistributeClient::new(env, &contract_id)
+}
+
+fn setup(env: &Env) -> (Address, CalloraDistributeClient<'_>) {
+    env.mock_all_auths();
+    let admin = Address::generate(env);
+    let client = create_contract(env);
+    client.init(&admin, &10);
+    (admin, client)
+}
+
+#[test]
+fn init_requires_auth() {
+    let env = Env::default();
+    let admin = Address::generate(&env);
+    let client = create_contract(&env);
+
+    env.set_auths(&[]);
+    let res = client.try_init(&admin, &10);
+    assert!(res.is_err(), "init must require auth");
+}
+
+#[test]
+fn set_global_cap_requires_auth() {
+    let env = Env::default();
+    let (admin, client) = setup(&env);
+
+    env.set_auths(&[]);
+    let res = client.try_set_global_cap(&admin, &20);
+    assert!(res.is_err(), "set_global_cap must require auth");
+}
+
+#[test]
+fn open_requires_auth() {
+    let env = Env::default();
+    let (admin, client) = setup(&env);
+
+    env.set_auths(&[]);
+    let account = Address::generate(&env);
+    let res = client.try_open(&admin, &account, &Symbol::new(&env, "test"));
+    assert!(res.is_err(), "open must require auth");
+}
+
+#[test]
+fn close_requires_auth() {
+    let env = Env::default();
+    let (admin, client) = setup(&env);
+
+    env.mock_all_auths();
+    let account = Address::generate(&env);
+    let cat = Symbol::new(&env, "test");
+    client.open(&admin, &account, &cat);
+
+    env.set_auths(&[]);
+    let res = client.try_close(&admin, &account, &cat);
+    assert!(res.is_err(), "close must require auth");
+}
+
+#[test]
+fn set_admin_requires_auth() {
+    let env = Env::default();
+    let (admin, client) = setup(&env);
+
+    env.set_auths(&[]);
+    let new_admin = Address::generate(&env);
+    let res = client.try_set_admin(&admin, &new_admin);
+    assert!(res.is_err(), "set_admin must require auth");
+}
+
+#[test]
+fn accept_admin_requires_auth() {
+    let env = Env::default();
+    let (admin, client) = setup(&env);
+
+    env.mock_all_auths();
+    let new_admin = Address::generate(&env);
+    client.set_admin(&admin, &new_admin);
+
+    env.set_auths(&[]);
+    let res = client.try_accept_admin();
+    assert!(res.is_err(), "accept_admin must require auth");
+}
+
+#[test]
+fn cancel_admin_transfer_requires_auth() {
+    let env = Env::default();
+    let (admin, client) = setup(&env);
+
+    env.mock_all_auths();
+    let new_admin = Address::generate(&env);
+    client.set_admin(&admin, &new_admin);
+
+    env.set_auths(&[]);
+    let res = client.try_cancel_admin_transfer(&admin);
+    assert!(res.is_err(), "cancel_admin_transfer must require auth");
+}
+
+#[test]
+fn pause_requires_auth() {
+    let env = Env::default();
+    let (admin, client) = setup(&env);
+
+    env.set_auths(&[]);
+    let res = client.try_pause(&admin);
+    assert!(res.is_err(), "pause must require auth");
+}
+
+#[test]
+fn unpause_requires_auth() {
+    let env = Env::default();
+    let (admin, client) = setup(&env);
+
+    env.mock_all_auths();
+    client.pause(&admin);
+
+    env.set_auths(&[]);
+    let res = client.try_unpause(&admin);
+    assert!(res.is_err(), "unpause must require auth");
+}
+
+#[test]
+fn upgrade_requires_auth() {
+    let env = Env::default();
+    let (admin, client) = setup(&env);
+
+    env.set_auths(&[]);
+    let dummy = BytesN::from_array(&env, &[0u8; 32]);
+    let res = client.try_upgrade(&admin, &dummy);
+    assert!(res.is_err(), "upgrade must require auth");
+}
+
+#[test]
+fn broadcast_requires_auth() {
+    let env = Env::default();
+    let (admin, client) = setup(&env);
+
+    env.set_auths(&[]);
+    let msg = soroban_sdk::String::from_str(&env, "test");
+    let res = client.try_broadcast(
+        &admin,
+        &callora_distribute::Severity::Info,
+        &msg,
+    );
+    assert!(res.is_err(), "broadcast must require auth");
+}
+
+#[test]
+fn get_admin_does_not_require_auth() {
+    let env = Env::default();
+    let (admin, client) = setup(&env);
+
+    env.set_auths(&[]);
+    assert_eq!(client.get_admin().unwrap(), admin);
+}
+
+#[test]
+fn get_global_cap_does_not_require_auth() {
+    let env = Env::default();
+    let (_admin, client) = setup(&env);
+
+    env.set_auths(&[]);
+    assert_eq!(client.get_global_cap(), 10);
+}
+
+#[test]
+fn is_paused_does_not_require_auth() {
+    let env = Env::default();
+    let (_admin, client) = setup(&env);
+
+    env.set_auths(&[]);
+    assert!(!client.is_paused());
+}
+
+#[test]
+fn get_pending_admin_does_not_require_auth() {
+    let env = Env::default();
+    let (_admin, client) = setup(&env);
+
+    env.set_auths(&[]);
+    assert_eq!(client.get_pending_admin(), None);
+}
+
+#[test]
+fn get_version_does_not_require_auth() {
+    let env = Env::default();
+    let (_admin, client) = setup(&env);
+
+    env.set_auths(&[]);
+    assert_eq!(client.get_version(), None);
+}
+
+#[test]
+fn admin_with_auth_can_call_all_entrypoints() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let client = create_contract(&env);
+    client.init(&admin, &10);
+
+    assert_eq!(client.get_global_cap(), 10);
+
+    client.set_global_cap(&admin, &20);
+    assert_eq!(client.get_global_cap(), 20);
+
+    let account = Address::generate(&env);
+    let cat = Symbol::new(&env, "test");
+    client.open(&admin, &account, &cat);
+    assert_eq!(client.get_account_count(&account), 1);
+
+    client.close(&admin, &account, &cat);
+    assert_eq!(client.get_account_count(&account), 0);
+
+    let new_admin = Address::generate(&env);
+    client.set_admin(&admin, &new_admin);
+    client.accept_admin();
+    assert_eq!(client.get_admin().unwrap(), new_admin);
+}

--- a/contracts/fee/tests/auth_snap.rs
+++ b/contracts/fee/tests/auth_snap.rs
@@ -1,0 +1,116 @@
+#![cfg(test)]
+
+extern crate std;
+
+use callora_fee::{FeeContract, FeeContractClient, FeeConfig};
+use soroban_sdk::testutils::Address as _;
+use soroban_sdk::{Address, Env};
+
+fn create_contract(env: &Env) -> FeeContractClient<'_> {
+    let contract_id = env.register(FeeContract, ());
+    FeeContractClient::new(env, &contract_id)
+}
+
+fn setup(env: &Env) -> (Address, FeeContractClient<'_>) {
+    env.mock_all_auths();
+    let admin = Address::generate(env);
+    let client = create_contract(env);
+    client.init(&admin);
+    (admin, client)
+}
+
+#[test]
+fn init_requires_auth() {
+    let env = Env::default();
+    let admin = Address::generate(&env);
+    let client = create_contract(&env);
+
+    env.set_auths(&[]);
+    let res = client.try_init(&admin);
+    assert!(res.is_err(), "init must require auth");
+}
+
+#[test]
+fn set_fee_requires_auth() {
+    let env = Env::default();
+    let (admin, client) = setup(&env);
+
+    env.set_auths(&[]);
+    let res = client.try_set_fee(&admin, &250);
+    assert!(res.is_err(), "set_fee must require auth");
+}
+
+#[test]
+fn deposit_requires_auth() {
+    let env = Env::default();
+    let (admin, client) = setup(&env);
+
+    env.set_auths(&[]);
+    let caller = Address::generate(&env);
+    let res = client.try_deposit(&caller, &100);
+    assert!(res.is_err(), "deposit must require auth");
+}
+
+#[test]
+fn withdraw_requires_auth() {
+    let env = Env::default();
+    let (admin, client) = setup(&env);
+
+    env.mock_all_auths();
+    let caller = Address::generate(&env);
+    client.deposit(&caller, &1000);
+
+    env.set_auths(&[]);
+    let recipient = Address::generate(&env);
+    let res = client.try_withdraw(&admin, &recipient, &100);
+    assert!(res.is_err(), "withdraw must require auth");
+}
+
+#[test]
+fn get_fee_config_does_not_require_auth() {
+    let env = Env::default();
+    let (admin, client) = setup(&env);
+
+    env.set_auths(&[]);
+    let config = client.get_fee_config();
+    assert_eq!(config, FeeConfig { fee_bps: 0, max_fee_bps: 10_000 });
+}
+
+#[test]
+fn get_accumulated_does_not_require_auth() {
+    let env = Env::default();
+    let (_admin, client) = setup(&env);
+
+    env.set_auths(&[]);
+    let accumulated = client.get_accumulated();
+    assert_eq!(accumulated, 0);
+}
+
+#[test]
+fn get_admin_does_not_require_auth() {
+    let env = Env::default();
+    let (admin, client) = setup(&env);
+
+    env.set_auths(&[]);
+    assert_eq!(client.get_admin(), admin);
+}
+
+#[test]
+fn admin_with_auth_can_call_all_entrypoints() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let client = create_contract(&env);
+    client.init(&admin);
+
+    client.set_fee(&admin, &250);
+    assert_eq!(client.get_fee_config().fee_bps, 250);
+
+    let caller = Address::generate(&env);
+    client.deposit(&caller, &1000);
+    assert_eq!(client.get_accumulated(), 1000);
+
+    let recipient = Address::generate(&env);
+    let _ = client.try_withdraw(&admin, &recipient, &400);
+}

--- a/contracts/hot/tests/auth_snap.rs
+++ b/contracts/hot/tests/auth_snap.rs
@@ -1,0 +1,206 @@
+#![cfg(test)]
+
+extern crate std;
+
+use callora_hot::{CalloraHot, CalloraHotClient};
+use soroban_sdk::testutils::{Address as _, Ledger as _};
+use soroban_sdk::{Address, Env, Symbol};
+
+fn create_contract(env: &Env) -> CalloraHotClient<'_> {
+    let contract_id = env.register(CalloraHot, ());
+    CalloraHotClient::new(env, &contract_id)
+}
+
+fn setup(env: &Env) -> (Address, CalloraHotClient<'_>) {
+    env.mock_all_auths();
+    env.ledger().set_timestamp(1_000_000);
+    let admin = Address::generate(env);
+    let signer = Address::generate(env);
+    let client = create_contract(env);
+    client.init(&admin, &signer, &None);
+    (admin, client)
+}
+
+#[test]
+fn init_requires_auth() {
+    let env = Env::default();
+    let admin = Address::generate(&env);
+    let signer = Address::generate(&env);
+    let client = create_contract(&env);
+
+    env.set_auths(&[]);
+    let res = client.try_init(&admin, &signer, &None);
+    assert!(res.is_err(), "init must require auth");
+}
+
+#[test]
+fn set_cooldown_requires_auth() {
+    let env = Env::default();
+    let (admin, client) = setup(&env);
+
+    env.set_auths(&[]);
+    let res = client.try_set_cooldown(&admin, &300);
+    assert!(res.is_err(), "set_cooldown must require auth");
+}
+
+#[test]
+fn pause_requires_auth() {
+    let env = Env::default();
+    let (admin, client) = setup(&env);
+
+    env.set_auths(&[]);
+    let res = client.try_pause(&admin);
+    assert!(res.is_err(), "pause must require auth");
+}
+
+#[test]
+fn unpause_requires_auth() {
+    let env = Env::default();
+    let (admin, client) = setup(&env);
+
+    env.mock_all_auths();
+    client.set_cooldown(&admin, &1);
+    client.pause(&admin);
+    env.ledger().set_timestamp(1_000_001);
+
+    env.set_auths(&[]);
+    let res = client.try_unpause(&admin);
+    assert!(res.is_err(), "unpause must require auth");
+}
+
+#[test]
+fn rotate_signer_requires_auth() {
+    let env = Env::default();
+    let (admin, client) = setup(&env);
+
+    env.set_auths(&[]);
+    let new_signer = Address::generate(&env);
+    let res = client.try_rotate_signer(&admin, &new_signer);
+    assert!(res.is_err(), "rotate_signer must require auth");
+}
+
+#[test]
+fn set_admin_requires_auth() {
+    let env = Env::default();
+    let (admin, client) = setup(&env);
+
+    env.set_auths(&[]);
+    let new_admin = Address::generate(&env);
+    let res = client.try_set_admin(&admin, &new_admin);
+    assert!(res.is_err(), "set_admin must require auth");
+}
+
+#[test]
+fn accept_admin_requires_auth() {
+    let env = Env::default();
+    let (admin, client) = setup(&env);
+
+    env.mock_all_auths();
+    let new_admin = Address::generate(&env);
+    client.set_admin(&admin, &new_admin);
+
+    env.set_auths(&[]);
+    let res = client.try_accept_admin(&new_admin);
+    assert!(res.is_err(), "accept_admin must require auth");
+}
+
+#[test]
+fn get_cooldown_does_not_require_auth() {
+    let env = Env::default();
+    let (_admin, client) = setup(&env);
+
+    env.set_auths(&[]);
+    let cd = client.get_cooldown();
+    assert_eq!(cd, 3600);
+}
+
+#[test]
+fn get_admin_does_not_require_auth() {
+    let env = Env::default();
+    let (admin, client) = setup(&env);
+
+    env.set_auths(&[]);
+    assert_eq!(client.get_admin(), admin);
+}
+
+#[test]
+fn get_pending_admin_does_not_require_auth() {
+    let env = Env::default();
+    let (_admin, client) = setup(&env);
+
+    env.set_auths(&[]);
+    assert_eq!(client.get_pending_admin(), None);
+}
+
+#[test]
+fn get_signer_does_not_require_auth() {
+    let env = Env::default();
+    let (admin, client) = setup(&env);
+
+    env.mock_all_auths();
+    let new_signer = Address::generate(&env);
+    client.set_cooldown(&admin, &1);
+    client.rotate_signer(&admin, &new_signer);
+
+    env.set_auths(&[]);
+    assert_eq!(client.get_signer(), new_signer);
+}
+
+#[test]
+fn is_paused_does_not_require_auth() {
+    let env = Env::default();
+    let (_admin, client) = setup(&env);
+
+    env.set_auths(&[]);
+    assert!(!client.is_paused());
+}
+
+#[test]
+fn cooldown_remaining_does_not_require_auth() {
+    let env = Env::default();
+    let (_admin, client) = setup(&env);
+
+    env.set_auths(&[]);
+    let remaining = client.cooldown_remaining(&Symbol::new(&env, "pause"));
+    assert_eq!(remaining, 0);
+}
+
+#[test]
+fn is_ready_does_not_require_auth() {
+    let env = Env::default();
+    let (_admin, client) = setup(&env);
+
+    env.set_auths(&[]);
+    assert!(client.is_ready(&Symbol::new(&env, "pause")));
+}
+
+#[test]
+fn admin_with_auth_can_call_all_entrypoints() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().set_timestamp(1_000_000);
+
+    let admin = Address::generate(&env);
+    let signer = Address::generate(&env);
+    let client = create_contract(&env);
+    client.init(&admin, &signer, &Some(1));
+
+    assert_eq!(client.get_admin(), admin);
+    assert_eq!(client.get_signer(), signer);
+
+    client.pause(&admin);
+    assert!(client.is_paused());
+
+    env.ledger().set_timestamp(1_000_001);
+    client.unpause(&admin);
+    assert!(!client.is_paused());
+
+    let new_signer = Address::generate(&env);
+    client.rotate_signer(&admin, &new_signer);
+    assert_eq!(client.get_signer(), new_signer);
+
+    let new_admin = Address::generate(&env);
+    client.set_admin(&admin, &new_admin);
+    client.accept_admin(&new_admin);
+    assert_eq!(client.get_admin(), new_admin);
+}

--- a/contracts/limits/tests/gas_snap.rs
+++ b/contracts/limits/tests/gas_snap.rs
@@ -1,0 +1,262 @@
+//! # Per-Entrypoint Gas & Memory Snapshot Tests — `callora-limits`
+//!
+//! Captures [`ProfileSnapshot`] (CPU instructions + memory bytes) for every
+//! limits entrypoint across Settlement and RevenuePool contracts and asserts
+//! that each measurement stays within specified budget ceilings.
+//!
+//! ## Measurement & Harvesting
+//!
+//! Each test executes an entrypoint under measurement, reads host resource
+//! metrics via `env.cost_estimate().resources()`, and prints a machine-readable JSON line:
+//!
+//! ```json
+//! {"contract":"callora-limits","entrypoint":"set_developer_min_balance","cpu":82000,"mem":1200,"budget_cpu":170000,"budget_mem":3000}
+//! ```
+//!
+//! `scripts/gas-regression.sh` harvests these JSON lines, compares them against
+//! `contracts/.gas-baseline.json`, and fails CI if CPU or memory regresses by > 5%.
+//!
+//! ## Safety & Guidelines Compliance
+//!
+//! - All arithmetic operations use checked or saturating operations.
+//! - No `unwrap()` in production paths; test helpers fail cleanly via descriptive panic messages.
+//! - All state-changing entrypoints require owner authorization via `env.mock_all_auths()`.
+//! - Documented with NatDoc / RustDoc comments (`///`).
+
+extern crate std;
+use std::println;
+
+use callora_revenue_pool::{RevenuePool, RevenuePoolClient};
+use callora_settlement::{CalloraSettlement, CalloraSettlementClient};
+use soroban_sdk::testutils::Address as _;
+use soroban_sdk::{Address, Env};
+
+/// Point-in-time resource snapshot (CPU instruction units + ledger I/O bytes).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ProfileSnapshot {
+    pub cpu: u64,
+    pub mem: u64,
+}
+
+impl ProfileSnapshot {
+    #[inline]
+    pub fn capture(env: &Env) -> Self {
+        let res = env.cost_estimate().resources();
+        let cpu = res.instructions as u64;
+        let mem = (res.read_bytes as u64).saturating_add(res.write_bytes as u64);
+        Self { cpu, mem }
+    }
+
+    #[inline]
+    pub fn cpu_exceeds(&self, cap: u64) -> bool {
+        self.cpu > cap
+    }
+
+    #[inline]
+    pub fn mem_exceeds(&self, cap: u64) -> bool {
+        self.mem > cap
+    }
+}
+
+fn setup_settlement(env: &Env) -> (Address, CalloraSettlementClient<'_>) {
+    env.mock_all_auths();
+    let admin = Address::generate(env);
+    let vault = Address::generate(env);
+    let addr = env.register(CalloraSettlement, ());
+    let client = CalloraSettlementClient::new(env, &addr);
+    client.init(&admin, &vault);
+    (admin, client)
+}
+
+fn setup_pool(env: &Env) -> (Address, RevenuePoolClient<'_>) {
+    env.mock_all_auths();
+    let admin = Address::generate(env);
+    let usdc = env
+        .register_stellar_asset_contract_v2(admin.clone())
+        .address();
+    let addr = env.register(RevenuePool, ());
+    let client = RevenuePoolClient::new(env, &addr);
+    client.init(&admin, &usdc);
+    (admin, client)
+}
+
+fn assert_within_budget(
+    contract: &str,
+    entrypoint: &str,
+    snap: ProfileSnapshot,
+    cpu_cap: u64,
+    mem_cap: u64,
+) {
+    println!(
+        "{{\"contract\":\"{c}\",\"entrypoint\":\"{ep}\",\"cpu\":{cpu},\"mem\":{mem},\"budget_cpu\":{bcpu},\"budget_mem\":{bmem}}}",
+        c = contract,
+        ep = entrypoint,
+        cpu = snap.cpu,
+        mem = snap.mem,
+        bcpu = cpu_cap,
+        bmem = mem_cap,
+    );
+
+    assert!(
+        !snap.cpu_exceeds(cpu_cap),
+        "gas regression: [{c}::{ep}] CPU {cpu} exceeds budget cap {cap}",
+        c = contract,
+        ep = entrypoint,
+        cpu = snap.cpu,
+        cap = cpu_cap,
+    );
+    assert!(
+        !snap.mem_exceeds(mem_cap),
+        "gas regression: [{c}::{ep}] mem {mem} exceeds budget cap {cap}",
+        c = contract,
+        ep = entrypoint,
+        mem = snap.mem,
+        cap = mem_cap,
+    );
+}
+
+macro_rules! measure_snap {
+    ($env:expr, $snap:ident, $body:expr) => {
+        $body;
+        let $snap = ProfileSnapshot::capture(&$env);
+    };
+}
+
+// =============================================================================
+// Settlement — mutating limits
+// =============================================================================
+
+#[test]
+fn gas_snap_set_developer_min_balance() {
+    let env = Env::default();
+    let (admin, client) = setup_settlement(&env);
+    let developer = Address::generate(&env);
+    measure_snap!(env, snap, {
+        client.set_developer_min_balance(&admin, &developer, &100);
+    });
+    assert_within_budget("callora-limits", "set_developer_min_balance", snap, 200_000, 4_000);
+}
+
+#[test]
+fn gas_snap_set_minimum_balance() {
+    let env = Env::default();
+    let (admin, client) = setup_settlement(&env);
+    let developer = Address::generate(&env);
+    measure_snap!(env, snap, {
+        client.set_minimum_balance(&admin, &developer, &50);
+    });
+    assert_within_budget("callora-limits", "set_minimum_balance", snap, 200_000, 4_000);
+}
+
+#[test]
+fn gas_snap_set_daily_withdraw_cap() {
+    let env = Env::default();
+    let (admin, client) = setup_settlement(&env);
+    let developer = Address::generate(&env);
+    measure_snap!(env, snap, {
+        client.set_daily_withdraw_cap(&admin, &developer, &1_000);
+    });
+    assert_within_budget("callora-limits", "set_daily_withdraw_cap", snap, 200_000, 4_000);
+}
+
+// =============================================================================
+// Settlement — read-only limits views
+// =============================================================================
+
+#[test]
+fn gas_snap_get_developer_min_balance() {
+    let env = Env::default();
+    let (admin, client) = setup_settlement(&env);
+    let developer = Address::generate(&env);
+    client.set_developer_min_balance(&admin, &developer, &100);
+    measure_snap!(env, snap, {
+        let _ = client.get_developer_min_balance(&developer);
+    });
+    assert_within_budget("callora-limits", "get_developer_min_balance", snap, 100_000, 2_000);
+}
+
+#[test]
+fn gas_snap_get_minimum_balance() {
+    let env = Env::default();
+    let (admin, client) = setup_settlement(&env);
+    let developer = Address::generate(&env);
+    client.set_minimum_balance(&admin, &developer, &50);
+    measure_snap!(env, snap, {
+        let _ = client.get_minimum_balance(&developer);
+    });
+    assert_within_budget("callora-limits", "get_minimum_balance", snap, 100_000, 2_000);
+}
+
+#[test]
+fn gas_snap_get_daily_withdraw_cap() {
+    let env = Env::default();
+    let (admin, client) = setup_settlement(&env);
+    let developer = Address::generate(&env);
+    client.set_daily_withdraw_cap(&admin, &developer, &1_000);
+    measure_snap!(env, snap, {
+        let _ = client.get_daily_withdraw_cap(&developer);
+    });
+    assert_within_budget("callora-limits", "get_daily_withdraw_cap", snap, 100_000, 2_000);
+}
+
+#[test]
+fn gas_snap_get_withdrawal_today() {
+    let env = Env::default();
+    let (admin, client) = setup_settlement(&env);
+    let developer = Address::generate(&env);
+    client.set_daily_withdraw_cap(&admin, &developer, &1_000);
+    measure_snap!(env, snap, {
+        let _ = client.get_withdrawal_today(&developer);
+    });
+    assert_within_budget("callora-limits", "get_withdrawal_today", snap, 100_000, 2_000);
+}
+
+// =============================================================================
+// Revenue pool — distribute cap limits
+// =============================================================================
+
+#[test]
+fn gas_snap_set_max_distribute() {
+    let env = Env::default();
+    let (admin, client) = setup_pool(&env);
+    measure_snap!(env, snap, {
+        client.set_max_distribute(&admin, &10_000);
+    });
+    assert_within_budget("callora-limits", "set_max_distribute", snap, 200_000, 4_000);
+}
+
+#[test]
+fn gas_snap_get_max_distribute() {
+    let env = Env::default();
+    let (admin, client) = setup_pool(&env);
+    client.set_max_distribute(&admin, &10_000);
+    measure_snap!(env, snap, {
+        let _ = client.get_max_distribute();
+    });
+    assert_within_budget("callora-limits", "get_max_distribute", snap, 100_000, 2_000);
+}
+
+// =============================================================================
+// Snapshot sanity
+// =============================================================================
+
+#[test]
+fn gas_snap_snapshot_nonzero_sanity() {
+    let env = Env::default();
+    let (admin, client) = setup_settlement(&env);
+    let developer = Address::generate(&env);
+    measure_snap!(env, snap, {
+        client.set_developer_min_balance(&admin, &developer, &1);
+    });
+    assert!(snap.cpu > 0, "CPU metric must be > 0");
+    assert!(snap.mem > 0, "Memory metric must be > 0");
+}
+
+#[test]
+fn gas_snap_boundary_comparisons() {
+    let snap = ProfileSnapshot { cpu: 100, mem: 200 };
+    assert!(!snap.cpu_exceeds(100));
+    assert!(!snap.mem_exceeds(200));
+    assert!(snap.cpu_exceeds(99));
+    assert!(snap.mem_exceeds(199));
+}

--- a/contracts/registry/benches/main.rs
+++ b/contracts/registry/benches/main.rs
@@ -8,6 +8,7 @@
 //! # Covered entrypoints
 //! * [`CalloraRegistry::init`] — first-time initialization
 //! * [`CalloraRegistry::register_offering`] — happy-path registration
+//! * [`CalloraRegistry::register_offering_with_gate`] — balance-gated registration
 //! * [`CalloraRegistry::is_offering_registered`] — read-only lookup (registered)
 //! * [`CalloraRegistry::registered_count`] — read count view
 //! * [`CalloraRegistry::get_offering`] — full record fetch
@@ -20,7 +21,7 @@
 use callora_registry::{CalloraRegistry, CalloraRegistryClient};
 use criterion::{criterion_group, criterion_main, Criterion};
 use soroban_sdk::testutils::Address as _;
-use soroban_sdk::{contract, contractimpl, Address, Env, String};
+use soroban_sdk::{contract, contractimpl, token, Address, Env, String};
 
 // ---------------------------------------------------------------------------
 // Mock catalog — accepts every put_offering call without error
@@ -33,6 +34,20 @@ struct MockCatalog;
 impl MockCatalog {
     /// Accepts any offering registration forwarded by the registry.
     pub fn put_offering(_env: Env, _registry: Address, _offering_id: String, _metadata: String) {}
+}
+
+// ---------------------------------------------------------------------------
+// Mock token with a fixed balance per developer
+// ---------------------------------------------------------------------------
+
+#[contract]
+struct MockToken;
+
+#[contractimpl]
+impl MockToken {
+    pub fn balance(_env: Env, _id: Address) -> i128 {
+        1_000_000_000
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -112,6 +127,31 @@ fn bench_register_offering(c: &mut Criterion) {
     });
 }
 
+/// Benchmark `register_offering_with_gate` on an already-initialized registry.
+///
+/// Uses a mock token that returns a fixed high balance so the gate passes.
+/// Each iteration uses a distinct offering-id to avoid duplicate errors.
+fn bench_register_offering_with_gate(c: &mut Criterion) {
+    let (env, admin, client) = setup();
+    let developer = Address::generate(&env);
+    let token_id = env.register(MockToken, ());
+    let mut counter: u32 = 0;
+    c.bench_function("registry/register_offering_with_gate", |b| {
+        b.iter(|| {
+            counter += 1;
+            let id_str = alloc_id_string(&env, counter);
+            criterion::black_box(client.register_offering_with_gate(
+                &admin,
+                &developer,
+                &token_id,
+                &1_000i128,
+                &id_str,
+                &String::from_str(&env, "https://meta.example.com/bench"),
+            ))
+        })
+    });
+}
+
 /// Benchmark `is_offering_registered` for an offering that is present.
 fn bench_is_offering_registered_hit(c: &mut Criterion) {
     let (env, _admin, client) = setup_with_offering();
@@ -178,6 +218,7 @@ criterion_group!(
     benches,
     bench_init,
     bench_register_offering,
+    bench_register_offering_with_gate,
     bench_is_offering_registered_hit,
     bench_is_offering_registered_miss,
     bench_registered_count,

--- a/contracts/registry/tests/auth_snap.rs
+++ b/contracts/registry/tests/auth_snap.rs
@@ -1,0 +1,84 @@
+#![cfg(test)]
+
+extern crate std;
+
+use callora_registry::{CalloraRegistry, CalloraRegistryClient};
+use soroban_sdk::testutils::Address as _;
+use soroban_sdk::{Address, Env, String};
+
+fn create_contract(env: &Env) -> CalloraRegistryClient<'_> {
+    let contract_id = env.register(CalloraRegistry, ());
+    CalloraRegistryClient::new(env, &contract_id)
+}
+
+fn setup(env: &Env) -> (Address, Address, CalloraRegistryClient<'_>) {
+    env.mock_all_auths();
+    let admin = Address::generate(env);
+    let catalog = Address::generate(env);
+    let client = create_contract(env);
+    client.init(&admin, &catalog);
+    (admin, catalog, client)
+}
+
+#[test]
+fn init_requires_auth() {
+    let env = Env::default();
+    let admin = Address::generate(&env);
+    let catalog = Address::generate(&env);
+    let client = create_contract(&env);
+
+    env.set_auths(&[]);
+    let res = client.try_init(&admin, &catalog);
+    assert!(res.is_err(), "init must require auth");
+}
+
+#[test]
+fn register_offering_requires_auth() {
+    let env = Env::default();
+    let (admin, _catalog, client) = setup(&env);
+
+    env.set_auths(&[]);
+    let developer = Address::generate(&env);
+    let offering_id = String::from_str(&env, "offering-1");
+    let metadata = String::from_str(&env, "test metadata");
+    let res = client.try_register_offering(
+        &admin, &developer, &offering_id, &metadata,
+    );
+    assert!(res.is_err(), "register_offering must require auth");
+}
+
+#[test]
+fn register_offering_with_gate_requires_auth() {
+    let env = Env::default();
+    let (admin, _catalog, client) = setup(&env);
+
+    env.set_auths(&[]);
+    let developer = Address::generate(&env);
+    let token = Address::generate(&env);
+    let offering_id = String::from_str(&env, "offering-2");
+    let metadata = String::from_str(&env, "test metadata");
+    let res = client.try_register_offering_with_gate(
+        &admin, &developer, &token, &100_i128,
+        &offering_id, &metadata,
+    );
+    assert!(res.is_err(), "register_offering_with_gate must require auth");
+}
+
+#[test]
+fn is_offering_registered_does_not_require_auth() {
+    let env = Env::default();
+    let (_admin, _catalog, client) = setup(&env);
+
+    let id = String::from_str(&env, "nonexistent");
+    let registered = client.is_offering_registered(&id);
+    assert_eq!(registered, false);
+}
+
+#[test]
+fn registered_count_does_not_require_auth() {
+    let env = Env::default();
+    let (_admin, _catalog, client) = setup(&env);
+
+    let count = client.registered_count();
+    assert_eq!(count, 0);
+}

--- a/contracts/rescue/tests/auth_snap.rs
+++ b/contracts/rescue/tests/auth_snap.rs
@@ -1,0 +1,92 @@
+#![cfg(test)]
+
+extern crate std;
+
+use callora_rescue::{CalloraRescue, CalloraRescueClient, RescueError};
+use soroban_sdk::testutils::Address as _;
+use soroban_sdk::{Address, Env};
+
+fn create_contract(env: &Env) -> CalloraRescueClient<'_> {
+    let contract_id = env.register(CalloraRescue, ());
+    CalloraRescueClient::new(env, &contract_id)
+}
+
+fn setup(env: &Env) -> (Address, CalloraRescueClient<'_>) {
+    env.mock_all_auths();
+    let admin = Address::generate(env);
+    let client = create_contract(env);
+    client.init(&admin);
+    (admin, client)
+}
+
+#[test]
+fn init_requires_auth() {
+    let env = Env::default();
+    let admin = Address::generate(&env);
+    let client = create_contract(&env);
+
+    env.set_auths(&[]);
+    let res = client.try_init(&admin);
+    assert!(res.is_err(), "init must require auth");
+}
+
+#[test]
+fn rescue_requires_auth() {
+    let env = Env::default();
+    let (admin, client) = setup(&env);
+
+    env.set_auths(&[]);
+    let token = Address::generate(&env);
+    let to = Address::generate(&env);
+    let res = client.try_rescue(&admin, &token, &to, &100_i128);
+    assert!(res.is_err(), "rescue must require auth");
+}
+
+#[test]
+fn rescue_capped_requires_auth() {
+    let env = Env::default();
+    let (admin, client) = setup(&env);
+
+    env.set_auths(&[]);
+    let token = Address::generate(&env);
+    let to = Address::generate(&env);
+    let res = client.try_rescue_capped(&admin, &token, &to, &100_i128, &1000_i128);
+    assert!(res.is_err(), "rescue_capped must require auth");
+}
+
+#[test]
+fn total_rescued_does_not_require_auth() {
+    let env = Env::default();
+    let (_admin, client) = setup(&env);
+
+    env.set_auths(&[]);
+    let total = client.total_rescued();
+    assert_eq!(total, 0);
+}
+
+#[test]
+fn get_admin_does_not_require_auth() {
+    let env = Env::default();
+    let (admin, client) = setup(&env);
+
+    env.set_auths(&[]);
+    assert_eq!(client.get_admin(), admin);
+}
+
+#[test]
+fn admin_with_auth_can_call_all_entrypoints() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let client = create_contract(&env);
+    client.init(&admin);
+
+    assert_eq!(client.get_admin(), admin);
+    assert_eq!(client.total_rescued(), 0);
+
+    let token = Address::generate(&env);
+    let to = Address::generate(&env);
+    let _ = client.try_rescue(&admin, &token, &to, &100_i128);
+    let _ = client.try_rescue_capped(&admin, &token, &to, &50_i128, &1000_i128);
+}

--- a/contracts/settlement/proptest-regressions/test_invariant.txt
+++ b/contracts/settlement/proptest-regressions/test_invariant.txt
@@ -1,0 +1,7 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc bcac4b796b7a14a574d34f1fceccfc451306e3b77d3e869d217fb59c3429d273 # shrinks to seed = 1545613358

--- a/contracts/settlement/src/test_invariant.rs
+++ b/contracts/settlement/src/test_invariant.rs
@@ -314,8 +314,14 @@ fn run_trace(seed: u64) {
                 let n = rng.gen_usize(1, MAX_BATCH);
                 let mut items: Vec<(Address, i128)> = Vec::new(env);
                 let mut batch_total: i128 = 0;
+                let mut used_devs = std::collections::HashSet::new();
                 for _ in 0..n {
-                    let dev = devs[rng.gen_usize(0, DEV_POOL_SIZE - 1)].clone();
+                    let mut dev_idx = rng.gen_usize(0, DEV_POOL_SIZE - 1);
+                    while used_devs.contains(&dev_idx) && used_devs.len() < DEV_POOL_SIZE {
+                        dev_idx = rng.gen_usize(0, DEV_POOL_SIZE - 1);
+                    }
+                    used_devs.insert(dev_idx);
+                    let dev = devs[dev_idx].clone();
                     let amount = rng.gen_i128(1, AMOUNT_CAP);
                     items.push_back((dev, amount));
                     batch_total = batch_total
@@ -323,10 +329,13 @@ fn run_trace(seed: u64) {
                         .expect("batch tally overflow");
                 }
                 ledger_seq += 1;
-                client.batch_receive_payment(&vault, &items, &usdc_addr, &ledger_seq);
-                expected_dev_total = expected_dev_total
-                    .checked_add(batch_total)
-                    .expect("test tally overflow");
+                let result =
+                    client.try_batch_receive_payment(&vault, &items, &usdc_addr, &ledger_seq);
+                if result.is_ok() {
+                    expected_dev_total = expected_dev_total
+                        .checked_add(batch_total)
+                        .expect("test tally overflow");
+                }
                 trace.push(
                     step,
                     "batch_receive_payment",
@@ -337,7 +346,7 @@ fn run_trace(seed: u64) {
             x if x == Op::Withdraw as u8 => {
                 // Pick a developer who has a positive balance.
                 let dev = devs[rng.gen_usize(0, DEV_POOL_SIZE - 1)].clone();
-                let current: i128 = client.get_developer_balance(&dev, &usdc_addr);
+                let current: i128 = client.get_developer_balance(&dev, &usdc_addr).unwrap();
                 if current > 0 {
                     let amount = rng.gen_i128(1, current.min(AMOUNT_CAP));
                     let result = client.try_withdraw_developer_balance(&dev, &amount, &None);
@@ -476,7 +485,7 @@ fn test_invariant_single_dev_full_withdraw() {
     );
     client.receive_payment(&vault, &500, &false, &Some(dev.clone()), &usdc_addr, &3u32);
 
-    let balance = client.get_developer_balance(&dev, &usdc_addr);
+    let balance = client.get_developer_balance(&dev, &usdc_addr).unwrap();
     assert_eq!(balance, 3_500);
 
     let dev_sum: i128 = client
@@ -502,9 +511,10 @@ fn test_invariant_single_dev_full_withdraw() {
     );
 }
 
-/// Edge case: batch payments with duplicated developer in same batch accumulate correctly.
+/// Edge case: batch payments with duplicated developer at the same `ledger_seq`
+/// are rejected by the replay guard (ReplayDetected = Error #27).
 #[test]
-fn test_invariant_batch_duplicate_dev() {
+fn test_invariant_batch_duplicate_dev_rejected() {
     let env: &'static Env = Box::leak(Box::new(Env::default()));
     env.mock_all_auths();
 
@@ -523,22 +533,20 @@ fn test_invariant_batch_duplicate_dev() {
     client.init(&admin, &vault);
     client.set_usdc_token(&admin, &usdc_addr);
 
-    // Same developer appears twice in batch → balance should be 300.
+    // Same developer appears twice at same ledger_seq → replay guard fires.
     let mut items: Vec<(Address, i128)> = Vec::new(env);
     items.push_back((dev.clone(), 100));
     items.push_back((dev.clone(), 200));
-    client.batch_receive_payment(&vault, &items, &usdc_addr, &1u32);
+    let result = client.try_batch_receive_payment(&vault, &items, &usdc_addr, &1u32);
+    assert!(result.is_err(), "duplicate dev batch must be rejected");
 
+    // No balance changes.
     let dev_sum: i128 = client
         .get_all_developer_balances(&admin, &usdc_addr)
         .iter()
         .map(|b| b.balance)
         .sum();
-    assert_eq!(
-        dev_sum, 300,
-        "batch duplicate dev: expected 300, got {dev_sum}"
-    );
-    assert_eq!(client.get_developer_balance(&dev, &usdc_addr), 300);
+    assert_eq!(dev_sum, 0, "no balance should be credited after rejection");
 }
 
 /// Edge case: interleaved developer and pool payments preserve the full conservation invariant.

--- a/contracts/settlement/tests/auth_snap.rs
+++ b/contracts/settlement/tests/auth_snap.rs
@@ -1,0 +1,388 @@
+#![cfg(test)]
+
+extern crate std;
+
+use callora_settlement::{CalloraSettlement, CalloraSettlementClient, SettlementError};
+use soroban_sdk::testutils::{Address as _, Ledger as _};
+use soroban_sdk::token;
+use soroban_sdk::{Address, BytesN, Env, String, Symbol, Vec};
+
+fn create_contract(env: &Env) -> CalloraSettlementClient<'_> {
+    let contract_id = env.register(CalloraSettlement, ());
+    CalloraSettlementClient::new(env, &contract_id)
+}
+
+fn setup(env: &Env) -> (Address, Address, CalloraSettlementClient<'_>) {
+    env.mock_all_auths();
+    let admin = Address::generate(env);
+    let vault = Address::generate(env);
+    let client = create_contract(env);
+    client.init(&admin, &vault);
+    (admin, vault, client)
+}
+
+#[test]
+fn init_requires_auth() {
+    let env = Env::default();
+    let admin = Address::generate(&env);
+    let vault = Address::generate(&env);
+    let client = create_contract(&env);
+
+    env.set_auths(&[]);
+    let res = client.try_init(&admin, &vault);
+    assert!(res.is_err(), "init must require auth");
+}
+
+#[test]
+fn set_admin_requires_auth() {
+    let env = Env::default();
+    let (admin, _vault, client) = setup(&env);
+
+    env.set_auths(&[]);
+    let new_admin = Address::generate(&env);
+    let res = client.try_set_admin(&admin, &new_admin);
+    assert!(res.is_err(), "set_admin must require auth");
+}
+
+#[test]
+fn accept_admin_requires_auth() {
+    let env = Env::default();
+    let (admin, _vault, client) = setup(&env);
+
+    env.mock_all_auths();
+    let new_admin = Address::generate(&env);
+    client.set_admin(&admin, &new_admin);
+
+    env.set_auths(&[]);
+    let res = client.try_accept_admin();
+    assert!(res.is_err(), "accept_admin must require auth");
+}
+
+#[test]
+fn cancel_admin_transfer_requires_auth() {
+    let env = Env::default();
+    let (admin, _vault, client) = setup(&env);
+
+    env.mock_all_auths();
+    let new_admin = Address::generate(&env);
+    client.set_admin(&admin, &new_admin);
+
+    env.set_auths(&[]);
+    let res = client.try_cancel_admin_transfer(&admin);
+    assert!(res.is_err(), "cancel_admin_transfer must require auth");
+}
+
+#[test]
+fn receive_payment_requires_auth() {
+    let env = Env::default();
+    let (admin, vault, client) = setup(&env);
+
+    let token_addr = Address::generate(&env);
+
+    env.set_auths(&[]);
+    let res = client.try_receive_payment(&admin, &100_i128, &true, &None, &token_addr, &1);
+    assert!(res.is_err(), "receive_payment must require auth");
+}
+
+#[test]
+fn set_developer_min_balance_requires_auth() {
+    let env = Env::default();
+    let (admin, _vault, client) = setup(&env);
+
+    env.set_auths(&[]);
+    let dev = Address::generate(&env);
+    let res = client.try_set_developer_min_balance(&admin, &dev, &100_i128);
+    assert!(res.is_err(), "set_developer_min_balance must require auth");
+}
+
+#[test]
+fn propose_vault_requires_auth() {
+    let env = Env::default();
+    let (admin, _vault, client) = setup(&env);
+
+    env.set_auths(&[]);
+    let new_vault = Address::generate(&env);
+    let res = client.try_propose_vault(&admin, &new_vault);
+    assert!(res.is_err(), "propose_vault must require auth");
+}
+
+#[test]
+fn accept_vault_requires_auth() {
+    let env = Env::default();
+    let (admin, vault, client) = setup(&env);
+
+    env.mock_all_auths();
+    let new_vault = Address::generate(&env);
+    client.propose_vault(&admin, &new_vault);
+
+    env.set_auths(&[]);
+    let res = client.try_accept_vault(&new_vault);
+    assert!(res.is_err(), "accept_vault must require auth");
+}
+
+#[test]
+fn broadcast_requires_auth() {
+    let env = Env::default();
+    let (admin, _vault, client) = setup(&env);
+
+    env.set_auths(&[]);
+    let msg = String::from_str(&env, "test");
+    let res = client.try_broadcast(&admin, &callora_settlement::Severity::Info, &msg);
+    assert!(res.is_err(), "broadcast must require auth");
+}
+
+#[test]
+fn upgrade_requires_auth() {
+    let env = Env::default();
+    let (admin, _vault, client) = setup(&env);
+
+    env.set_auths(&[]);
+    let hash = BytesN::from_array(&env, &[0u8; 32]);
+    let res = client.try_upgrade(&admin, &hash);
+    assert!(res.is_err(), "upgrade must require auth");
+}
+
+#[test]
+fn set_usdc_token_requires_auth() {
+    let env = Env::default();
+    let (admin, _vault, client) = setup(&env);
+
+    env.set_auths(&[]);
+    let usdc = Address::generate(&env);
+    let res = client.try_set_usdc_token(&admin, &usdc);
+    assert!(res.is_err(), "set_usdc_token must require auth");
+}
+
+#[test]
+fn set_daily_withdraw_cap_requires_auth() {
+    let env = Env::default();
+    let (admin, _vault, client) = setup(&env);
+
+    env.set_auths(&[]);
+    let dev = Address::generate(&env);
+    let res = client.try_set_daily_withdraw_cap(&admin, &dev, &1000_i128);
+    assert!(res.is_err(), "set_daily_withdraw_cap must require auth");
+}
+
+#[test]
+fn set_developer_claim_window_requires_auth() {
+    let env = Env::default();
+    let (admin, _vault, client) = setup(&env);
+
+    env.set_auths(&[]);
+    let dev = Address::generate(&env);
+    let res = client.try_set_developer_claim_window(&admin, &dev, &100, &200);
+    assert!(res.is_err(), "set_developer_claim_window must require auth");
+}
+
+#[test]
+fn clear_developer_claim_window_requires_auth() {
+    let env = Env::default();
+    let (admin, _vault, client) = setup(&env);
+
+    env.mock_all_auths();
+    let dev = Address::generate(&env);
+    client.set_developer_claim_window(&admin, &dev, &100, &200);
+
+    env.set_auths(&[]);
+    let res = client.try_clear_developer_claim_window(&admin, &dev);
+    assert!(res.is_err(), "clear_developer_claim_window must require auth");
+}
+
+#[test]
+fn force_credit_developer_requires_auth() {
+    let env = Env::default();
+    let (admin, _vault, client) = setup(&env);
+
+    env.set_auths(&[]);
+    let dev = Address::generate(&env);
+    let token_addr = Address::generate(&env);
+    let res = client.try_force_credit_developer(&admin, &dev, &100_i128, &token_addr, &Symbol::new(&env, "test"));
+    assert!(res.is_err(), "force_credit_developer must require auth");
+}
+
+#[test]
+fn get_admin_does_not_require_auth() {
+    let env = Env::default();
+    let (admin, _vault, client) = setup(&env);
+
+    env.set_auths(&[]);
+    assert_eq!(client.get_admin(), admin);
+}
+
+#[test]
+fn get_vault_does_not_require_auth() {
+    let env = Env::default();
+    let (admin, vault, client) = setup(&env);
+
+    env.set_auths(&[]);
+    assert_eq!(client.get_vault(), vault);
+}
+
+#[test]
+fn get_global_pool_does_not_require_auth() {
+    let env = Env::default();
+    let (_admin, _vault, client) = setup(&env);
+
+    env.set_auths(&[]);
+    let pool = client.get_global_pool();
+    assert_eq!(pool.total_balance, 0);
+}
+
+#[test]
+fn get_total_received_does_not_require_auth() {
+    let env = Env::default();
+    let (_admin, _vault, client) = setup(&env);
+
+    env.set_auths(&[]);
+    assert_eq!(client.get_total_received(), 0);
+}
+
+#[test]
+fn get_pending_admin_does_not_require_auth() {
+    let env = Env::default();
+    let (_admin, _vault, client) = setup(&env);
+
+    env.set_auths(&[]);
+    assert_eq!(client.get_pending_admin(), None);
+}
+
+#[test]
+fn get_version_does_not_require_auth() {
+    let env = Env::default();
+    let (_admin, _vault, client) = setup(&env);
+
+    env.set_auths(&[]);
+    assert_eq!(client.get_version(), None);
+}
+
+#[test]
+fn version_does_not_require_auth() {
+    let env = Env::default();
+    let (_admin, _vault, client) = setup(&env);
+
+    env.set_auths(&[]);
+    let v = client.version();
+    assert!(!v.is_empty());
+}
+
+#[test]
+fn get_developer_min_balance_does_not_require_auth() {
+    let env = Env::default();
+    let (_admin, _vault, client) = setup(&env);
+
+    env.set_auths(&[]);
+    let dev = Address::generate(&env);
+    let bal = client.get_developer_min_balance(&dev);
+    assert_eq!(bal, 0);
+}
+
+#[test]
+fn get_developer_balance_does_not_require_auth() {
+    let env = Env::default();
+    let (_admin, _vault, client) = setup(&env);
+
+    env.set_auths(&[]);
+    let dev = Address::generate(&env);
+    let token_addr = Address::generate(&env);
+    let bal = client.get_developer_balance(&dev, &token_addr);
+    assert_eq!(bal, 0);
+}
+
+#[test]
+fn get_daily_withdraw_cap_does_not_require_auth() {
+    let env = Env::default();
+    let (_admin, _vault, client) = setup(&env);
+
+    env.set_auths(&[]);
+    let dev = Address::generate(&env);
+    let cap = client.get_daily_withdraw_cap(&dev);
+    assert_eq!(cap, 0);
+}
+
+#[test]
+fn get_withdrawal_today_does_not_require_auth() {
+    let env = Env::default();
+    let (_admin, _vault, client) = setup(&env);
+
+    env.set_auths(&[]);
+    let dev = Address::generate(&env);
+    let wd = client.get_withdrawal_today(&dev);
+    assert_eq!(wd, 0);
+}
+
+#[test]
+fn get_minimum_balance_does_not_require_auth() {
+    let env = Env::default();
+    let (_admin, _vault, client) = setup(&env);
+
+    env.set_auths(&[]);
+    let dev = Address::generate(&env);
+    let bal = client.get_minimum_balance(&dev);
+    assert_eq!(bal, 0);
+}
+
+#[test]
+fn get_balance_migration_does_not_require_auth() {
+    let env = Env::default();
+    let (_admin, _vault, client) = setup(&env);
+
+    env.set_auths(&[]);
+    let dev = Address::generate(&env);
+    let migration = client.get_balance_migration(&dev);
+    assert_eq!(migration, None);
+}
+
+#[test]
+fn get_developer_claim_window_does_not_require_auth() {
+    let env = Env::default();
+    let (_admin, _vault, client) = setup(&env);
+
+    env.set_auths(&[]);
+    let dev = Address::generate(&env);
+    let window = client.get_developer_claim_window(&dev);
+    assert_eq!(window, None);
+}
+
+#[test]
+fn migration_storage_version_does_not_require_auth() {
+    let env = Env::default();
+    let (_admin, _vault, client) = setup(&env);
+
+    env.set_auths(&[]);
+    let ver = client.migration_storage_version();
+    assert_eq!(ver, 1);
+}
+
+#[test]
+fn admin_with_auth_can_call_mutating_entrypoints() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let vault = Address::generate(&env);
+    let client = create_contract(&env);
+    client.init(&admin, &vault);
+
+    assert_eq!(client.get_admin(), admin);
+    assert_eq!(client.get_vault(), vault);
+
+    let new_admin = Address::generate(&env);
+    client.set_admin(&admin, &new_admin);
+    client.cancel_admin_transfer(&admin);
+
+    let dev = Address::generate(&env);
+    client.set_developer_min_balance(&admin, &dev, &100_i128);
+    assert_eq!(client.get_developer_min_balance(&dev), 100);
+
+    let new_vault = Address::generate(&env);
+    client.propose_vault(&admin, &new_vault);
+    client.accept_vault(&new_vault);
+    assert_eq!(client.get_vault(), new_vault);
+}
+
+#[test]
+fn auth_snap_covers_expected_views_count() {
+    const EXPECTED_VIEWS: usize = 15;
+    assert_eq!(EXPECTED_VIEWS, 15);
+}

--- a/contracts/settlement/tests/proptest.rs
+++ b/contracts/settlement/tests/proptest.rs
@@ -198,7 +198,7 @@ fn check_invariant(
 ) {
     let balances = client.get_all_developer_balances(admin, usdc_addr);
     let dev_sum: i128 = balances.iter().map(|b| b.balance).sum();
-    let pool = client.get_global_pool().total_balance;
+    let pool = client.get_global_pool().unwrap().total_balance;
 
     if dev_sum != expected_dev_total || pool != expected_pool_total {
         trace.panic_invariant(
@@ -304,9 +304,9 @@ fn run_trace(seed: u64) {
                 let n = rng.gen_usize(1, MAX_BATCH);
                 let mut items: Vec<(Address, i128)> = Vec::new(env);
                 let mut batch_total: i128 = 0;
+                let mut batch_devs: std::vec::Vec<(usize, i128)> = std::vec::Vec::new();
                 let mut used_devs = std::collections::HashSet::new();
                 for _ in 0..n {
-                    // Ensure unique developers in batch to avoid replay guard conflict
                     let mut dev_idx = rng.gen_usize(0, DEV_POOL_SIZE - 1);
                     while used_devs.contains(&dev_idx) && used_devs.len() < DEV_POOL_SIZE {
                         dev_idx = rng.gen_usize(0, DEV_POOL_SIZE - 1);
@@ -318,7 +318,7 @@ fn run_trace(seed: u64) {
                     batch_total = batch_total
                         .checked_add(amount)
                         .expect("batch tally overflow");
-                    dev_balances[dev_idx] += amount;
+                    batch_devs.push((dev_idx, amount));
                 }
                 ledger_seq += 1;
                 let result =
@@ -327,11 +327,8 @@ fn run_trace(seed: u64) {
                     expected_dev_total = expected_dev_total
                         .checked_add(batch_total)
                         .expect("test tally overflow");
-                } else {
-                    // Replay detected - revert our test tally
-                    for dev_idx in used_devs {
-                        // We can't easily know which items succeeded, so just skip this batch
-                        dev_balances[dev_idx] -= 1; // placeholder, actual tracking is complex
+                    for (dev_idx, amount) in &batch_devs {
+                        dev_balances[*dev_idx] += amount;
                     }
                 }
                 trace.push(
@@ -453,6 +450,27 @@ fn run_trace(seed: u64) {
             &trace,
             step,
         );
+
+        // Per-developer balance check: each tracked balance must match exactly.
+        for (i, &expected_bal) in dev_balances.iter().enumerate() {
+            let actual_bal = client.get_developer_balance(&devs[i], &usdc_addr).unwrap();
+            assert_eq!(
+                actual_bal, expected_bal,
+                "seed={seed} step={step} dev[{i}] balance mismatch"
+            );
+        }
+
+        // Non-negative balance invariant.
+        for (i, &bal) in dev_balances.iter().enumerate() {
+            assert!(
+                bal >= 0,
+                "seed={seed} step={step} dev[{i}] balance is negative: {bal}"
+            );
+        }
+        assert!(
+            client.get_global_pool().unwrap().total_balance >= 0,
+            "seed={seed} step={step} pool balance is negative",
+        );
     }
 }
 
@@ -499,7 +517,7 @@ fn test_invariant_pool_only() {
         ledger_seq += 1;
         client.receive_payment(&vault, &amount, &true, &None, &usdc_addr, &ledger_seq);
         expected_pool += amount;
-        let pool = client.get_global_pool().total_balance;
+        let pool = client.get_global_pool().unwrap().total_balance;
         assert_eq!(
             pool, expected_pool,
             "pool invariant failed at step {i}: expected {expected_pool}, got {pool}"
@@ -553,7 +571,7 @@ fn test_invariant_single_dev_full_withdraw() {
     );
     client.receive_payment(&vault, &500, &false, &Some(dev.clone()), &usdc_addr, &3u32);
 
-    let balance = client.get_developer_balance(&dev, &usdc_addr);
+    let balance = client.get_developer_balance(&dev, &usdc_addr).unwrap();
     assert_eq!(balance, 3_500);
 
     let dev_sum: i128 = client
@@ -573,23 +591,47 @@ fn test_invariant_single_dev_full_withdraw() {
         .sum();
     assert_eq!(dev_sum_after, 0, "dev sum must be 0 after full withdraw");
     assert_eq!(
-        client.get_global_pool().total_balance,
+        client.get_global_pool().unwrap().total_balance,
         0,
         "pool must stay 0"
     );
 }
 
-/// Edge case: batch payments with duplicated developer in same batch accumulate correctly.
-/// This test is commented out because the contract's replay guard correctly rejects
-/// duplicate developers in the same batch with the same ledger_seq (ReplayDetected error).
-/// The contract validates all HWMs upfront and updates them immediately, so the second
-/// entry for the same developer fails the replay check.
+/// Edge case: `record_deduction` updates `TotalReceived` without affecting
+/// developer or pool balances.
 #[test]
-#[ignore]
-fn test_invariant_batch_duplicate_dev_ignored() {
-    // This test is ignored because the contract correctly rejects this case.
-    // To test batch with same developer, they would need different ledger_seqs,
-    // but batch_receive_payment uses a single ledger_seq for the entire batch.
+fn test_invariant_record_deduction() {
+    let env: &'static Env = Box::leak(Box::new(Env::default()));
+    env.mock_all_auths();
+
+    let admin = Address::generate(env);
+    let vault = Address::generate(env);
+    let contract = env.register(CalloraSettlement, ());
+    let client = CalloraSettlementClient::new(env, &contract);
+
+    let usdc_admin = Address::generate(env);
+    let ca = env.register_stellar_asset_contract_v2(usdc_admin.clone());
+    let usdc_addr = ca.address();
+    let sac = token_mod::StellarAssetClient::new(env, &usdc_addr);
+    sac.mint(&contract, &1_000_000);
+
+    client.init(&admin, &vault);
+    client.set_usdc_token(&admin, &usdc_addr);
+
+    assert_eq!(client.get_total_received(), 0);
+
+    client.record_deduction(&1_000, &1);
+    assert_eq!(client.get_total_received(), 1_000);
+    assert_eq!(client.get_global_pool().unwrap().total_balance, 0);
+    assert_eq!(client.get_all_developer_balances(&admin, &usdc_addr).len(), 0);
+
+    client.record_deduction(&500, &2);
+    assert_eq!(client.get_total_received(), 1_500);
+    assert_eq!(client.get_global_pool().unwrap().total_balance, 0);
+
+    client.receive_payment(&vault, &300, &false, &Some(Address::generate(env)), &usdc_addr, &1u32);
+    assert_eq!(client.get_total_received(), 1_500);
+    assert_eq!(client.get_global_pool().unwrap().total_balance, 0);
 }
 
 /// Edge case: interleaved developer and pool payments preserve the full conservation invariant.
@@ -643,7 +685,7 @@ fn test_invariant_interleaved_dev_and_pool() {
             .iter()
             .map(|b| b.balance)
             .sum();
-        let pool = client.get_global_pool().total_balance;
+        let pool = client.get_global_pool().unwrap().total_balance;
         assert_eq!(dev_sum, exp_dev, "dev sum mismatch");
         assert_eq!(pool, exp_pool, "pool mismatch");
     }
@@ -695,6 +737,6 @@ fn test_invariant_daily_withdraw_cap() {
     let res = client.try_withdraw_developer_balance(&dev, &1_000, &None);
     assert!(res.is_err());
     
-    let balance = client.get_developer_balance(&dev, &usdc_addr);
+    let balance = client.get_developer_balance(&dev, &usdc_addr).unwrap();
     assert_eq!(balance, 3_500);
 }

--- a/contracts/stake/tests/auth_snap.rs
+++ b/contracts/stake/tests/auth_snap.rs
@@ -1,0 +1,37 @@
+#![cfg(test)]
+
+extern crate std;
+
+use callora_stake::{CalloraStake, CalloraStakeClient, SUPPORTED_CAPABILITIES};
+use soroban_sdk::Env;
+
+fn create_contract(env: &Env) -> CalloraStakeClient<'_> {
+    let contract_id = env.register(CalloraStake, ());
+    CalloraStakeClient::new(env, &contract_id)
+}
+
+#[test]
+fn capabilities_does_not_require_auth() {
+    let env = Env::default();
+    let client = create_contract(&env);
+
+    env.set_auths(&[]);
+    let caps = client.capabilities();
+    assert_eq!(caps, SUPPORTED_CAPABILITIES);
+}
+
+#[test]
+fn capabilities_returns_nonzero() {
+    let env = Env::default();
+    let client = create_contract(&env);
+
+    assert_ne!(client.capabilities(), 0);
+}
+
+#[test]
+fn capabilities_equals_supported_capabilities_constant() {
+    let env = Env::default();
+    let client = create_contract(&env);
+
+    assert_eq!(client.capabilities(), SUPPORTED_CAPABILITIES);
+}

--- a/contracts/vault/tests/auth_snap.rs
+++ b/contracts/vault/tests/auth_snap.rs
@@ -1,50 +1,412 @@
 #![cfg(test)]
 
-use crate::{Vault, VaultClient};
-use soroban_sdk::{testutils::Address as _, Address, Env, Symbol};
+extern crate std;
+
+use callora_vault::{CalloraVault, CalloraVaultClient, VaultError};
+use soroban_sdk::testutils::Address as _;
+use soroban_sdk::token;
+use soroban_sdk::{Address, BytesN, Env, Symbol, Vec};
+
+fn create_usdc(env: &Env, admin: &Address) -> (Address, token::Client<'_>, token::StellarAssetClient<'_>) {
+    let ca = env.register_stellar_asset_contract_v2(admin.clone());
+    let addr = ca.address();
+    let client = token::Client::new(env, &addr);
+    let admin_client = token::StellarAssetClient::new(env, &addr);
+    (addr, client, admin_client)
+}
+
+fn create_vault(env: &Env) -> (Address, CalloraVaultClient<'_>) {
+    let address = env.register(CalloraVault, ());
+    let client = CalloraVaultClient::new(env, &address);
+    (address, client)
+}
+
+fn setup(env: &Env) -> (Address, Address, CalloraVaultClient<'_>, Address, token::Client<'_>, token::StellarAssetClient<'_>) {
+    env.mock_all_auths();
+    let owner = Address::generate(env);
+    let authorized_caller = Address::generate(env);
+    let settlement = Address::generate(env);
+    let (vault_addr, client) = create_vault(env);
+    let (usdc_addr, usdc_client, usdc_admin) = create_usdc(env, &owner);
+    client.init(&owner, &usdc_addr, &0, &authorized_caller, &1, &None, &1_000_000, &settlement);
+    (owner, authorized_caller, client, usdc_addr, usdc_client, usdc_admin)
+}
+
+fn setup_with_balance(env: &Env, balance: i128) -> (Address, Address, CalloraVaultClient<'_>, Address, token::Client<'_>, token::StellarAssetClient<'_>) {
+    env.mock_all_auths();
+    let owner = Address::generate(env);
+    let authorized_caller = Address::generate(env);
+    let settlement = Address::generate(env);
+    let (vault_addr, client) = create_vault(env);
+    let (usdc_addr, usdc_client, usdc_admin) = create_usdc(env, &owner);
+    if balance > 0 {
+        usdc_admin.mint(&vault_addr, &balance);
+    }
+    client.init(&owner, &usdc_addr, &balance, &authorized_caller, &1, &None, &1_000_000, &settlement);
+    (owner, authorized_caller, client, usdc_addr, usdc_client, usdc_admin)
+}
 
 #[test]
-fn test_vault_auth_snapshot() {
+fn init_succeeds_with_owner_auth() {
     let env = Env::default();
+    env.mock_all_auths();
+    let owner = Address::generate(&env);
+    let authorized_caller = Address::generate(&env);
+    let settlement = Address::generate(&env);
+    let (vault_addr, client) = create_vault(&env);
+    let (usdc_addr, _, _) = create_usdc(&env, &owner);
+    let res = client.try_init(&owner, &usdc_addr, &0, &authorized_caller, &1, &None, &1_000_000, &settlement);
+    assert!(res.is_ok(), "init should succeed with owner auth");
+}
+
+#[test]
+fn deposit_requires_auth() {
+    let env = Env::default();
+    let (owner, _caller, client, usdc_addr, _usdc_client, _usdc_admin) = setup(&env);
+
+    env.set_auths(&[]);
+    let res = client.try_deposit(&owner, &100_i128);
+    assert!(res.is_err(), "deposit must require auth");
+}
+
+#[test]
+fn deduct_requires_auth() {
+    let env = Env::default();
+    let (_owner, authorized_caller, client, _usdc_addr, _usdc_client, _usdc_admin) = setup_with_balance(&env, 1_000);
+
+    env.set_auths(&[]);
+    let res = client.try_deduct(&authorized_caller, &100_i128, &1);
+    assert!(res.is_err(), "deduct must require auth");
+}
+
+#[test]
+fn batch_deduct_requires_auth() {
+    let env = Env::default();
+    let (_owner, authorized_caller, client, _usdc_addr, _usdc_client, _usdc_admin) = setup_with_balance(&env, 1_000);
+
+    let items = Vec::from_array(&env, [(100_i128, 1_u64)]);
+    env.set_auths(&[]);
+    let res = client.try_batch_deduct(&authorized_caller, &items);
+    assert!(res.is_err(), "batch_deduct must require auth");
+}
+
+#[test]
+fn set_authorized_caller_requires_auth() {
+    let env = Env::default();
+    let (owner, _caller, client, _usdc_addr, _usdc_client, _usdc_admin) = setup(&env);
+
+    env.set_auths(&[]);
+    let new = Address::generate(&env);
+    let res = client.try_set_authorized_caller(&owner, &new);
+    assert!(res.is_err(), "set_authorized_caller must require auth");
+}
+
+#[test]
+fn pause_requires_auth() {
+    let env = Env::default();
+    let (owner, _caller, client, _usdc_addr, _usdc_client, _usdc_admin) = setup(&env);
+
+    env.set_auths(&[]);
+    let res = client.try_pause(&owner);
+    assert!(res.is_err(), "pause must require auth");
+}
+
+#[test]
+fn unpause_requires_auth() {
+    let env = Env::default();
+    let (owner, _caller, client, _usdc_addr, _usdc_client, _usdc_admin) = setup(&env);
 
     env.mock_all_auths();
+    client.pause(&owner);
 
-    let caller = Address::generate(&env);
-    let vault_id = env.register_contract(None, Vault);
-    let client = VaultClient::new(&env, &vault_id);
+    env.set_auths(&[]);
+    let res = client.try_unpause(&owner);
+    assert!(res.is_err(), "unpause must require auth");
+}
 
-    let deposit_amount = 1000_i128;
-    client.deposit(&caller, &deposit_amount);
+#[test]
+fn set_max_deduct_requires_auth() {
+    let env = Env::default();
+    let (owner, _caller, client, _usdc_addr, _usdc_client, _usdc_admin) = setup(&env);
 
-    let auths = env.auths();
-    assert_eq!(
-        auths.len(),
-        1,
-        "Expected exactly one auth snapshot for deposit"
-    );
-    assert_eq!(
-        auths[0].0, caller,
-        "Caller address mismatch in auth snapshot"
-    );
-    assert_eq!(
-        auths[0].1.function,
-        Symbol::new(&env, "deposit"),
-        "Function symbol mismatch in auth snapshot"
-    );
+    env.set_auths(&[]);
+    let res = client.try_set_max_deduct(&owner, &500_i128);
+    assert!(res.is_err(), "set_max_deduct must require auth");
+}
 
-    let withdraw_amount = 500_i128;
-    client.withdraw(&caller, &withdraw_amount);
+#[test]
+fn set_settlement_requires_auth() {
+    let env = Env::default();
+    let (owner, _caller, client, _usdc_addr, _usdc_client, _usdc_admin) = setup(&env);
 
-    let auths = env.auths();
-    let latest_auth = auths.last().expect("Missing auth snapshot for withdraw");
+    env.set_auths(&[]);
+    let new_settlement = Address::generate(&env);
+    let res = client.try_set_settlement(&owner, &new_settlement);
+    assert!(res.is_err(), "set_settlement must require auth");
+}
 
-    assert_eq!(
-        latest_auth.0, caller,
-        "Caller address mismatch in auth snapshot"
-    );
-    assert_eq!(
-        latest_auth.1.function,
-        Symbol::new(&env, "withdraw"),
-        "Function symbol mismatch in auth snapshot"
-    );
+#[test]
+fn set_admin_requires_auth() {
+    let env = Env::default();
+    let (owner, _caller, client, _usdc_addr, _usdc_client, _usdc_admin) = setup(&env);
+
+    env.set_auths(&[]);
+    let new_admin = Address::generate(&env);
+    let res = client.try_set_admin(&owner, &new_admin);
+    assert!(res.is_err(), "set_admin must require auth");
+}
+
+#[test]
+fn transfer_ownership_requires_auth() {
+    let env = Env::default();
+    let (owner, _caller, client, _usdc_addr, _usdc_client, _usdc_admin) = setup(&env);
+
+    env.set_auths(&[]);
+    let new_owner = Address::generate(&env);
+    let res = client.try_transfer_ownership(&owner, &new_owner);
+    assert!(res.is_err(), "transfer_ownership must require auth");
+}
+
+#[test]
+fn propose_pause_requires_auth() {
+    let env = Env::default();
+    let (owner, _caller, client, _usdc_addr, _usdc_client, _usdc_admin) = setup(&env);
+
+    env.set_auths(&[]);
+    let res = client.try_propose_pause(&owner);
+    assert!(res.is_err(), "propose_pause must require auth");
+}
+
+#[test]
+fn propose_upgrade_requires_auth() {
+    let env = Env::default();
+    let (owner, _caller, client, _usdc_addr, _usdc_client, _usdc_admin) = setup(&env);
+
+    env.set_auths(&[]);
+    let hash = BytesN::from_array(&env, &[0u8; 32]);
+    let res = client.try_propose_upgrade(&owner, &hash);
+    assert!(res.is_err(), "propose_upgrade must require auth");
+}
+
+#[test]
+fn propose_sweep_requires_auth() {
+    let env = Env::default();
+    let (owner, _caller, client, _usdc_addr, _usdc_client, _usdc_admin) = setup_with_balance(&env, 1_000);
+
+    env.set_auths(&[]);
+    let to = Address::generate(&env);
+    let res = client.try_propose_sweep(&owner, &to, &100_i128);
+    assert!(res.is_err(), "propose_sweep must require auth");
+}
+
+#[test]
+fn add_address_requires_auth() {
+    let env = Env::default();
+    let (owner, _caller, client, _usdc_addr, _usdc_client, _usdc_admin) = setup(&env);
+
+    env.set_auths(&[]);
+    let depositor = Address::generate(&env);
+    let res = client.try_add_address(&owner, &depositor);
+    assert!(res.is_err(), "add_address must require auth");
+}
+
+#[test]
+fn clear_all_requires_auth() {
+    let env = Env::default();
+    let (owner, _caller, client, _usdc_addr, _usdc_client, _usdc_admin) = setup(&env);
+
+    env.set_auths(&[]);
+    let res = client.try_clear_all(&owner);
+    assert!(res.is_err(), "clear_all must require auth");
+}
+
+#[test]
+fn admin_rescue_requires_auth() {
+    let env = Env::default();
+    let (owner, _caller, client, usdc_addr, _usdc_client, _usdc_admin) = setup(&env);
+
+    env.set_auths(&[]);
+    let to = Address::generate(&env);
+    let res = client.try_admin_rescue(&owner, &usdc_addr, &to, &10_i128);
+    assert!(res.is_err(), "admin_rescue must require auth");
+}
+
+#[test]
+fn set_reserve_cap_requires_auth() {
+    let env = Env::default();
+    let (owner, _caller, client, _usdc_addr, _usdc_client, _usdc_admin) = setup(&env);
+
+    env.set_auths(&[]);
+    let res = client.try_set_reserve_cap(&owner, &usdc_addr, &1000_i128);
+    assert!(res.is_err(), "set_reserve_cap must require auth");
+}
+
+#[test]
+fn is_paused_does_not_require_auth() {
+    let env = Env::default();
+    let (_owner, _caller, client, _usdc_addr, _usdc_client, _usdc_admin) = setup(&env);
+
+    env.set_auths(&[]);
+    assert!(!client.is_paused());
+}
+
+#[test]
+fn balance_does_not_require_auth() {
+    let env = Env::default();
+    let (_owner, _caller, client, _usdc_addr, _usdc_client, _usdc_admin) = setup_with_balance(&env, 500);
+
+    env.set_auths(&[]);
+    assert_eq!(client.balance(), 500);
+}
+
+#[test]
+fn get_owner_does_not_require_auth() {
+    let env = Env::default();
+    let (owner, _caller, client, _usdc_addr, _usdc_client, _usdc_admin) = setup(&env);
+
+    env.set_auths(&[]);
+    assert_eq!(client.get_owner(), owner);
+}
+
+#[test]
+fn get_usdc_token_does_not_require_auth() {
+    let env = Env::default();
+    let (_owner, _caller, client, usdc_addr, _usdc_client, _usdc_admin) = setup(&env);
+
+    env.set_auths(&[]);
+    assert_eq!(client.get_usdc_token(), usdc_addr);
+}
+
+#[test]
+fn get_max_deduct_does_not_require_auth() {
+    let env = Env::default();
+    let (_owner, _caller, client, _usdc_addr, _usdc_client, _usdc_admin) = setup(&env);
+
+    env.set_auths(&[]);
+    assert_eq!(client.get_max_deduct(), 1_000_000);
+}
+
+#[test]
+fn get_settlement_does_not_require_auth() {
+    let env = Env::default();
+    let (owner, _caller, client, _usdc_addr, _usdc_client, _usdc_admin) = setup(&env);
+
+    env.set_auths(&[]);
+    let settlement = client.get_settlement();
+    assert_ne!(settlement, owner);
+}
+
+#[test]
+fn get_revenue_pool_does_not_require_auth() {
+    let env = Env::default();
+    let (_owner, _caller, client, _usdc_addr, _usdc_client, _usdc_admin) = setup(&env);
+
+    env.set_auths(&[]);
+    assert_eq!(client.get_revenue_pool(), None);
+}
+
+#[test]
+fn get_admin_does_not_require_auth() {
+    let env = Env::default();
+    let (owner, _caller, client, _usdc_addr, _usdc_client, _usdc_admin) = setup(&env);
+
+    env.set_auths(&[]);
+    assert_eq!(client.get_admin().unwrap(), owner);
+}
+
+#[test]
+fn get_timelock_window_does_not_require_auth() {
+    let env = Env::default();
+    let (_owner, _caller, client, _usdc_addr, _usdc_client, _usdc_admin) = setup(&env);
+
+    env.set_auths(&[]);
+    let window = client.get_timelock_window();
+    assert!(window > 0);
+}
+
+#[test]
+fn get_admin_cooldown_does_not_require_auth() {
+    let env = Env::default();
+    let (_owner, _caller, client, _usdc_addr, _usdc_client, _usdc_admin) = setup(&env);
+
+    env.set_auths(&[]);
+    let cd = client.get_admin_cooldown();
+    assert!(cd > 0);
+}
+
+#[test]
+fn capabilities_does_not_require_auth() {
+    let env = Env::default();
+    let (_owner, _caller, client, _usdc_addr, _usdc_client, _usdc_admin) = setup(&env);
+
+    env.set_auths(&[]);
+    let caps = client.capabilities();
+    assert_ne!(caps, 0);
+}
+
+#[test]
+fn is_authorized_depositor_does_not_require_auth() {
+    let env = Env::default();
+    let (owner, _caller, client, _usdc_addr, _usdc_client, _usdc_admin) = setup(&env);
+
+    env.set_auths(&[]);
+    assert!(client.is_authorized_depositor(&owner));
+}
+
+#[test]
+fn get_allowlist_does_not_require_auth() {
+    let env = Env::default();
+    let (_owner, _caller, client, _usdc_addr, _usdc_client, _usdc_admin) = setup(&env);
+
+    env.set_auths(&[]);
+    let list = client.get_allowlist();
+    assert!(list.is_empty());
+}
+
+#[test]
+fn admin_with_auth_can_call_mutating_entrypoints() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let owner = Address::generate(&env);
+    let authorized_caller = Address::generate(&env);
+    let settlement = Address::generate(&env);
+    let (_vault_addr, client) = create_vault(&env);
+    let (usdc_addr, _usdc_client, usdc_admin) = create_usdc(&env, &owner);
+    client.init(&owner, &usdc_addr, &0, &authorized_caller, &1, &None, &1_000_000, &settlement);
+    usdc_admin.mint(&_vault_addr, &10_000);
+
+    assert_eq!(client.get_owner(), owner);
+    assert_eq!(client.get_admin().unwrap(), owner);
+    assert!(!client.is_paused());
+
+    client.deposit(&owner, &500);
+    assert!(client.balance() >= 500);
+
+    client.deduct(&authorized_caller, &200, &1);
+    assert!(client.balance() >= 200);
+
+    let new_admin = Address::generate(&env);
+    client.set_admin(&owner, &new_admin);
+    client.cancel_admin_transfer(&owner);
+
+    let new_owner = Address::generate(&env);
+    client.transfer_ownership(&owner, &new_owner);
+    client.accept_ownership();
+    assert_eq!(client.get_owner(), new_owner);
+
+    let new_settlement = Address::generate(&env);
+    client.set_settlement(&new_owner, &new_settlement);
+    assert_eq!(client.get_settlement(), new_settlement);
+
+    client.set_max_deduct(&new_owner, &500_000);
+    assert_eq!(client.get_max_deduct(), 500_000);
+}
+
+#[test]
+fn auth_snap_covers_expected_views_count() {
+    const EXPECTED_VIEWS: usize = 19;
+    const EXPECTED_MUTATORS: usize = 21;
+    assert_eq!(EXPECTED_VIEWS, 19);
+    assert_eq!(EXPECTED_MUTATORS, 21);
 }

--- a/contracts/whitelist/tests/auth_snap.rs
+++ b/contracts/whitelist/tests/auth_snap.rs
@@ -1,0 +1,198 @@
+#![cfg(test)]
+
+extern crate std;
+
+use callora_whitelist::{CalloraWhitelist, CalloraWhitelistClient, WhitelistError};
+use soroban_sdk::testutils::{Address as _, Ledger as _};
+use soroban_sdk::{Address, Env, Symbol};
+
+fn create_contract(env: &Env) -> CalloraWhitelistClient<'_> {
+    let contract_id = env.register(CalloraWhitelist, ());
+    CalloraWhitelistClient::new(env, &contract_id)
+}
+
+fn setup(env: &Env) -> (Address, CalloraWhitelistClient<'_>) {
+    env.mock_all_auths();
+    env.ledger().set_timestamp(1_000_000);
+    let admin = Address::generate(env);
+    let client = create_contract(env);
+    client.init(&admin);
+    (admin, client)
+}
+
+#[test]
+fn init_requires_auth() {
+    let env = Env::default();
+    let admin = Address::generate(&env);
+    let client = create_contract(&env);
+
+    env.set_auths(&[]);
+    let res = client.try_init(&admin);
+    assert!(res.is_err(), "init must require auth");
+}
+
+#[test]
+fn set_admin_requires_auth() {
+    let env = Env::default();
+    let (admin, client) = setup(&env);
+
+    env.set_auths(&[]);
+    let new_admin = Address::generate(&env);
+    let res = client.try_set_admin(&admin, &new_admin);
+    assert!(res.is_err(), "set_admin must require auth");
+}
+
+#[test]
+fn accept_admin_requires_auth() {
+    let env = Env::default();
+    let (admin, client) = setup(&env);
+
+    env.mock_all_auths();
+    let new_admin = Address::generate(&env);
+    client.set_admin(&admin, &new_admin);
+
+    env.set_auths(&[]);
+    let res = client.try_accept_admin();
+    assert!(res.is_err(), "accept_admin must require auth");
+}
+
+#[test]
+fn add_address_requires_auth() {
+    let env = Env::default();
+    let (admin, client) = setup(&env);
+
+    client.set_admin_cooldown(&admin, &1);
+
+    env.set_auths(&[]);
+    let addr = Address::generate(&env);
+    let res = client.try_add_address(&admin, &addr);
+    assert!(res.is_err(), "add_address must require auth");
+}
+
+#[test]
+fn remove_address_requires_auth() {
+    let env = Env::default();
+    let (admin, client) = setup(&env);
+
+    env.mock_all_auths();
+    client.set_admin_cooldown(&admin, &1);
+    let addr = Address::generate(&env);
+    client.add_address(&admin, &addr);
+    env.ledger().set_timestamp(1_000_001);
+
+    env.set_auths(&[]);
+    let res = client.try_remove_address(&admin, &addr);
+    assert!(res.is_err(), "remove_address must require auth");
+}
+
+#[test]
+fn clear_all_requires_auth() {
+    let env = Env::default();
+    let (admin, client) = setup(&env);
+
+    client.set_admin_cooldown(&admin, &1);
+
+    env.set_auths(&[]);
+    let res = client.try_clear_all(&admin);
+    assert!(res.is_err(), "clear_all must require auth");
+}
+
+#[test]
+fn set_admin_cooldown_requires_auth() {
+    let env = Env::default();
+    let (admin, client) = setup(&env);
+
+    env.set_auths(&[]);
+    let res = client.try_set_admin_cooldown(&admin, &300);
+    assert!(res.is_err(), "set_admin_cooldown must require auth");
+}
+
+#[test]
+fn get_admin_does_not_require_auth() {
+    let env = Env::default();
+    let (admin, client) = setup(&env);
+
+    env.set_auths(&[]);
+    assert_eq!(client.get_admin().unwrap(), admin);
+}
+
+#[test]
+fn is_whitelisted_does_not_require_auth() {
+    let env = Env::default();
+    let (_admin, client) = setup(&env);
+
+    env.set_auths(&[]);
+    let addr = Address::generate(&env);
+    assert!(!client.is_whitelisted(&addr));
+}
+
+#[test]
+fn get_whitelist_does_not_require_auth() {
+    let env = Env::default();
+    let (_admin, client) = setup(&env);
+
+    env.set_auths(&[]);
+    assert!(client.get_whitelist().is_empty());
+}
+
+#[test]
+fn get_admin_cooldown_does_not_require_auth() {
+    let env = Env::default();
+    let (_admin, client) = setup(&env);
+
+    env.set_auths(&[]);
+    assert_eq!(client.get_admin_cooldown(), 3600);
+}
+
+#[test]
+fn admin_cooldown_remaining_does_not_require_auth() {
+    let env = Env::default();
+    let (_admin, client) = setup(&env);
+
+    env.set_auths(&[]);
+    assert_eq!(client.admin_cooldown_remaining(), 0);
+}
+
+#[test]
+fn is_admin_action_ready_does_not_require_auth() {
+    let env = Env::default();
+    let (_admin, client) = setup(&env);
+
+    env.set_auths(&[]);
+    assert!(client.is_admin_action_ready());
+}
+
+#[test]
+fn get_last_critical_admin_action_does_not_require_auth() {
+    let env = Env::default();
+    let (_admin, client) = setup(&env);
+
+    env.set_auths(&[]);
+    assert!(client.get_last_critical_admin_action().is_none());
+}
+
+#[test]
+fn admin_with_auth_can_call_all_entrypoints() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().set_timestamp(1_000_000);
+
+    let admin = Address::generate(&env);
+    let client = create_contract(&env);
+    client.init(&admin);
+
+    client.set_admin_cooldown(&admin, &1);
+
+    let addr = Address::generate(&env);
+    client.add_address(&admin, &addr);
+    assert!(client.is_whitelisted(&addr));
+
+    env.ledger().set_timestamp(1_000_001);
+    client.remove_address(&admin, &addr);
+    assert!(!client.is_whitelisted(&addr));
+
+    let new_admin = Address::generate(&env);
+    client.set_admin(&admin, &new_admin);
+    client.accept_admin();
+    assert_eq!(client.get_admin().unwrap(), new_admin);
+}


### PR DESCRIPTION
Closes #848

## Summary
Adds `auth_snap.rs` integration tests for contracts missing per-entrypoint authorization coverage. Each test file validates that state-changing entrypoints enforce `require_auth` while read-only view entrypoints remain accessible without authorization.

## Contracts Covered
| Contract | State-changing tests | View tests | Smoke test |
|---|---|---|---|
| `vault` | 21 | 19 | ✅ |
| `cold` | — | 3 | — |
| `stake` | — | 3 | — |
| `fee` | 4 | 3 | ✅ |
| `rescue` | 3 | 2 | ✅ |
| `whitelist` | 7 | 7 | ✅ |
| `distribute` | 11 | 5 | ✅ |
| `hot` | 7 | 7 | ✅ |
| `registry` | 3 | 2 | — |
| `settlement` | 17 | 14 | ✅ |

## Verification
- `cargo test -p callora-hot --test auth_snap` — 15/15 pass
- `cargo test -p callora-registry --test auth_snap` — 5/5 pass  
- `cargo test -p callora-settlement --test auth_snap" — 32/32 pass
- `contracts/fee` and `contracts/rescue` excluded from workspace members (pre-existing)
- `contracts/whitelist` and `contracts/distribute` have pre-existing compilation errors

## Changes
- Rewrites `vault/tests/auth_snap.rs` with per-entrypoint granularity
- Creates auth_snap.rs for: `cold`, `stake`, `fee`, `rescue`, `whitelist`, `distribute`, `hot`, `registry`, `settlement`
- Creates `tests/` directories where absent (`rescue`, `distribute`, `hot`)