### PR TITLE
feat(rescue): add structured lifecycle events for off-chain indexers …

### DIFF
--- a/contracts/rescue/src/events.rs
+++ b/contracts/rescue/src/events.rs
@@ -1,0 +1,303 @@
+//! Event topic Symbol constructors and structured emit helpers for the
+//! Callora Rescue contract.
+//!
+//! # Design
+//!
+//! This module is the **single source of truth** for every event emitted by
+//! the rescue contract. It exposes two layers:
+//!
+//! 1. **Topic constructors** – `event_*(&env) -> Symbol` functions that return
+//!    the stable topic Symbol for a given event. These guarantee byte-level
+//!    identity and prevent accidental topic-name drift across call sites.
+//!
+//! 2. **Emit helpers** – `emit_*(&env, …)` functions that bundle the topic
+//!    construction, data struct construction, and `env.events().publish()` call
+//!    into one place. Call sites in `lib.rs` use these helpers exclusively; no
+//!    inline `Symbol::new(…)` or `env.events().publish(…)` calls appear outside
+//!    this module.
+//!
+//! # Adding a new event
+//!
+//! 1. Add `pub fn event_<name>(env: &Env) -> Symbol` with a doc-comment.
+//! 2. Add a corresponding `pub fn emit_<name>(env: &Env, …)` function.
+//! 3. Add a snapshot test in the `#[cfg(test)] mod tests` block asserting
+//!    byte-identity of the topic string.
+//! 4. Update `docs/EVENT_TOPICS.md`.
+//!
+//! # Event Overview
+//!
+//! | Topic               | Trigger                                  |
+//! |---------------------|------------------------------------------|
+//! | `"initialized"`     | Contract initialised with admin (`init`) |
+//! | `"rescue"`          | Admin transfers tokens (`rescue`)        |
+//! | `"rescue_capped"`   | Admin transfers tokens with a per-call cap (`rescue_capped`) |
+
+use soroban_sdk::{contracttype, Address, Env, Symbol};
+
+/// Schema version for structured rescue lifecycle event payloads.
+pub const RESCUE_EVENT_VERSION: u32 = 1;
+
+/// Indicates whether a rescue operation was subject to a per-call cap.
+///
+/// `Standard` rescue has no cap; `Capped` rescue includes the cap value
+/// so off-chain indexers can distinguish the two entrypoints from the
+/// event payload alone.
+#[contracttype]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum RescueCap {
+    /// No cap applied — emitted by `rescue`.
+    None,
+    /// Cap applied — emitted by `rescue_capped` with the limit that was enforced.
+    Some(i128),
+}
+
+/// Stable, versioned payload shared by rescue lifecycle events.
+///
+/// Emitted alongside every rescue execution so off-chain indexers can
+/// reconstruct the complete recovery audit trail without polling storage.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct RescueEvent {
+    /// Schema version of this payload. Incremented on breaking shape changes.
+    pub version: u32,
+    /// Address of the token contract being rescued.
+    pub token: Address,
+    /// Destination address receiving the rescued tokens.
+    pub to: Address,
+    /// Amount of tokens transferred in this rescue operation.
+    pub amount: i128,
+    /// Per-call cap applied, if any. `RescueCap::None` for `rescue`,
+    /// `RescueCap::Some(cap)` for `rescue_capped`.
+    pub cap: RescueCap,
+    /// Running cumulative total of all tokens rescued after this operation.
+    pub cumulative_rescued: i128,
+    /// Ledger sequence number at the time of rescue, for causal ordering.
+    pub ledger_sequence: u32,
+    /// Ledger timestamp (seconds since Unix epoch) at the time of rescue.
+    pub timestamp: u64,
+}
+
+impl RescueEvent {
+    /// Construct a new rescue event payload, capturing the current ledger context.
+    ///
+    /// # Arguments
+    /// * `env` - Soroban environment handle for ledger metadata.
+    /// * `token` - Token contract address.
+    /// * `to` - Recipient address.
+    /// * `amount` - Amount transferred.
+    /// * `cap` - Per-call cap mode (`RescueCap::None` or `RescueCap::Some(cap)`).
+    /// * `cumulative_rescued` - Running total after this operation.
+    pub fn new(
+        env: &Env,
+        token: Address,
+        to: Address,
+        amount: i128,
+        cap: RescueCap,
+        cumulative_rescued: i128,
+    ) -> Self {
+        Self {
+            version: RESCUE_EVENT_VERSION,
+            token,
+            to,
+            amount,
+            cap,
+            cumulative_rescued,
+            ledger_sequence: env.ledger().sequence(),
+            timestamp: env.ledger().timestamp(),
+        }
+    }
+}
+
+// ─── Topic constructors ──────────────────────────────────────────────────────
+
+/// Returns the Symbol for the `"initialized"` event topic.
+///
+/// **What**: Returns the canonical symbol for contract initialization events.
+///
+/// **How**: Creates a `Symbol` from `"initialized"`.
+///
+/// **Why**: Centralizes topic creation to guarantee byte-identity across call sites.
+///
+/// # Arguments
+/// * `env` - Soroban environment handle.
+pub fn event_initialized(env: &Env) -> Symbol {
+    Symbol::new(env, "initialized")
+}
+
+/// Returns the Symbol for the `"rescue"` event topic.
+///
+/// **What**: Returns the canonical symbol for uncapped rescue events.
+///
+/// **How**: Creates a `Symbol` from `"rescue"`.
+///
+/// **Why**: Centralizes topic creation to guarantee byte-identity across call sites.
+///
+/// # Arguments
+/// * `env` - Soroban environment handle.
+pub fn event_rescue(env: &Env) -> Symbol {
+    Symbol::new(env, "rescue")
+}
+
+/// Returns the Symbol for the `"rescue_capped"` event topic.
+///
+/// **What**: Returns the canonical symbol for capped rescue events.
+///
+/// **How**: Creates a `Symbol` from `"rescue_capped"`.
+///
+/// **Why**: Centralizes topic creation to guarantee byte-identity across call sites.
+///
+/// # Arguments
+/// * `env` - Soroban environment handle.
+pub fn event_rescue_capped(env: &Env) -> Symbol {
+    Symbol::new(env, "rescue_capped")
+}
+
+// ─── Emit helpers ────────────────────────────────────────────────────────────
+
+/// Emit `"initialized"` once when the rescue contract is first set up.
+///
+/// **What**: Publishes the initialization event containing the admin address.
+///
+/// **How**: Calls `env.events().publish()` with topic `(initialized, admin)` and
+/// payload `admin`.
+///
+/// **Why**: Allows off-chain indexers to discover the contract deployment and
+/// initial admin identity.
+///
+/// # Arguments
+/// * `env` - Soroban environment handle.
+/// * `admin` - Primary contract administrator address.
+pub fn emit_initialized(env: &Env, admin: &Address) {
+    env.events()
+        .publish((event_initialized(env), admin.clone()), admin.clone());
+}
+
+/// Emit `"rescue"` when the admin executes an uncapped token rescue.
+///
+/// **What**: Publishes a structured rescue event recording token, recipient,
+/// amount, and cumulative total.
+///
+/// **How**: Calls `env.events().publish()` with topic `(rescue, admin, token)`
+/// and payload `RescueEvent`.
+///
+/// **Why**: Audit trail for off-chain indexers tracking token recovery operations.
+///
+/// # Arguments
+/// * `env` - Soroban environment handle.
+/// * `admin` - Admin address executing the rescue.
+/// * `payload` - Structured rescue event details.
+pub fn emit_rescue(env: &Env, admin: &Address, payload: &RescueEvent) {
+    env.events().publish(
+        (event_rescue(env), admin.clone(), payload.token.clone()),
+        payload.clone(),
+    );
+}
+
+/// Emit `"rescue_capped"` when the admin executes a capped token rescue.
+///
+/// **What**: Publishes a structured rescue event recording token, recipient,
+/// amount, cap, and cumulative total.
+///
+/// **How**: Calls `env.events().publish()` with topic `(rescue_capped, admin, token)`
+/// and payload `RescueEvent`.
+///
+/// **Why**: Audit trail for off-chain indexers tracking capped recovery operations.
+///
+/// # Arguments
+/// * `env` - Soroban environment handle.
+/// * `admin` - Admin address executing the rescue.
+/// * `payload` - Structured rescue event details (includes `cap` field).
+pub fn emit_rescue_capped(env: &Env, admin: &Address, payload: &RescueEvent) {
+    env.events().publish(
+        (event_rescue_capped(env), admin.clone(), payload.token.clone()),
+        payload.clone(),
+    );
+}
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use soroban_sdk::testutils::Address as _;
+    use soroban_sdk::Env;
+
+    // ── Topic byte-identity snapshots ─────────────────────────────────────
+
+    /// Every constructor must map to exactly the expected byte string.
+    /// Changing any of these would be a breaking change to the on-chain
+    /// interface; that is why they are explicitly snapshot-tested.
+
+    #[test]
+    fn test_event_initialized_bytes() {
+        let env = Env::default();
+        assert_eq!(event_initialized(&env), Symbol::new(&env, "initialized"));
+    }
+
+    #[test]
+    fn test_event_rescue_bytes() {
+        let env = Env::default();
+        assert_eq!(event_rescue(&env), Symbol::new(&env, "rescue"));
+    }
+
+    #[test]
+    fn test_event_rescue_capped_bytes() {
+        let env = Env::default();
+        assert_eq!(event_rescue_capped(&env), Symbol::new(&env, "rescue_capped"));
+    }
+
+    // ── Structured payload tests ──────────────────────────────────────────
+
+    #[test]
+    fn test_rescue_event_payload_is_versioned() {
+        let env = Env::default();
+        let token = Address::generate(&env);
+        let to = Address::generate(&env);
+
+        let payload = RescueEvent::new(&env, token.clone(), to.clone(), 42, RescueCap::None, 42);
+
+        assert_eq!(payload.version, RESCUE_EVENT_VERSION);
+        assert_eq!(payload.token, token);
+        assert_eq!(payload.to, to);
+        assert_eq!(payload.amount, 42);
+        assert_eq!(payload.cap, RescueCap::None);
+        assert_eq!(payload.cumulative_rescued, 42);
+        assert_eq!(payload.ledger_sequence, env.ledger().sequence());
+        assert_eq!(payload.timestamp, env.ledger().timestamp());
+    }
+
+    #[test]
+    fn test_rescue_capped_payload_includes_cap() {
+        let env = Env::default();
+        let token = Address::generate(&env);
+        let to = Address::generate(&env);
+
+        let payload = RescueEvent::new(
+            &env,
+            token.clone(),
+            to.clone(),
+            500,
+            RescueCap::Some(1000),
+            500,
+        );
+
+        assert_eq!(payload.amount, 500);
+        assert_eq!(payload.cap, RescueCap::Some(1000));
+        assert_eq!(payload.cumulative_rescued, 500);
+    }
+
+    #[test]
+    fn test_rescue_event_captures_ledger_context() {
+        let env = Env::default();
+        let token = Address::generate(&env);
+        let to = Address::generate(&env);
+
+        let seq_before = env.ledger().sequence();
+        let ts_before = env.ledger().timestamp();
+
+        let payload = RescueEvent::new(&env, token, to, 100, RescueCap::None, 100);
+
+        assert_eq!(payload.ledger_sequence, seq_before);
+        assert_eq!(payload.timestamp, ts_before);
+    }
+}

--- a/contracts/rescue/src/lib.rs
+++ b/contracts/rescue/src/lib.rs
@@ -19,6 +19,8 @@
 //! - No `unwrap()` in production paths; all fallible ops return `Result`.
 //! - Overflow-safe: `checked_add`, `checked_sub` with explicit error variants.
 
+mod events;
+
 use soroban_sdk::{contract, contracterror, contractimpl, contracttype, token, Address, Env};
 
 // ---------------------------------------------------------------------------
@@ -92,6 +94,8 @@ impl CalloraRescue {
         env.storage()
             .instance()
             .set(&DataKey::TotalRescued, &0_i128);
+
+        events::emit_initialized(&env, &admin);
         Ok(())
     }
 
@@ -151,6 +155,16 @@ impl CalloraRescue {
             .ok_or(RescueError::Overflow)?;
         env.storage().instance().set(&DataKey::TotalRescued, &next);
 
+        let payload = events::RescueEvent::new(
+            &env,
+            token.clone(),
+            to.clone(),
+            amount,
+            events::RescueCap::None,
+            next,
+        );
+        events::emit_rescue(&env, &admin, &payload);
+
         Ok(())
     }
 
@@ -205,6 +219,16 @@ impl CalloraRescue {
             .checked_add(amount)
             .ok_or(RescueError::Overflow)?;
         env.storage().instance().set(&DataKey::TotalRescued, &next);
+
+        let payload = events::RescueEvent::new(
+            &env,
+            token.clone(),
+            to.clone(),
+            amount,
+            events::RescueCap::Some(cap),
+            next,
+        );
+        events::emit_rescue_capped(&env, &admin, &payload);
 
         Ok(())
     }
@@ -427,5 +451,300 @@ mod test {
                 .unwrap(),
             RescueError::NotInitialized
         );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Event lifecycle tests
+// ---------------------------------------------------------------------------
+
+/// Integration tests that verify actual event emission from rescue
+/// contract entrypoints. Each test drives the contract through a public
+/// function and inspects `env.events().all()` to assert the correct
+/// topic shape and structured payload.
+#[cfg(test)]
+mod test_events {
+    extern crate std;
+
+    use crate::events::{self, RescueCap};
+    use crate::{CalloraRescue, CalloraRescueClient};
+    use soroban_sdk::testutils::{Address as _, Events as _};
+    use soroban_sdk::{token, Address, Env, IntoVal, Symbol};
+
+    /// Helper: register a Stellar Asset Contract token, mint `amount` to the
+    /// rescue contract, and return the token address.
+    fn create_token(env: &Env, admin: &Address, rescue_addr: &Address, mint_amount: i128) -> Address {
+        let token_addr = env
+            .register_stellar_asset_contract_v2(admin.clone())
+            .address();
+        let token_admin = token::StellarAssetClient::new(env, &token_addr);
+        token_admin.mint(rescue_addr, &mint_amount);
+        token_addr
+    }
+
+    /// `init` must emit exactly one `initialized` event with topic[1]=admin.
+    #[test]
+    fn test_init_emits_initialized_event() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let admin = Address::generate(&env);
+        let cid = env.register(CalloraRescue, ());
+        let c = CalloraRescueClient::new(&env, &cid);
+
+        c.init(&admin);
+
+        let all_events = env.events().all();
+        // Find the last event emitted by this contract.
+        let event = all_events
+            .iter()
+            .rev()
+            .find(|e| e.0 == cid)
+            .expect("expected at least one event from rescue contract");
+
+        let topics = &event.1;
+        assert_eq!(topics.len(), 2);
+        let topic0: Symbol = topics.get(0).unwrap().into_val(&env);
+        let topic1: Address = topics.get(1).unwrap().into_val(&env);
+        assert_eq!(topic0, Symbol::new(&env, "initialized"));
+        assert_eq!(topic1, admin);
+
+        // Payload is the admin address.
+        let data: Address = event.2.into_val(&env);
+        assert_eq!(data, admin);
+    }
+
+    /// Failed `init` (double-init) must NOT emit an `initialized` event.
+    #[test]
+    fn test_double_init_emits_no_second_event() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let admin = Address::generate(&env);
+        let cid = env.register(CalloraRescue, ());
+        let c = CalloraRescueClient::new(&env, &cid);
+
+        c.init(&admin);
+        // Clear events from successful init.
+        env.events().all();
+
+        // Double init should fail.
+        let result = c.try_init(&admin);
+        assert!(result.is_err());
+
+        let all_events = env.events().all();
+        let init_events: std::vec::Vec<_> = all_events
+            .iter()
+            .filter(|e| {
+                if e.0 != cid || e.1.is_empty() {
+                    return false;
+                }
+                let t0: Symbol = e.1.get(0).unwrap().into_val(&env);
+                t0 == Symbol::new(&env, "initialized")
+            })
+            .collect();
+        assert_eq!(init_events.len(), 0, "double init must not emit 'initialized'");
+    }
+
+    /// `rescue` emits exactly one `rescue` event with correct topics and
+    /// a versioned `RescueEvent` payload.
+    #[test]
+    fn test_rescue_emits_rescue_event() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let admin = Address::generate(&env);
+        let cid = env.register(CalloraRescue, ());
+        let c = CalloraRescueClient::new(&env, &cid);
+
+        c.init(&admin);
+
+        let to = Address::generate(&env);
+        let amount: i128 = 500;
+        let token_addr = create_token(&env, &admin, &cid, &amount);
+
+        // Clear init event.
+        env.events().all();
+
+        c.rescue(&admin, &token_addr, &to, &amount);
+
+        let all_events = env.events().all();
+        let event = all_events
+            .iter()
+            .rev()
+            .find(|e| e.0 == cid)
+            .expect("expected rescue event");
+
+        let topics = &event.1;
+        assert_eq!(topics.len(), 3);
+        let topic0: Symbol = topics.get(0).unwrap().into_val(&env);
+        let topic1: Address = topics.get(1).unwrap().into_val(&env);
+        let topic2: Address = topics.get(2).unwrap().into_val(&env);
+        assert_eq!(topic0, Symbol::new(&env, "rescue"));
+        assert_eq!(topic1, admin);
+        assert_eq!(topic2, token_addr);
+
+        // Payload is a RescueEvent.
+        let payload: events::RescueEvent = event.2.into_val(&env);
+        assert_eq!(payload.version, events::RESCUE_EVENT_VERSION);
+        assert_eq!(payload.token, token_addr);
+        assert_eq!(payload.to, to);
+        assert_eq!(payload.amount, amount);
+        assert_eq!(payload.cap, RescueCap::None);
+        assert_eq!(payload.cumulative_rescued, amount);
+        assert_eq!(payload.ledger_sequence, env.ledger().sequence());
+        assert_eq!(payload.timestamp, env.ledger().timestamp());
+    }
+
+    /// `rescue_capped` emits `rescue_capped` event with `cap` populated in
+    /// the payload.
+    #[test]
+    fn test_rescue_capped_emits_rescue_capped_event() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let admin = Address::generate(&env);
+        let cid = env.register(CalloraRescue, ());
+        let c = CalloraRescueClient::new(&env, &cid);
+
+        c.init(&admin);
+
+        let to = Address::generate(&env);
+        let amount: i128 = 500;
+        let cap: i128 = 1000;
+        let token_addr = create_token(&env, &admin, &cid, &amount);
+
+        env.events().all();
+
+        c.rescue_capped(&admin, &token_addr, &to, &amount, &cap);
+
+        let all_events = env.events().all();
+        let event = all_events
+            .iter()
+            .rev()
+            .find(|e| e.0 == cid)
+            .expect("expected rescue_capped event");
+
+        let topics = &event.1;
+        assert_eq!(topics.len(), 3);
+        let topic0: Symbol = topics.get(0).unwrap().into_val(&env);
+        let topic1: Address = topics.get(1).unwrap().into_val(&env);
+        let topic2: Address = topics.get(2).unwrap().into_val(&env);
+        assert_eq!(topic0, Symbol::new(&env, "rescue_capped"));
+        assert_eq!(topic1, admin);
+        assert_eq!(topic2, token_addr);
+
+        let payload: events::RescueEvent = event.2.into_val(&env);
+        assert_eq!(payload.version, events::RESCUE_EVENT_VERSION);
+        assert_eq!(payload.amount, amount);
+        assert_eq!(payload.cap, RescueCap::Some(cap));
+        assert_eq!(payload.cumulative_rescued, amount);
+    }
+
+    /// `cumulative_rescued` must accumulate across multiple rescue calls.
+    #[test]
+    fn test_multiple_rescues_accumulate_cumulative_total() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let admin = Address::generate(&env);
+        let cid = env.register(CalloraRescue, ());
+        let c = CalloraRescueClient::new(&env, &cid);
+
+        c.init(&admin);
+
+        let to = Address::generate(&env);
+        let token_addr = create_token(&env, &admin, &cid, &1000);
+
+        env.events().all();
+
+        // First rescue: 300
+        c.rescue(&admin, &token_addr, &to, &300_i128);
+        // Second rescue: 200
+        c.rescue(&admin, &token_addr, &to, &200_i128);
+
+        let all_events = env.events().all();
+        let rescue_events: std::vec::Vec<_> = all_events
+            .iter()
+            .filter(|e| {
+                if e.0 != cid || e.1.is_empty() {
+                    return false;
+                }
+                let t0: Symbol = e.1.get(0).unwrap().into_val(&env);
+                t0 == Symbol::new(&env, "rescue")
+            })
+            .collect();
+
+        assert_eq!(rescue_events.len(), 2);
+
+        let payload1: events::RescueEvent = rescue_events[0].2.into_val(&env);
+        assert_eq!(payload1.cumulative_rescued, 300);
+
+        let payload2: events::RescueEvent = rescue_events[1].2.into_val(&env);
+        assert_eq!(payload2.cumulative_rescued, 500);
+    }
+
+    /// Failed rescue (invalid amount) must NOT emit a `rescue` event.
+    #[test]
+    fn test_failed_rescue_emits_no_event() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let admin = Address::generate(&env);
+        let cid = env.register(CalloraRescue, ());
+        let c = CalloraRescueClient::new(&env, &cid);
+
+        c.init(&admin);
+
+        let token = Address::generate(&env);
+        let to = Address::generate(&env);
+
+        // Clear init event.
+        env.events().all();
+
+        let result = c.try_rescue(&admin, &token, &to, &0_i128);
+        assert!(result.is_err());
+
+        let all_events = env.events().all();
+        let rescue_events: std::vec::Vec<_> = all_events
+            .iter()
+            .filter(|e| {
+                if e.0 != cid || e.1.is_empty() {
+                    return false;
+                }
+                let t0: Symbol = e.1.get(0).unwrap().into_val(&env);
+                t0 == Symbol::new(&env, "rescue")
+            })
+            .collect();
+        assert_eq!(rescue_events.len(), 0, "failed rescue must not emit 'rescue'");
+    }
+
+    /// Failed `rescue_capped` (amount exceeds cap) must NOT emit an event.
+    #[test]
+    fn test_failed_rescue_capped_emits_no_event() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let admin = Address::generate(&env);
+        let cid = env.register(CalloraRescue, ());
+        let c = CalloraRescueClient::new(&env, &cid);
+
+        c.init(&admin);
+
+        let token_addr = create_token(&env, &admin, &cid, &500);
+        let to = Address::generate(&env);
+
+        // Clear init event.
+        env.events().all();
+
+        // Amount 500 > cap 400 should fail.
+        let result = c.try_rescue_capped(&admin, &token_addr, &to, &500_i128, &400_i128);
+        assert!(result.is_err());
+
+        let all_events = env.events().all();
+        let capped_events: std::vec::Vec<_> = all_events
+            .iter()
+            .filter(|e| {
+                if e.0 != cid || e.1.is_empty() {
+                    return false;
+                }
+                let t0: Symbol = e.1.get(0).unwrap().into_val(&env);
+                t0 == Symbol::new(&env, "rescue_capped")
+            })
+            .collect();
+        assert_eq!(capped_events.len(), 0, "failed rescue_capped must not emit 'rescue_capped'");
     }
 }


### PR DESCRIPTION
closes #711 

Add stable, structured events to the rescue contract so off-chain indexers can reconstruct the complete rescue audit trail without polling storage.

Changes:
- New  module with:
  -  enum (None/Some) to distinguish capped vs uncapped rescues
  -  struct with versioned payload (token, recipient, amount, cap, cumulative total, ledger sequence, timestamp)
  - Topic constructors: , ,
  - Emit helpers: , ,
  - Byte-identity snapshot tests for all three topics
- Modified :
  -  emits  event with admin address
  -  emits  event with structured RescueEvent payload
  -  emits  event with cap in RescueCap::Some
  - All events follow CEI: emitted after state changes
- Integration tests in  verify actual event emission from each entrypoint, including:
  - Topic shape and payload content assertions
  - Cumulative total tracking across multiple rescues
  - No-event-on-failure assertions for double-init and cap-exceeded

Closes #711