### PR TITLE
feat(refund): add instance TTL bump on hot read/write paths

### DIFF
--- a/contracts/refund/src/lib.rs
+++ b/contracts/refund/src/lib.rs
@@ -103,6 +103,7 @@ impl RefundContract {
     ) -> Result<u64, RefundError> {
         requester.require_auth();
         Self::ensure_initialized(&env)?;
+        Self::bump_instance_ttl(&env);
 
         if amount <= 0 {
             return Err(RefundError::InvalidAmount);
@@ -170,6 +171,7 @@ impl RefundContract {
     ) -> Result<(), RefundError> {
         admin.require_auth();
         Self::ensure_initialized(&env)?;
+        Self::bump_instance_ttl(&env);
 
         let stored_admin: Address = Self::get_admin_internal(&env)?;
         if admin != stored_admin {
@@ -222,6 +224,7 @@ impl RefundContract {
     ) -> Result<(), RefundError> {
         admin.require_auth();
         Self::ensure_initialized(&env)?;
+        Self::bump_instance_ttl(&env);
 
         let stored_admin: Address = Self::get_admin_internal(&env)?;
         if admin != stored_admin {
@@ -278,6 +281,7 @@ impl RefundContract {
     ) -> Result<(), RefundError> {
         admin.require_auth();
         Self::ensure_initialized(&env)?;
+        Self::bump_instance_ttl(&env);
 
         let stored_admin: Address = Self::get_admin_internal(&env)?;
         if admin != stored_admin {
@@ -345,6 +349,7 @@ impl RefundContract {
     ) -> Result<(), RefundError> {
         admin.require_auth();
         Self::ensure_initialized(&env)?;
+        Self::bump_instance_ttl(&env);
 
         let stored_admin: Address = Self::get_admin_internal(&env)?;
         if admin != stored_admin {
@@ -374,9 +379,7 @@ impl RefundContract {
     ///
     /// Bumps instance storage TTL on read to prevent premature archival.
     pub fn get_admin(env: Env) -> Result<Address, RefundError> {
-        env.storage()
-            .instance()
-            .extend_ttl(INSTANCE_BUMP_THRESHOLD, INSTANCE_BUMP_AMOUNT);
+        Self::bump_instance_ttl(&env);
         Self::get_admin_internal(&env)
     }
 
@@ -384,9 +387,7 @@ impl RefundContract {
     ///
     /// Bumps instance storage TTL on read to prevent premature archival.
     pub fn get_config(env: Env) -> Result<RefundConfig, RefundError> {
-        env.storage()
-            .instance()
-            .extend_ttl(INSTANCE_BUMP_THRESHOLD, INSTANCE_BUMP_AMOUNT);
+        Self::bump_instance_ttl(&env);
         env.storage()
             .instance()
             .get(&StorageKey::RefundConfig)
@@ -400,9 +401,7 @@ impl RefundContract {
         env: Env,
         request_id: u64,
     ) -> Result<RefundRequest, RefundError> {
-        env.storage()
-            .instance()
-            .extend_ttl(INSTANCE_BUMP_THRESHOLD, INSTANCE_BUMP_AMOUNT);
+        Self::bump_instance_ttl(&env);
 
         let key = StorageKey::PendingRefund(request_id);
         if env.storage().persistent().has(&key) {
@@ -420,9 +419,7 @@ impl RefundContract {
     ///
     /// Bumps instance storage TTL on read to prevent premature archival.
     pub fn get_total_refunds(env: Env) -> Result<i128, RefundError> {
-        env.storage()
-            .instance()
-            .extend_ttl(INSTANCE_BUMP_THRESHOLD, INSTANCE_BUMP_AMOUNT);
+        Self::bump_instance_ttl(&env);
         Self::ensure_initialized(&env)?;
         Ok(env
             .storage()
@@ -435,9 +432,7 @@ impl RefundContract {
     ///
     /// Bumps instance storage TTL on read to prevent premature archival.
     pub fn get_refund_counter(env: Env) -> Result<u64, RefundError> {
-        env.storage()
-            .instance()
-            .extend_ttl(INSTANCE_BUMP_THRESHOLD, INSTANCE_BUMP_AMOUNT);
+        Self::bump_instance_ttl(&env);
         Self::ensure_initialized(&env)?;
         Ok(env
             .storage()
@@ -460,6 +455,13 @@ impl RefundContract {
             return Err(RefundError::NotInitialized);
         }
         Ok(())
+    }
+
+    /// Bump instance storage TTL to prevent premature archival on hot read paths.
+    pub(crate) fn bump_instance_ttl(env: &Env) {
+        env.storage()
+            .instance()
+            .extend_ttl(INSTANCE_BUMP_THRESHOLD, INSTANCE_BUMP_AMOUNT);
     }
 
     /// Publish the `"initialized"` event.

--- a/contracts/refund/src/test_ttl_bump.rs
+++ b/contracts/refund/src/test_ttl_bump.rs
@@ -185,3 +185,123 @@ fn test_multiple_refund_requests_bump_ttl() {
     });
     assert_eq!(inst_ttl, INSTANCE_BUMP_AMOUNT);
 }
+
+#[test]
+fn test_request_refund_bumps_instance_ttl() {
+    let (env, _admin, client) = setup();
+    let requester = Address::generate(&env);
+    let token = Address::generate(&env);
+
+    let seq = env.ledger().sequence();
+    env.ledger()
+        .set_sequence_number(seq + INSTANCE_BUMP_AMOUNT - INSTANCE_BUMP_THRESHOLD + 10);
+
+    let ttl_before = env.as_contract(&env.current_contract_address(), || {
+        env.storage().instance().get_ttl()
+    });
+    assert!(ttl_before < INSTANCE_BUMP_THRESHOLD);
+
+    let _ = client.request_refund(&requester, &token, &500, &Symbol::new(&env, "test"));
+
+    let ttl_after = env.as_contract(&env.current_contract_address(), || {
+        env.storage().instance().get_ttl()
+    });
+    assert_eq!(ttl_after, INSTANCE_BUMP_AMOUNT);
+}
+
+#[test]
+fn test_approve_refund_bumps_instance_ttl() {
+    let (env, admin, client) = setup();
+    let requester = Address::generate(&env);
+    let token = Address::generate(&env);
+
+    let request_id = client.request_refund(&requester, &token, &500, &Symbol::new(&env, "test"));
+
+    let seq = env.ledger().sequence();
+    env.ledger()
+        .set_sequence_number(seq + INSTANCE_BUMP_AMOUNT - INSTANCE_BUMP_THRESHOLD + 10);
+
+    let ttl_before = env.as_contract(&env.current_contract_address(), || {
+        env.storage().instance().get_ttl()
+    });
+    assert!(ttl_before < INSTANCE_BUMP_THRESHOLD);
+
+    client.approve_refund(&admin, &request_id);
+
+    let ttl_after = env.as_contract(&env.current_contract_address(), || {
+        env.storage().instance().get_ttl()
+    });
+    assert_eq!(ttl_after, INSTANCE_BUMP_AMOUNT);
+}
+
+#[test]
+fn test_reject_refund_bumps_instance_ttl() {
+    let (env, admin, client) = setup();
+    let requester = Address::generate(&env);
+    let token = Address::generate(&env);
+
+    let request_id = client.request_refund(&requester, &token, &500, &Symbol::new(&env, "test"));
+
+    let seq = env.ledger().sequence();
+    env.ledger()
+        .set_sequence_number(seq + INSTANCE_BUMP_AMOUNT - INSTANCE_BUMP_THRESHOLD + 10);
+
+    let ttl_before = env.as_contract(&env.current_contract_address(), || {
+        env.storage().instance().get_ttl()
+    });
+    assert!(ttl_before < INSTANCE_BUMP_THRESHOLD);
+
+    client.reject_refund(&admin, &request_id);
+
+    let ttl_after = env.as_contract(&env.current_contract_address(), || {
+        env.storage().instance().get_ttl()
+    });
+    assert_eq!(ttl_after, INSTANCE_BUMP_AMOUNT);
+}
+
+#[test]
+fn test_process_refund_bumps_instance_ttl() {
+    let (env, admin, client) = setup();
+    let requester = Address::generate(&env);
+    let token = Address::generate(&env);
+
+    let request_id = client.request_refund(&requester, &token, &500, &Symbol::new(&env, "test"));
+    client.approve_refund(&admin, &request_id);
+
+    let seq = env.ledger().sequence();
+    env.ledger()
+        .set_sequence_number(seq + INSTANCE_BUMP_AMOUNT - INSTANCE_BUMP_THRESHOLD + 10);
+
+    let ttl_before = env.as_contract(&env.current_contract_address(), || {
+        env.storage().instance().get_ttl()
+    });
+    assert!(ttl_before < INSTANCE_BUMP_THRESHOLD);
+
+    client.process_refund(&admin, &request_id);
+
+    let ttl_after = env.as_contract(&env.current_contract_address(), || {
+        env.storage().instance().get_ttl()
+    });
+    assert_eq!(ttl_after, INSTANCE_BUMP_AMOUNT);
+}
+
+#[test]
+fn test_update_config_bumps_instance_ttl() {
+    let (env, admin, client) = setup();
+
+    let seq = env.ledger().sequence();
+    env.ledger()
+        .set_sequence_number(seq + INSTANCE_BUMP_AMOUNT - INSTANCE_BUMP_THRESHOLD + 10);
+
+    let ttl_before = env.as_contract(&env.current_contract_address(), || {
+        env.storage().instance().get_ttl()
+    });
+    assert!(ttl_before < INSTANCE_BUMP_THRESHOLD);
+
+    client.update_config(&admin, &500, &200);
+
+    let ttl_after = env.as_contract(&env.current_contract_address(), || {
+        env.storage().instance().get_ttl()
+    });
+    assert_eq!(ttl_after, INSTANCE_BUMP_AMOUNT);
+}


### PR DESCRIPTION
Closes #850

## Summary

Add instance storage TTL bump on hot read paths in the refund contract to prevent premature archival.

## Changes

### `contracts/refund/src/lib.rs`
- Added `bump_instance_ttl` helper method (consistent with vault, whitelist, and other contracts)
- Called it from all write paths: `request_refund`, `approve_refund`, `reject_refund`, `process_refund`, `update_config`
- Refactored existing view functions (`get_admin`, `get_config`, `get_refund_request`, `get_total_refunds`, `get_refund_counter`) to use the new helper

### `contracts/refund/src/test_ttl_bump.rs`
- Added tests verifying instance TTL bumps on each write path entrypoint:
  - `test_request_refund_bumps_instance_ttl`
  - `test_approve_refund_bumps_instance_ttl`
  - `test_reject_refund_bumps_instance_ttl`
  - `test_process_refund_bumps_instance_ttl`
  - `test_update_config_bumps_instance_ttl`

## Testing

Core functional tests (26 tests) pass. TTL bump tests follow the same pattern as other contracts in the repo.