### PR TITLE
fix(whitelist): close cooldown-reconfiguration bypass in set_admin_cooldown

### DIFF
--- a/contracts/whitelist/src/admin.rs
+++ b/contracts/whitelist/src/admin.rs
@@ -121,6 +121,25 @@ pub fn guard(env: &Env, action: Symbol) -> Result<(), WhitelistError> {
     Ok(())
 }
 
+/// Enforce the admin cool-off window without arming it.
+///
+/// Unlike [`guard`], this does not record a new critical action on success —
+/// it only rejects the caller while an *existing* window from a prior
+/// critical action is still counting down. Use this to gate configuration
+/// changes (like reconfiguring the window itself) that must not be usable to
+/// escape an already-active cool-off, but that shouldn't independently arm a
+/// fresh window when the contract is idle.
+///
+/// # Errors
+/// Returns [`WhitelistError::AdminCooldownActive`] while another critical action's
+/// cool-off window is still active.
+pub fn require_ready(env: &Env) -> Result<(), WhitelistError> {
+    if !is_ready(env) {
+        return Err(WhitelistError::AdminCooldownActive);
+    }
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -181,6 +200,31 @@ mod tests {
             let record = last_action(&env).expect("critical action record");
             assert_eq!(record.action, Symbol::new(&env, "clear_all"));
             assert_eq!(record.executed_at, 1_300);
+        });
+    }
+
+    #[test]
+    fn require_ready_rejects_during_an_active_window_without_arming_one() {
+        let env = Env::default();
+        env.ledger().set_timestamp(2_000);
+        in_contract(&env, || {
+            // Idle contract: require_ready must not arm anything.
+            assert_eq!(require_ready(&env), Ok(()));
+            assert_eq!(require_ready(&env), Ok(()));
+            assert!(last_action(&env).is_none());
+
+            set_cooldown(&env, 300).unwrap();
+            assert_eq!(guard(&env, Symbol::new(&env, "add_address")), Ok(()));
+
+            // A window is now actively counting down; require_ready must
+            // reject rather than silently allow reconfiguration.
+            assert_eq!(
+                require_ready(&env),
+                Err(WhitelistError::AdminCooldownActive)
+            );
+
+            env.ledger().set_timestamp(2_300);
+            assert_eq!(require_ready(&env), Ok(()));
         });
     }
 

--- a/contracts/whitelist/src/lib.rs
+++ b/contracts/whitelist/src/lib.rs
@@ -192,7 +192,6 @@ impl CalloraWhitelist {
     /// - [`WhitelistError::AdminCooldownActive`] if another action's cool-off is still active.
     /// - [`WhitelistError::AddressAlreadyInWhitelist`] if the address is already whitelisted.
     pub fn add_address(env: Env, caller: Address, address: Address) -> Result<(), WhitelistError> {
-        caller.require_auth();
         Self::require_admin(&env, &caller)?;
 
         admin::guard(&env, Symbol::new(&env, "add_address"))?;
@@ -332,6 +331,14 @@ impl CalloraWhitelist {
 
     /// Configure the admin cool-off window (admin only).
     ///
+    /// Rejected while another critical action's cool-off is still actively
+    /// counting down — otherwise an admin could defeat the entire mechanism
+    /// by shrinking the window to its minimum immediately after arming it
+    /// with a real mutation, then acting again almost immediately. This
+    /// check does not itself arm a new cool-off window: reconfiguring while
+    /// idle (no active window) is unrestricted, since there is no in-flight
+    /// action for the window to protect.
+    ///
     /// # Bounds
     /// - Minimum: [`admin::MIN_COOLDOWN_SECONDS`] (1 s).
     /// - Maximum: [`admin::MAX_COOLDOWN_SECONDS`] (30 d).
@@ -343,6 +350,7 @@ impl CalloraWhitelist {
     /// # Errors
     /// - [`WhitelistError::Unauthorized`] when `caller` is not the current admin.
     /// - [`WhitelistError::NotInitialized`] when the contract has no configured admin.
+    /// - [`WhitelistError::AdminCooldownActive`] if another action's cool-off is still active.
     /// - [`WhitelistError::InvalidAdminCooldown`] when `seconds` is outside bounds.
     pub fn set_admin_cooldown(
         env: Env,
@@ -350,6 +358,7 @@ impl CalloraWhitelist {
         seconds: u64,
     ) -> Result<(), WhitelistError> {
         Self::require_admin(&env, &caller)?;
+        admin::require_ready(&env)?;
         admin::set_cooldown(&env, seconds)?;
         Self::bump_instance_ttl(&env);
         Ok(())
@@ -492,7 +501,10 @@ mod tests {
 
         let client = deploy_whitelist(&env, &admin);
         let result = client.try_accept_admin();
-        assert_eq!(result.unwrap_err(), WhitelistError::NoAdminTransferPending);
+        assert_eq!(
+            result.unwrap_err(),
+            Ok(WhitelistError::NoAdminTransferPending)
+        );
     }
 
     // -----------------------------------------------------------------------
@@ -744,6 +756,63 @@ mod tests {
             result.unwrap_err(),
             Ok(WhitelistError::InvalidAdminCooldown)
         );
+    }
+
+    #[test]
+    fn test_set_admin_cooldown_cannot_shrink_an_active_window() {
+        // Regression test: set_admin_cooldown must not be usable to escape an
+        // already-armed cool-off from a prior critical action. Before this
+        // fix, an admin could call add_address (arming the default 1-hour
+        // window) and then immediately shrink the window to 1 second via
+        // set_admin_cooldown, defeating the entire rate limit within the
+        // same transaction sequence.
+        let env = Env::default();
+        env.mock_all_auths();
+        env.ledger().set_timestamp(1_000_000);
+
+        let admin = Address::generate(&env);
+        let addr = Address::generate(&env);
+
+        let client = deploy_whitelist(&env, &admin);
+        client.set_admin_cooldown(&admin, &3600);
+
+        client.add_address(&admin, &addr);
+
+        // Attempting to shrink the window while add_address's cool-off is
+        // still counting down must fail, not silently succeed.
+        let result = client.try_set_admin_cooldown(&admin, &admin::MIN_COOLDOWN_SECONDS);
+        assert_eq!(result.unwrap_err(), Ok(WhitelistError::AdminCooldownActive));
+
+        // The cooldown value itself must be unchanged by the rejected call.
+        assert_eq!(client.get_admin_cooldown(), 3600);
+
+        // Once the original window elapses, reconfiguration succeeds again.
+        env.ledger().set_timestamp(1_003_600);
+        client.set_admin_cooldown(&admin, &admin::MIN_COOLDOWN_SECONDS);
+        assert_eq!(client.get_admin_cooldown(), admin::MIN_COOLDOWN_SECONDS);
+    }
+
+    #[test]
+    fn test_set_admin_cooldown_does_not_arm_a_window_when_idle() {
+        // Reconfiguring the cooldown while no critical action is in flight
+        // must not itself start a new cool-off window — otherwise the very
+        // common "shrink the cooldown, then act" setup pattern used
+        // throughout this test suite would break.
+        let env = Env::default();
+        env.mock_all_auths();
+        env.ledger().set_timestamp(1_000_000);
+
+        let admin = Address::generate(&env);
+        let addr = Address::generate(&env);
+
+        let client = deploy_whitelist(&env, &admin);
+
+        client.set_admin_cooldown(&admin, &1);
+        assert!(client.is_admin_action_ready());
+
+        // No timestamp advance — this must still succeed.
+        client.add_address(&admin, &addr);
+        assert!(client.is_whitelisted(&addr));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Security hardening follow-up on the whitelist admin cooldown feature (issue 894, already implemented and merged via PR #966; this is not a reimplementation, it's a gap found while auditing that existing work).

**The gap:** `set_admin_cooldown` was never gated by the cool-off mechanism it configures. Sequence that defeated the whole feature:
1. Admin calls `add_address` — arms the default 1-hour cool-off window.
2. Admin immediately calls `set_admin_cooldown(1)` — succeeds instantly, no gating, shrinks the window to 1 second.
3. Admin waits 1 second, calls `add_address` again — the "1 hour cool-off between critical actions" was bypassed in ~1 second by the same actor it's meant to slow down.

**The fix:** added `admin::require_ready()`, a check-only sibling of the existing `admin::guard()`. It rejects the caller while a window from a prior critical action is still counting down, but — unlike `guard()` — does not arm a new window on success. `set_admin_cooldown` now calls this before applying any change.

A full `guard()` (check-and-arm) was considered and rejected: it would make every `set_admin_cooldown` call start its own cool-off window, which breaks the "shrink cooldown, then immediately act" setup pattern used by most of the existing whitelist test suite on an otherwise-idle contract. `require_ready` targets the actual threat — escaping an in-flight window — without restricting reconfiguration while genuinely idle.

This branch is cut from `main`, which doesn't yet have PR #1004's changes, so it also re-applies two fixes from that PR (the `add_address` double-`require_auth()` panic, and a stale test assertion) since the new tests here need a working `add_address` to exercise the bypass scenario. These will no-op on rebase once #1004 merges.

## Test plan
- [x] New regression test proving the bypass is closed: shrinking the cooldown while a real critical action's window is active is rejected with `AdminCooldownActive`, and the cooldown value is left unchanged.
- [x] New test proving reconfiguration while idle still works with no timestamp advance (guards against the "arm on every call" regression).
- [x] New unit test on `admin::require_ready` directly (idle passes twice without arming anything; active window rejects; clears after the window elapses).
- [x] `cargo test --lib` for `callora-whitelist`: 27/27 pass.
- [x] `rustfmt --check` clean on both edited files.
- [x] `cargo clippy --lib --all-features -- -D warnings` clean.