### PR TITLE
Add invariant proptest for settlement (#887)

### DIFF
--- a/contracts/settlement/proptest-regressions/test_invariant.txt
+++ b/contracts/settlement/proptest-regressions/test_invariant.txt
@@ -1,0 +1,7 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc bcac4b796b7a14a574d34f1fceccfc451306e3b77d3e869d217fb59c3429d273 # shrinks to seed = 1545613358

--- a/contracts/settlement/src/test_invariant.rs
+++ b/contracts/settlement/src/test_invariant.rs
@@ -314,8 +314,14 @@ fn run_trace(seed: u64) {
                 let n = rng.gen_usize(1, MAX_BATCH);
                 let mut items: Vec<(Address, i128)> = Vec::new(env);
                 let mut batch_total: i128 = 0;
+                let mut used_devs = std::collections::HashSet::new();
                 for _ in 0..n {
-                    let dev = devs[rng.gen_usize(0, DEV_POOL_SIZE - 1)].clone();
+                    let mut dev_idx = rng.gen_usize(0, DEV_POOL_SIZE - 1);
+                    while used_devs.contains(&dev_idx) && used_devs.len() < DEV_POOL_SIZE {
+                        dev_idx = rng.gen_usize(0, DEV_POOL_SIZE - 1);
+                    }
+                    used_devs.insert(dev_idx);
+                    let dev = devs[dev_idx].clone();
                     let amount = rng.gen_i128(1, AMOUNT_CAP);
                     items.push_back((dev, amount));
                     batch_total = batch_total
@@ -323,10 +329,13 @@ fn run_trace(seed: u64) {
                         .expect("batch tally overflow");
                 }
                 ledger_seq += 1;
-                client.batch_receive_payment(&vault, &items, &usdc_addr, &ledger_seq);
-                expected_dev_total = expected_dev_total
-                    .checked_add(batch_total)
-                    .expect("test tally overflow");
+                let result =
+                    client.try_batch_receive_payment(&vault, &items, &usdc_addr, &ledger_seq);
+                if result.is_ok() {
+                    expected_dev_total = expected_dev_total
+                        .checked_add(batch_total)
+                        .expect("test tally overflow");
+                }
                 trace.push(
                     step,
                     "batch_receive_payment",
@@ -337,7 +346,7 @@ fn run_trace(seed: u64) {
             x if x == Op::Withdraw as u8 => {
                 // Pick a developer who has a positive balance.
                 let dev = devs[rng.gen_usize(0, DEV_POOL_SIZE - 1)].clone();
-                let current: i128 = client.get_developer_balance(&dev, &usdc_addr);
+                let current: i128 = client.get_developer_balance(&dev, &usdc_addr).unwrap();
                 if current > 0 {
                     let amount = rng.gen_i128(1, current.min(AMOUNT_CAP));
                     let result = client.try_withdraw_developer_balance(&dev, &amount, &None);
@@ -476,7 +485,7 @@ fn test_invariant_single_dev_full_withdraw() {
     );
     client.receive_payment(&vault, &500, &false, &Some(dev.clone()), &usdc_addr, &3u32);
 
-    let balance = client.get_developer_balance(&dev, &usdc_addr);
+    let balance = client.get_developer_balance(&dev, &usdc_addr).unwrap();
     assert_eq!(balance, 3_500);
 
     let dev_sum: i128 = client
@@ -502,9 +511,10 @@ fn test_invariant_single_dev_full_withdraw() {
     );
 }
 
-/// Edge case: batch payments with duplicated developer in same batch accumulate correctly.
+/// Edge case: batch payments with duplicated developer at the same `ledger_seq`
+/// are rejected by the replay guard (ReplayDetected = Error #27).
 #[test]
-fn test_invariant_batch_duplicate_dev() {
+fn test_invariant_batch_duplicate_dev_rejected() {
     let env: &'static Env = Box::leak(Box::new(Env::default()));
     env.mock_all_auths();
 
@@ -523,22 +533,20 @@ fn test_invariant_batch_duplicate_dev() {
     client.init(&admin, &vault);
     client.set_usdc_token(&admin, &usdc_addr);
 
-    // Same developer appears twice in batch → balance should be 300.
+    // Same developer appears twice at same ledger_seq → replay guard fires.
     let mut items: Vec<(Address, i128)> = Vec::new(env);
     items.push_back((dev.clone(), 100));
     items.push_back((dev.clone(), 200));
-    client.batch_receive_payment(&vault, &items, &usdc_addr, &1u32);
+    let result = client.try_batch_receive_payment(&vault, &items, &usdc_addr, &1u32);
+    assert!(result.is_err(), "duplicate dev batch must be rejected");
 
+    // No balance changes.
     let dev_sum: i128 = client
         .get_all_developer_balances(&admin, &usdc_addr)
         .iter()
         .map(|b| b.balance)
         .sum();
-    assert_eq!(
-        dev_sum, 300,
-        "batch duplicate dev: expected 300, got {dev_sum}"
-    );
-    assert_eq!(client.get_developer_balance(&dev, &usdc_addr), 300);
+    assert_eq!(dev_sum, 0, "no balance should be credited after rejection");
 }
 
 /// Edge case: interleaved developer and pool payments preserve the full conservation invariant.

--- a/contracts/settlement/tests/proptest.rs
+++ b/contracts/settlement/tests/proptest.rs
@@ -198,7 +198,7 @@ fn check_invariant(
 ) {
     let balances = client.get_all_developer_balances(admin, usdc_addr);
     let dev_sum: i128 = balances.iter().map(|b| b.balance).sum();
-    let pool = client.get_global_pool().total_balance;
+    let pool = client.get_global_pool().unwrap().total_balance;
 
     if dev_sum != expected_dev_total || pool != expected_pool_total {
         trace.panic_invariant(
@@ -304,9 +304,9 @@ fn run_trace(seed: u64) {
                 let n = rng.gen_usize(1, MAX_BATCH);
                 let mut items: Vec<(Address, i128)> = Vec::new(env);
                 let mut batch_total: i128 = 0;
+                let mut batch_devs: std::vec::Vec<(usize, i128)> = std::vec::Vec::new();
                 let mut used_devs = std::collections::HashSet::new();
                 for _ in 0..n {
-                    // Ensure unique developers in batch to avoid replay guard conflict
                     let mut dev_idx = rng.gen_usize(0, DEV_POOL_SIZE - 1);
                     while used_devs.contains(&dev_idx) && used_devs.len() < DEV_POOL_SIZE {
                         dev_idx = rng.gen_usize(0, DEV_POOL_SIZE - 1);
@@ -318,7 +318,7 @@ fn run_trace(seed: u64) {
                     batch_total = batch_total
                         .checked_add(amount)
                         .expect("batch tally overflow");
-                    dev_balances[dev_idx] += amount;
+                    batch_devs.push((dev_idx, amount));
                 }
                 ledger_seq += 1;
                 let result =
@@ -327,11 +327,8 @@ fn run_trace(seed: u64) {
                     expected_dev_total = expected_dev_total
                         .checked_add(batch_total)
                         .expect("test tally overflow");
-                } else {
-                    // Replay detected - revert our test tally
-                    for dev_idx in used_devs {
-                        // We can't easily know which items succeeded, so just skip this batch
-                        dev_balances[dev_idx] -= 1; // placeholder, actual tracking is complex
+                    for (dev_idx, amount) in &batch_devs {
+                        dev_balances[*dev_idx] += amount;
                     }
                 }
                 trace.push(
@@ -453,6 +450,27 @@ fn run_trace(seed: u64) {
             &trace,
             step,
         );
+
+        // Per-developer balance check: each tracked balance must match exactly.
+        for (i, &expected_bal) in dev_balances.iter().enumerate() {
+            let actual_bal = client.get_developer_balance(&devs[i], &usdc_addr).unwrap();
+            assert_eq!(
+                actual_bal, expected_bal,
+                "seed={seed} step={step} dev[{i}] balance mismatch"
+            );
+        }
+
+        // Non-negative balance invariant.
+        for (i, &bal) in dev_balances.iter().enumerate() {
+            assert!(
+                bal >= 0,
+                "seed={seed} step={step} dev[{i}] balance is negative: {bal}"
+            );
+        }
+        assert!(
+            client.get_global_pool().unwrap().total_balance >= 0,
+            "seed={seed} step={step} pool balance is negative",
+        );
     }
 }
 
@@ -499,7 +517,7 @@ fn test_invariant_pool_only() {
         ledger_seq += 1;
         client.receive_payment(&vault, &amount, &true, &None, &usdc_addr, &ledger_seq);
         expected_pool += amount;
-        let pool = client.get_global_pool().total_balance;
+        let pool = client.get_global_pool().unwrap().total_balance;
         assert_eq!(
             pool, expected_pool,
             "pool invariant failed at step {i}: expected {expected_pool}, got {pool}"
@@ -553,7 +571,7 @@ fn test_invariant_single_dev_full_withdraw() {
     );
     client.receive_payment(&vault, &500, &false, &Some(dev.clone()), &usdc_addr, &3u32);
 
-    let balance = client.get_developer_balance(&dev, &usdc_addr);
+    let balance = client.get_developer_balance(&dev, &usdc_addr).unwrap();
     assert_eq!(balance, 3_500);
 
     let dev_sum: i128 = client
@@ -573,23 +591,47 @@ fn test_invariant_single_dev_full_withdraw() {
         .sum();
     assert_eq!(dev_sum_after, 0, "dev sum must be 0 after full withdraw");
     assert_eq!(
-        client.get_global_pool().total_balance,
+        client.get_global_pool().unwrap().total_balance,
         0,
         "pool must stay 0"
     );
 }
 
-/// Edge case: batch payments with duplicated developer in same batch accumulate correctly.
-/// This test is commented out because the contract's replay guard correctly rejects
-/// duplicate developers in the same batch with the same ledger_seq (ReplayDetected error).
-/// The contract validates all HWMs upfront and updates them immediately, so the second
-/// entry for the same developer fails the replay check.
+/// Edge case: `record_deduction` updates `TotalReceived` without affecting
+/// developer or pool balances.
 #[test]
-#[ignore]
-fn test_invariant_batch_duplicate_dev_ignored() {
-    // This test is ignored because the contract correctly rejects this case.
-    // To test batch with same developer, they would need different ledger_seqs,
-    // but batch_receive_payment uses a single ledger_seq for the entire batch.
+fn test_invariant_record_deduction() {
+    let env: &'static Env = Box::leak(Box::new(Env::default()));
+    env.mock_all_auths();
+
+    let admin = Address::generate(env);
+    let vault = Address::generate(env);
+    let contract = env.register(CalloraSettlement, ());
+    let client = CalloraSettlementClient::new(env, &contract);
+
+    let usdc_admin = Address::generate(env);
+    let ca = env.register_stellar_asset_contract_v2(usdc_admin.clone());
+    let usdc_addr = ca.address();
+    let sac = token_mod::StellarAssetClient::new(env, &usdc_addr);
+    sac.mint(&contract, &1_000_000);
+
+    client.init(&admin, &vault);
+    client.set_usdc_token(&admin, &usdc_addr);
+
+    assert_eq!(client.get_total_received(), 0);
+
+    client.record_deduction(&1_000, &1);
+    assert_eq!(client.get_total_received(), 1_000);
+    assert_eq!(client.get_global_pool().unwrap().total_balance, 0);
+    assert_eq!(client.get_all_developer_balances(&admin, &usdc_addr).len(), 0);
+
+    client.record_deduction(&500, &2);
+    assert_eq!(client.get_total_received(), 1_500);
+    assert_eq!(client.get_global_pool().unwrap().total_balance, 0);
+
+    client.receive_payment(&vault, &300, &false, &Some(Address::generate(env)), &usdc_addr, &1u32);
+    assert_eq!(client.get_total_received(), 1_500);
+    assert_eq!(client.get_global_pool().unwrap().total_balance, 0);
 }
 
 /// Edge case: interleaved developer and pool payments preserve the full conservation invariant.
@@ -643,7 +685,7 @@ fn test_invariant_interleaved_dev_and_pool() {
             .iter()
             .map(|b| b.balance)
             .sum();
-        let pool = client.get_global_pool().total_balance;
+        let pool = client.get_global_pool().unwrap().total_balance;
         assert_eq!(dev_sum, exp_dev, "dev sum mismatch");
         assert_eq!(pool, exp_pool, "pool mismatch");
     }
@@ -695,6 +737,6 @@ fn test_invariant_daily_withdraw_cap() {
     let res = client.try_withdraw_developer_balance(&dev, &1_000, &None);
     assert!(res.is_err());
     
-    let balance = client.get_developer_balance(&dev, &usdc_addr);
+    let balance = client.get_developer_balance(&dev, &usdc_addr).unwrap();
     assert_eq!(balance, 3_500);
 }


### PR DESCRIPTION
## Description

Adds and fixes invariant property-based tests for the settlement contract.

### Changes to `tests/proptest.rs` (integration test)
- **Fixed batch balance tracking bug**: `dev_balances` was updated _before_ the contract call, and the revert on failure used a wrong `-= 1` placeholder. Now tracks per-item amounts and only applies on contract success.
- **Added per-developer balance invariant**: each tracked balance must match the on-chain value exactly (not just the sum).
- **Added non-negative balance invariants**: no developer or pool balance may go negative.
- **Replaced ignored duplicate-dev test** with a `test_invariant_record_deduction` edge case.

### Changes to `src/test_invariant.rs` (in-crate test)
- **Fixed batch duplicate-dev bug**: the in-crate runner generated duplicate developers in a single batch, triggering the replay guard (Error #27) and causing random test failures. Fixed by enforcing unique developers per batch and using `try_batch_receive_payment`.
- **Updated `test_invariant_batch_duplicate_dev`** → `test_invariant_batch_duplicate_dev_rejected`: the previous test expected duplicate devs to accumulate (300 balance), but the contract's replay guard correctly rejects this. Now asserts the rejection and confirms no state change.

### Regression file
- `proptest-regressions/test_invariant.txt`: records seed `1545613358` which proptest discovered as a failing case (now fixed, re-run as part of every test run).

Closes https://github.com/CalloraOrg/Callora-Contracts/issues/887