### PR TITLE
fix: enforce cross-contract caller identity at the registry↔catalog trust boundary (#1060)

### DIFF
--- a/contracts/registry/src/catalog.rs
+++ b/contracts/registry/src/catalog.rs
@@ -4,6 +4,22 @@
 //! persists offering metadata (for example an on-chain catalog or vault hook).
 //! Integration tests swap in mock callees that revert or panic to exercise
 //! cross-contract failure safety.
+//!
+//! # Cross-contract trust boundary (issue #1060)
+//!
+//! `registry` is the address of the contract performing the cross-contract
+//! call. A catalog implementation **must** treat this as a caller-supplied
+//! identity and enforce it before recording anything: the first statement of
+//! `put_offering` must be `registry.require_auth()`. That check succeeds only
+//! when the invocation actually originates from the registry contract (the
+//! host authorizes the immediate contract caller), and fails closed for any
+//! other caller — including a spoofing contract that passes the registry's
+//! address as an argument. Without this check any contract could call the
+//! catalog directly with an arbitrary `registry` value and inject unverified
+//! offering metadata at a trust boundary.
+//!
+//! See `contracts/registry/tests/xcontract.rs` (`identity_catalog`) for a
+//! reference implementation and adversarial coverage of this boundary.
 
 use soroban_sdk::{contractclient, Address, Env, String};
 
@@ -11,5 +27,9 @@ use soroban_sdk::{contractclient, Address, Env, String};
 #[contractclient(name = "OfferingCatalogClient")]
 pub trait OfferingCatalog {
     /// Publish or anchor `metadata` for `offering_id` on behalf of `registry`.
+    ///
+    /// # Security requirement
+    /// Implementations MUST call `registry.require_auth()` before any state
+    /// mutation or event, so only the real registry contract can publish.
     fn put_offering(env: Env, registry: Address, offering_id: String, metadata: String);
 }

--- a/contracts/registry/tests/xcontract.rs
+++ b/contracts/registry/tests/xcontract.rs
@@ -17,7 +17,7 @@ extern crate std;
 use callora_registry::{CalloraRegistry, CalloraRegistryClient, RegistryError};
 use soroban_sdk::testutils::Address as _;
 use soroban_sdk::token;
-use soroban_sdk::{contract, contractimpl, Address, Env, String};
+use soroban_sdk::{contract, contractimpl, Address, Env, String, Symbol};
 
 // ---------------------------------------------------------------------------
 // Mock callees - each in separate modules to avoid symbol conflicts
@@ -75,6 +75,38 @@ pub mod revert_catalog {
             _metadata: String,
         ) {
             panic!("catalog callee revert");
+        }
+    }
+}
+
+/// Catalog that enforces the cross-contract caller identity contract from
+/// `catalog.rs` (issue #1060): `registry.require_auth()` must succeed before
+/// anything is recorded. This is the reference implementation of what a
+/// production catalog must do.
+pub mod identity_catalog {
+    use super::*;
+
+    #[contract]
+    pub struct IdentityCatalog;
+
+    #[contractimpl]
+    impl IdentityCatalog {
+        pub fn put_offering(env: Env, registry: Address, _offering_id: String, _metadata: String) {
+            // Identity check FIRST: only the real registry contract may
+            // publish. A spoofing caller that passes the registry address as
+            // an argument does not satisfy this check and fails closed.
+            registry.require_auth();
+            let key = Symbol::new(&env, "published");
+            let count: u32 = env.storage().instance().get(&key).unwrap_or(0);
+            env.storage().instance().set(&key, &(count + 1));
+        }
+
+        /// Number of offerings successfully published (identity-verified).
+        pub fn published_count(env: Env) -> u32 {
+            env.storage()
+                .instance()
+                .get(&Symbol::new(&env, "published"))
+                .unwrap_or(0)
         }
     }
 }
@@ -290,4 +322,58 @@ fn balance_gate_insufficient_balance_does_not_call_catalog() {
 
     assert_eq!(client.registered_count(), 0);
     assert!(!client.is_offering_registered(&oid));
+}
+
+// ---------------------------------------------------------------------------
+// Cross-contract caller identity (issue #1060)
+// ---------------------------------------------------------------------------
+//
+// The catalog is a trust boundary: it must only accept `put_offering` calls
+// that genuinely originate from the registry contract. `registry.require_auth()`
+// is the identity check — it succeeds only when the immediate caller is the
+// registry (the host authorizes the contract caller) and fails closed for any
+// other caller, even one that passes the registry's address as an argument.
+
+/// A spoofing caller (here, the test acting as an external account) that
+/// passes the real registry's address as `registry` must be rejected by an
+/// identity-enforcing catalog, and nothing may be recorded.
+#[test]
+fn identity_enforcing_catalog_rejects_spoofed_registry() {
+    let env = Env::default();
+    let catalog = env.register(identity_catalog::IdentityCatalog, ());
+    let registry_addr = env.register(CalloraRegistry, ());
+    let catalog_client = identity_catalog::IdentityCatalogClient::new(&env, &catalog);
+
+    let oid = offering_id(&env, "spoof");
+    let meta = metadata(&env);
+
+    // Deliberately no `mock_all_auths()`: an external caller invoking the
+    // catalog directly with the registry's address is NOT the registry.
+    let result = catalog_client.try_put_offering(&registry_addr, &oid, &meta);
+    assert!(
+        result.is_err(),
+        "catalog must reject a caller that is not the registry contract"
+    );
+    // Fail closed: nothing was recorded at the boundary.
+    assert_eq!(catalog_client.published_count(), 0);
+}
+
+/// The real registry can still publish through an identity-enforcing catalog:
+/// its own cross-contract call satisfies `registry.require_auth()`.
+#[test]
+fn registry_publishes_through_identity_enforcing_catalog() {
+    let env = Env::default();
+    let catalog_id = env.register(identity_catalog::IdentityCatalog, ());
+    let (admin, client, developer) = setup_registry(&env, catalog_id.clone());
+
+    let oid = offering_id(&env, "real");
+    let meta = metadata(&env);
+
+    client.register_offering(&admin, &developer, &oid, &meta);
+
+    assert_eq!(client.registered_count(), 1);
+    assert!(client.is_offering_registered(&oid));
+    // The identity-enforcing catalog recorded exactly one verified offering.
+    let catalog_client = identity_catalog::IdentityCatalogClient::new(&env, &catalog_id);
+    assert_eq!(catalog_client.published_count(), 1);
 }


### PR DESCRIPTION
## What this fixes

Closes #1060 — "audit cross-contract trust boundaries" (caller identity). Every cross-contract boundary in the workspace must verify that the caller is the contract it claims to be, so a spoofing contract cannot impersonate a trusted caller by passing its address as an argument.

## Root cause

The audit traced every production cross-contract call boundary in the workspace:

- **vault → settlement** (`record_deduction`): settlement already enforces `vault.require_auth()` — the host authenticates the *immediate* contract caller, so only the real vault can record deductions. ✅
- **settlement → USDC token** (`withdraw_developer_balance`): token transfers are made from the settlement contract's own address (`token::Client::new(&env, &usdc_address).transfer(&contract_address, ...)`) — no caller-supplied callee identity. ✅
- **registry → catalog** (`put_offering(registry, offering_id, metadata)`): the catalog is an *external* contract (only mock implementations live in-repo), and the `registry` argument is **caller-supplied identity**. This is the one boundary where a spoofing contract could invoke the catalog directly with an arbitrary `registry` value and inject unverified offering metadata — the callee has no way to tell the real registry from an impostor unless it checks the identity itself. ❌

## The fix and why

Document and enforce the identity contract at the registry↔catalog boundary:

1. **Document the trust contract** on the `OfferingCatalog` trait (`contracts/registry/src/catalog.rs`): implementations MUST call `registry.require_auth()` as the first statement of `put_offering`. That call succeeds only when the invocation genuinely originates from the registry contract (the host authorizes the immediate caller) and fails closed for every other caller — including a spoofing contract passing the registry's real address as an argument.
2. **Add a reference identity-enforcing catalog** and adversarial tests (`contracts/registry/tests/xcontract.rs`):
   - `identity_enforcing_catalog_rejects_spoofed_registry` — a non-registry caller invoking `put_offering` with the registry's real address is rejected and records nothing;
   - `registry_publishes_through_identity_enforcing_catalog` — the real registry still publishes successfully through the identity-enforcing catalog.

Why this approach: the repo's own hardened boundary (settlement's `vault.require_auth()`) shows the correct pattern — enforcement belongs on the *callee* side, not the caller side. Mirroring that pattern at the catalog boundary, plus making it a documented trait contract with tests, closes the trust gap and gives every current and future catalog implementation an unambiguous, test-enforced requirement. No production behavior is weakened; the registry's own cross-contract flow is unchanged.

## How it was tested

- `cargo test -p callora-registry` → **41 passed** (2 unit + 5 auth + 12 metadata + 15 overflow_safe + 7 xcontract), including the 2 new identity tests.
- The new catalog mock is exercised through the real Soroban auth framework (no `mock_all_auths` on the adversarial test), so the rejection genuinely exercises `require_auth` semantics.
- Changed files pass `rustfmt --check`.

## Follow-ups worth filing separately

- The workspace has no *production* catalog contract — only mocks. When a real catalog is deployed, it must implement the documented `registry.require_auth()` requirement; consider a contract-level CI check that greps catalog implementations for the guard.
- `main` carries pre-existing breakage in other crates (settlement duplicate `pub mod errors;`, distribute generics-in-contract-fn, validators/settlement stale proptests) — a repair-main-CI issue would unblock full-workspace validation.