### PR TITLE
fix(fee): validate fee recipients before value-moving operations

### DIFF
--- a/contracts/fee/src/errors.rs
+++ b/contracts/fee/src/errors.rs
@@ -19,4 +19,6 @@ pub enum ContractError {
     FeeTooHigh = 6,
     /// Insufficient balance to satisfy the request.
     InsufficientBalance = 7,
+    /// Recipient address is invalid (contract itself or zero address).
+    InvalidRecipient = 8,
 }

--- a/contracts/fee/src/lib.rs
+++ b/contracts/fee/src/lib.rs
@@ -8,6 +8,10 @@ pub use errors::ContractError;
 /// Maximum fee rate in basis points (100% = 10_000 bps).
 const MAX_BASIS_POINTS: u32 = 10_000;
 
+/// StrKey of the zero contract address (all 32 bytes are zero).
+/// Rejected as a fee-withdrawal destination to avoid burning accumulated fees.
+const ZERO_CONTRACT_ADDRESS: &str = "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABSC4";
+
 /// Storage key for the fee configuration.
 #[contracttype]
 pub enum DataKey {
@@ -107,6 +111,25 @@ impl FeeContract {
         Ok(())
     }
 
+    /// Validate that a recipient is a legitimate destination for withdrawn fees.
+    ///
+    /// Rejects the contract's own address (which would self-credit accumulated
+    /// fees) and the zero address (which would burn them), ensuring the check
+    /// runs before any value moves. See [`Self::withdraw`].
+    ///
+    /// # Errors
+    /// - `InvalidRecipient` if `recipient` is the contract itself or the zero address.
+    fn validate_recipient(env: &Env, recipient: &Address) -> Result<(), ContractError> {
+        if recipient == &env.current_contract_address() {
+            return Err(ContractError::InvalidRecipient);
+        }
+        let zero = Address::from_str(env, ZERO_CONTRACT_ADDRESS);
+        if recipient == &zero {
+            return Err(ContractError::InvalidRecipient);
+        }
+        Ok(())
+    }
+
     /// Withdraw accumulated fees to a recipient.
     ///
     /// # Arguments
@@ -118,6 +141,7 @@ impl FeeContract {
     /// - `NotInitialized` if the contract is not initialised.
     /// - `Unauthorized` if the caller is not the stored admin.
     /// - `InvalidAmount` if `amount` is not positive.
+    /// - `InvalidRecipient` if `recipient` is the contract itself or the zero address.
     /// - `InsufficientBalance` if accumulated fees are less than `amount`.
     /// - `Overflow` if the remaining balance would underflow.
     pub fn withdraw(env: Env, admin: Address, recipient: Address, amount: i128) -> Result<(), ContractError> {
@@ -131,6 +155,7 @@ impl FeeContract {
         if amount <= 0 {
             return Err(ContractError::InvalidAmount);
         }
+        Self::validate_recipient(&env, &recipient)?;
 
         let accumulated: i128 = env.storage().instance().get(&DataKey::Accumulated)
             .unwrap_or(0);
@@ -357,5 +382,70 @@ mod test {
             client.try_deposit(&caller, &1).unwrap_err().unwrap(),
             ContractError::Overflow
         );
+    }
+
+    #[test]
+    fn test_withdraw_to_contract_self_fails() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let contract_id = env.register_contract(None, FeeContract);
+        let client = FeeContractClient::new(&env, &contract_id);
+        let admin = Address::generate(&env);
+        let caller = Address::generate(&env);
+
+        client.init(&admin);
+        client.deposit(&caller, &1000);
+
+        assert_eq!(
+            client
+                .try_withdraw(&admin, &contract_id, &400)
+                .unwrap_err()
+                .unwrap(),
+            ContractError::InvalidRecipient
+        );
+        assert_eq!(client.get_accumulated(), 1000);
+    }
+
+    #[test]
+    fn test_withdraw_to_zero_address_fails() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let contract_id = env.register_contract(None, FeeContract);
+        let client = FeeContractClient::new(&env, &contract_id);
+        let admin = Address::generate(&env);
+        let caller = Address::generate(&env);
+
+        client.init(&admin);
+        client.deposit(&caller, &1000);
+
+        let zero = Address::from_str(&env, ZERO_CONTRACT_ADDRESS);
+        assert_eq!(
+            client
+                .try_withdraw(&admin, &zero, &400)
+                .unwrap_err()
+                .unwrap(),
+            ContractError::InvalidRecipient
+        );
+        assert_eq!(client.get_accumulated(), 1000);
+    }
+
+    #[test]
+    fn test_withdraw_to_valid_recipient_succeeds() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let contract_id = env.register_contract(None, FeeContract);
+        let client = FeeContractClient::new(&env, &contract_id);
+        let admin = Address::generate(&env);
+        let caller = Address::generate(&env);
+        let recipient = Address::generate(&env);
+
+        client.init(&admin);
+        client.deposit(&caller, &1000);
+
+        client.withdraw(&admin, &recipient, &400);
+        assert_eq!(client.get_accumulated(), 600);
     }
 }

--- a/contracts/fee/tests/err_stab.rs
+++ b/contracts/fee/tests/err_stab.rs
@@ -11,4 +11,5 @@ fn test_fee_error_stability() {
     assert_eq!(ContractError::Overflow as u32, 5);
     assert_eq!(ContractError::FeeTooHigh as u32, 6);
     assert_eq!(ContractError::InsufficientBalance as u32, 7);
+    assert_eq!(ContractError::InvalidRecipient as u32, 8);
 }


### PR DESCRIPTION
Closes #1061

## Summary
Validates the fee recipient in `FeeContract::withdraw` **before** the accumulated-fee balance is decremented. Previously `recipient` was completely unvalidated: an admin could withdraw to the contract itself (self-crediting accumulated fees) or to the zero/burn address, while the `fee_withdrawn` event claimed the fees went to that recipient.

## Security boundary (failure-mode handling)
- `withdraw` now rejects two invalid destinations up front, strictly before the `checked_sub` mutation:
  - **Contract self** - prevents self-crediting the fee balance (`InvalidRecipient`).
  - **Zero address** (all-zero contract id, StrKey `CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABSC4`) - prevents burning accumulated fees (`InvalidRecipient`).
- All checks are additive and run after the existing `admin.require_auth()` + stored-admin equality + `amount > 0` checks, so authorization and least-privilege are unchanged and nothing is weakened.
- No state is mutated on invalid input; errors carry no raw recipient data (no secret/detail leakage).

## Acceptance-criteria mapping
- **Validation runs before sensitive mutation**: `Self::validate_recipient` is called at the top of `withdraw`, before any storage write (`contracts/fee/src/lib.rs`).
- **Invalid/malformed inputs fail closed**: self and zero-address recipients return `ContractError::InvalidRecipient` with zero state change.
- **Negative/adversarial tests**: `test_withdraw_to_contract_self_fails` and `test_withdraw_to_zero_address_fails` assert both rejection and that `get_accumulated()` is unchanged; `test_withdraw_to_valid_recipient_succeeds` covers the positive path; `err_stab.rs` pins the new error code (`InvalidRecipient = 8`).

## Validation results
- `cargo test -p callora-fee` - 22 passed (13 lib, 8 auth_snap, 1 err_stab).
- `cargo fmt -p callora-fee -- --check` - no new formatting violations (only pre-existing repo-wide deviations remain).
- `cargo clippy -p callora-fee --all-targets -- -D warnings` - no new warnings (only pre-existing `register_contract` deprecations shared by the whole crate).