### PR TITLE
fix: bound gas and resource limits for settlement entry points (#1069)

### DIFF
--- a/contracts/settlement/src/archive.rs
+++ b/contracts/settlement/src/archive.rs
@@ -35,6 +35,10 @@ pub const ARCHIVE_TTL_LEDGERS: u32 = 3_110_400; // ~6 months
 pub fn archive_events(env: &Env, developer: Address, batch_size: u32) -> u32 {
     developer.require_auth();
 
+    // Cap the per-call batch so loop iterations and storage writes stay within
+    // a predictable resource budget regardless of the caller-supplied value.
+    let batch_size = batch_size.min(crate::MAX_BATCH_SIZE);
+
     let cursor_key = DataKey::Cursor(developer.clone());
 
     // Retrieve cursor or initialize a default instance. No unwraps permitted.
@@ -159,6 +163,55 @@ mod tests {
         // Will panic as auth is not mocked
         env.as_contract(&contract_id, || {
             archive_events(&env, developer, 1);
+        });
+    }
+}
+
+// Gas/resource regression (issue #1069): the per-call batch must be capped so
+// the caller-supplied `batch_size` cannot drive unbounded loop iterations or
+// storage writes.
+#[cfg(test)]
+mod gas_cap_test {
+    use super::*;
+    use crate::CalloraSettlement;
+    use soroban_sdk::testutils::Address as _;
+
+    #[test]
+    fn archive_events_batch_size_is_capped() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let developer = Address::generate(&env);
+        let contract_id = env.register(CalloraSettlement, ());
+
+        let cursor_key = DataKey::Cursor(developer.clone());
+
+        env.as_contract(&contract_id, || {
+            // Seed more pending events than any single call may process.
+            let pending = crate::MAX_BATCH_SIZE as u64 + 10;
+            for i in 0..pending {
+                let active_key = DataKey::ActiveEvent(developer.clone(), i);
+                env.storage()
+                    .persistent()
+                    .set(&active_key, &Bytes::from_slice(&env, &[i as u8]));
+            }
+            env.storage().persistent().set(
+                &cursor_key,
+                &Cursor {
+                    tail: 0,
+                    head: pending,
+                },
+            );
+        });
+
+        // Even a huge caller-supplied batch must stop at the cap.
+        let archived = env.as_contract(&contract_id, || {
+            archive_events(&env, developer.clone(), u32::MAX)
+        });
+        assert_eq!(archived, crate::MAX_BATCH_SIZE);
+
+        env.as_contract(&contract_id, || {
+            let cursor: Cursor = env.storage().persistent().get(&cursor_key).unwrap();
+            assert_eq!(cursor.tail, crate::MAX_BATCH_SIZE as u64);
         });
     }
 }

--- a/contracts/settlement/src/batch.rs
+++ b/contracts/settlement/src/batch.rs
@@ -48,9 +48,11 @@ pub fn batch_settle(env: &Env, settlements: Vec<SettleInput>) -> Vec<SettleOutco
         return outcomes;
     }
 
-    // Explicit per-claimant authorization and cross-tenant validation before mutation
+    // Cross-tenant validation before mutation: every item must belong to the
+    // same claimant. Per-item authorization is enforced inside
+    // `withdraw_developer_balance` (each item requires the claimant's auth), so
+    // no extra top-level `require_auth` is needed here.
     let claimant = settlements.get_unchecked(0).developer.clone();
-    claimant.require_auth();
 
     for input in settlements.iter() {
         if input.developer != claimant {

--- a/contracts/settlement/src/errors.rs
+++ b/contracts/settlement/src/errors.rs
@@ -41,6 +41,15 @@ use soroban_sdk::contracterror;
 /// | 31   | DeveloperNotFrozen            | Developer is not frozen; cannot unfreeze             |
 /// | 32   | FreezeUnauthorized            | Caller is not authorized to freeze/unfreeze           |
 /// | 33   | WriteRateLimitExceeded       | Admin wrote prices too frequently                    |
+/// | 34   | InvalidConfigDistinct        | Init config requires distinct admin and vault        |
+/// | 35   | InvalidConfigAdminContract   | Init config forbids the admin being the contract     |
+/// | 36   | InvalidConfigVaultContract   | Init config forbids the vault being the contract     |
+/// | 37   | InvalidUsdcToken             | USDC token address is invalid                        |
+/// | 38   | InvalidRecipient             | Withdrawal recipient cannot be the contract          |
+/// | 39   | NoAdminTransferPending       | No admin transfer is pending                         |
+/// | 40   | InvalidVault                 | Vault address is invalid                             |
+/// | 41   | NoVaultRotationPending       | No vault rotation is pending                         |
+/// | 42   | BroadcastMessageTooLong      | Admin broadcast message exceeds the maximum length   |
 #[contracterror]
 #[derive(Clone, Copy, Debug, PartialEq)]
 #[repr(u32)]
@@ -90,4 +99,6 @@ pub enum SettlementError {
     NoAdminTransferPending = 39,
     InvalidVault = 40,
     NoVaultRotationPending = 41,
+    /// Admin broadcast message exceeds the maximum allowed length.
+    BroadcastMessageTooLong = 42,
 }

--- a/contracts/settlement/src/lib.rs
+++ b/contracts/settlement/src/lib.rs
@@ -3,10 +3,8 @@ pub mod admin;
 pub mod archive;
 pub mod batch;
 pub mod errors;
-pub mod errors;
 pub mod events;
 
-use crate::errors::SettlementError;
 pub mod freeze;
 pub mod limits;
 pub mod migrate;
@@ -23,6 +21,12 @@ pub const MAX_BATCH_SIZE: u32 = 50;
 
 /// Maximum number of developer balances returned per page in paginated queries.
 pub const MAX_DEVELOPER_BALANCES_PAGE_SIZE: u32 = 100;
+
+/// Maximum byte length of an admin broadcast message.
+///
+/// Keeps per-call resource consumption (event payload size, transaction size)
+/// bounded and predictable for a public admin entry point.
+pub const MAX_BROADCAST_MESSAGE_LEN: u32 = 1024;
 
 pub use errors::SettlementError;
 pub use migrate::{STORAGE_VERSION_V1, STORAGE_VERSION_V2};
@@ -596,7 +600,10 @@ impl CalloraSettlement {
             .persistent()
             .extend_ttl(&balance_key, 50000, 50000);
 
-        daily.amount = daily.amount.checked_add(amount).ok_or(SettlementError::DailyWithdrawCapExceeded)?;
+        daily.amount = daily
+            .amount
+            .checked_add(amount)
+            .ok_or(SettlementError::DailyWithdrawCapExceeded)?;
         env.storage().persistent().set(&today_key, &daily);
         env.storage()
             .persistent()
@@ -1255,6 +1262,9 @@ impl CalloraSettlement {
         if caller != admin {
             env.panic_with_error(SettlementError::Unauthorized);
         }
+        if message.len() > MAX_BROADCAST_MESSAGE_LEN {
+            env.panic_with_error(SettlementError::BroadcastMessageTooLong);
+        }
         events::emit_admin_broadcast(&env, &caller, AdminBroadcast { severity, message });
     }
 
@@ -1340,6 +1350,9 @@ impl CalloraSettlement {
         let count = developers.len();
         if count != amounts.len() {
             return Err(SettlementError::AmountNotPositive);
+        }
+        if count > MAX_BATCH_SIZE {
+            return Err(SettlementError::BatchTooLarge);
         }
         Ok((0, true))
     }

--- a/contracts/settlement/src/test_error_codes.rs
+++ b/contracts/settlement/src/test_error_codes.rs
@@ -33,6 +33,21 @@ fn settlement_error_codes_are_stable_and_unique() {
         (25, SettlementError::ClaimWindowClosed),
         (26, SettlementError::MinBalanceViolation),
         (27, SettlementError::ReplayDetected),
+        (28, SettlementError::BatchEmpty),
+        (29, SettlementError::BatchTooLarge),
+        (30, SettlementError::DeveloperFrozen),
+        (31, SettlementError::DeveloperNotFrozen),
+        (32, SettlementError::FreezeUnauthorized),
+        (33, SettlementError::WriteRateLimitExceeded),
+        (34, SettlementError::InvalidConfigDistinct),
+        (35, SettlementError::InvalidConfigAdminContract),
+        (36, SettlementError::InvalidConfigVaultContract),
+        (37, SettlementError::InvalidUsdcToken),
+        (38, SettlementError::InvalidRecipient),
+        (39, SettlementError::NoAdminTransferPending),
+        (40, SettlementError::InvalidVault),
+        (41, SettlementError::NoVaultRotationPending),
+        (42, SettlementError::BroadcastMessageTooLong),
     ];
 
     let mut seen = BTreeSet::new();
@@ -44,7 +59,7 @@ fn settlement_error_codes_are_stable_and_unique() {
         );
     }
 
-    assert_eq!(seen.len(), 27);
+    assert_eq!(seen.len(), 42);
 }
 
 #[test]
@@ -78,6 +93,21 @@ fn error_code_docs_list_every_settlement_code() {
         "| 25 | `ClaimWindowClosed` | Settlement | Developer claim window is not currently open |",
         "| 26 | `MinBalanceViolation` | Settlement | Withdrawal would leave balance below the minimum |",
         "| 27 | `ReplayDetected` | Settlement | Settlement request reused or regressed the replay-guard ledger sequence |",
+        "| 28 | `BatchEmpty` | Settlement | Batch operation received an empty vector |",
+        "| 29 | `BatchTooLarge` | Settlement | Batch operation exceeded the maximum allowed size |",
+        "| 30 | `DeveloperFrozen` | Settlement | Developer is frozen and cannot withdraw |",
+        "| 31 | `DeveloperNotFrozen` | Settlement | Developer is not frozen; cannot unfreeze |",
+        "| 32 | `FreezeUnauthorized` | Settlement | Caller is not authorized to freeze/unfreeze |",
+        "| 33 | `WriteRateLimitExceeded` | Settlement | Admin wrote prices too frequently |",
+        "| 34 | `InvalidConfigDistinct` | Settlement | Init config requires distinct admin and vault |",
+        "| 35 | `InvalidConfigAdminContract` | Settlement | Init config forbids the admin being the contract |",
+        "| 36 | `InvalidConfigVaultContract` | Settlement | Init config forbids the vault being the contract |",
+        "| 37 | `InvalidUsdcToken` | Settlement | USDC token address is invalid |",
+        "| 38 | `InvalidRecipient` | Settlement | Withdrawal recipient cannot be the contract |",
+        "| 39 | `NoAdminTransferPending` | Settlement | No admin transfer is pending |",
+        "| 40 | `InvalidVault` | Settlement | Vault address is invalid |",
+        "| 41 | `NoVaultRotationPending` | Settlement | No vault rotation is pending |",
+        "| 42 | `BroadcastMessageTooLong` | Settlement | Admin broadcast message exceeds the maximum length |",
     ];
 
     for line in expected_lines {

--- a/contracts/settlement/tests/gas_regression.rs
+++ b/contracts/settlement/tests/gas_regression.rs
@@ -1,0 +1,378 @@
+#![cfg(test)]
+
+//! Gas / resource regression limits for settlement entry points (issue #1069).
+//!
+//! These tests pin the resource budget of the looping/batch entry points so
+//! that input size, batch size, loops, and storage growth stay bounded and
+//! predictable for both normal and adversarial inputs. They measure the
+//! instruction (CPU) and memory consumed by representative calls using the
+//! Soroban host budget tracker and fail if a call exceeds its documented
+//! ceiling or if a failure path leaves partial state behind.
+//!
+//! Ceilings are "representative budgets" with ~2x headroom over the measured
+//! native-test cost, per the SDK caveat that native test runs underestimate
+//! WASM cost. They are intentionally loose enough to avoid CI flake while
+//! still catching regressions that multiply cost (e.g. unbounded loops, batch
+//! caps removed, per-item scans reintroduced).
+
+extern crate std;
+
+use callora_settlement::{CalloraSettlement, CalloraSettlementClient, SettlementError};
+use soroban_sdk::testutils::Address as _;
+use soroban_sdk::{Address, Env, String, Vec};
+
+// ─── Documented resource budgets (CPU instructions / memory bytes) ──────────
+
+/// Ceiling for a single-item `batch_receive_payment` (measured ~172k / ~26k).
+const BRP_ONE_CPU_CEILING: u64 = 400_000;
+const BRP_ONE_MEM_CEILING: u64 = 60_000;
+
+/// Ceiling for a max-size (50-item) `batch_receive_payment` (measured ~10.8M / ~2.1M).
+const BRP_MAX_CPU_CEILING: u64 = 22_000_000;
+const BRP_MAX_MEM_CEILING: u64 = 4_200_000;
+
+/// Hard budget enforced for a max-size batch: the call must fit or the test fails.
+const BRP_MAX_CPU_BUDGET: u64 = 25_000_000;
+const BRP_MAX_MEM_BUDGET: u64 = 5_000_000;
+
+/// Ceiling for a single-item `batch_settle` (measured ~74k / ~10k).
+const BS_ONE_CPU_CEILING: u64 = 200_000;
+const BS_ONE_MEM_CEILING: u64 = 30_000;
+
+/// Ceiling for an over-cap (65-item) `batch_settle` rejection (measured ~239k / ~38k).
+const BS_OVER_CAP_CPU_CEILING: u64 = 600_000;
+const BS_OVER_CAP_MEM_CEILING: u64 = 100_000;
+
+/// Ceiling for a full-page (100-record) paginated read (measured ~4.1M / ~0.5M).
+const PAGE_CPU_CEILING: u64 = 10_000_000;
+const PAGE_MEM_CEILING: u64 = 1_200_000;
+
+/// Ceiling for cheap rejection paths (over-limit / invalid input).
+const REJECT_CPU_CEILING: u64 = 500_000;
+const REJECT_MEM_CEILING: u64 = 80_000;
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+fn setup(env: &Env) -> (Address, Address, CalloraSettlementClient<'_>) {
+    env.mock_all_auths();
+    let admin = Address::generate(env);
+    let vault = Address::generate(env);
+    let contract_id = env.register(CalloraSettlement, ());
+    let client = CalloraSettlementClient::new(env, &contract_id);
+    client.init(&admin, &vault);
+    (admin, vault, client)
+}
+
+// ─── batch_receive_payment ──────────────────────────────────────────────────
+
+#[test]
+fn batch_receive_payment_single_item_within_budget() {
+    let env = Env::default();
+    let (_admin, vault, client) = setup(&env);
+    let token = Address::generate(&env);
+    let dev = Address::generate(&env);
+
+    let mut items = Vec::new(&env);
+    items.push_back((dev.clone(), 100_i128));
+
+    env.budget().reset_tracker();
+    client.batch_receive_payment(&vault, &items, &token, &1);
+    let used_cpu = env.budget().cpu_instruction_cost();
+    let used_mem = env.budget().memory_bytes_cost();
+
+    assert!(
+        used_cpu <= BRP_ONE_CPU_CEILING,
+        "single-item batch_receive_payment exceeded CPU ceiling: {used_cpu} > {BRP_ONE_CPU_CEILING}"
+    );
+    assert!(
+        used_mem <= BRP_ONE_MEM_CEILING,
+        "single-item batch_receive_payment exceeded memory ceiling: {used_mem} > {BRP_ONE_MEM_CEILING}"
+    );
+    assert_eq!(client.get_developer_balance(&dev, &token), 100);
+}
+
+#[test]
+fn batch_receive_payment_max_batch_within_budget() {
+    let env = Env::default();
+    let (_admin, vault, client) = setup(&env);
+    let token = Address::generate(&env);
+
+    let mut items = Vec::new(&env);
+    for _ in 0..50 {
+        items.push_back((Address::generate(&env), 100_i128));
+    }
+
+    // Enforce the documented budget: exceeding it aborts the test.
+    env.budget()
+        .reset_limits(BRP_MAX_CPU_BUDGET, BRP_MAX_MEM_BUDGET);
+    env.budget().reset_tracker();
+    client.batch_receive_payment(&vault, &items, &token, &1);
+    let used_cpu = env.budget().cpu_instruction_cost();
+    let used_mem = env.budget().memory_bytes_cost();
+
+    assert!(
+        used_cpu <= BRP_MAX_CPU_CEILING,
+        "max batch_receive_payment exceeded CPU ceiling: {used_cpu} > {BRP_MAX_CPU_CEILING}"
+    );
+    assert!(
+        used_mem <= BRP_MAX_MEM_CEILING,
+        "max batch_receive_payment exceeded memory ceiling: {used_mem} > {BRP_MAX_MEM_CEILING}"
+    );
+}
+
+#[test]
+fn batch_receive_payment_over_limit_rejected_cheaply_and_atomically() {
+    let env = Env::default();
+    let (_admin, vault, client) = setup(&env);
+    let token = Address::generate(&env);
+    let dev = Address::generate(&env);
+
+    let mut items = Vec::new(&env);
+    items.push_back((dev.clone(), 100_i128));
+    for _ in 0..50 {
+        items.push_back((Address::generate(&env), 100_i128));
+    }
+
+    env.budget().reset_tracker();
+    let res = client.try_batch_receive_payment(&vault, &items, &token, &1);
+    let used_cpu = env.budget().cpu_instruction_cost();
+    let used_mem = env.budget().memory_bytes_cost();
+
+    assert!(res.is_err(), "over-limit batch must be rejected");
+    assert!(
+        used_cpu <= REJECT_CPU_CEILING,
+        "over-limit rejection consumed too much CPU: {used_cpu} > {REJECT_CPU_CEILING}"
+    );
+    assert!(
+        used_mem <= REJECT_MEM_CEILING,
+        "over-limit rejection consumed too much memory: {used_mem} > {REJECT_MEM_CEILING}"
+    );
+    // No partial state: the batch is rejected before any balance is written.
+    assert_eq!(
+        client.get_developer_balance(&dev, &token),
+        0,
+        "rejected batch must not write balances"
+    );
+}
+
+#[test]
+fn batch_receive_payment_invalid_amount_leaves_no_partial_state() {
+    let env = Env::default();
+    let (_admin, vault, client) = setup(&env);
+    let token = Address::generate(&env);
+    let dev = Address::generate(&env);
+
+    let mut items = Vec::new(&env);
+    items.push_back((dev.clone(), 100_i128));
+    // Invalid amount in the middle of the batch.
+    items.push_back((Address::generate(&env), 0_i128));
+    for _ in 0..10 {
+        items.push_back((Address::generate(&env), 100_i128));
+    }
+
+    env.budget().reset_tracker();
+    let res = client.try_batch_receive_payment(&vault, &items, &token, &1);
+    let used_cpu = env.budget().cpu_instruction_cost();
+    let used_mem = env.budget().memory_bytes_cost();
+
+    assert!(res.is_err(), "batch with invalid amount must be rejected");
+    assert!(
+        used_cpu <= REJECT_CPU_CEILING,
+        "invalid-amount rejection consumed too much CPU: {used_cpu} > {REJECT_CPU_CEILING}"
+    );
+    assert!(
+        used_mem <= REJECT_MEM_CEILING,
+        "invalid-amount rejection consumed too much memory: {used_mem} > {REJECT_MEM_CEILING}"
+    );
+    // Validation runs before any state mutation: nothing may be credited.
+    assert_eq!(
+        client.get_developer_balance(&dev, &token),
+        0,
+        "rejected batch must not credit the valid leading item"
+    );
+}
+
+#[test]
+fn batch_receive_payment_storage_growth_is_bounded() {
+    let env = Env::default();
+    let (_admin, vault, client) = setup(&env);
+    let token = Address::generate(&env);
+
+    // Seed 100 distinct developers in two max-size batches.
+    let mut first = Vec::new(&env);
+    for _ in 0..50 {
+        first.push_back((Address::generate(&env), 50_i128));
+    }
+    client.batch_receive_payment(&vault, &first, &token, &1);
+
+    // Re-credit the SAME 50 developers: the developer index must not grow
+    // (sorted_insert dedupes), so storage growth stays bounded.
+    client.batch_receive_payment(&vault, &first, &token, &2);
+
+    let page = client.get_developer_balances_page(&_admin, &0, &100, &token);
+    assert_eq!(page.len(), 50, "index must not grow on re-credit");
+
+    // A second distinct set of 50 grows the index to exactly 100.
+    let mut second = Vec::new(&env);
+    for _ in 0..50 {
+        second.push_back((Address::generate(&env), 50_i128));
+    }
+    client.batch_receive_payment(&vault, &second, &token, &3);
+    let page = client.get_developer_balances_page(&_admin, &0, &100, &token);
+    assert_eq!(
+        page.len(),
+        100,
+        "index must track distinct developers exactly"
+    );
+}
+
+// ─── batch_settle ───────────────────────────────────────────────────────────
+
+#[test]
+fn batch_settle_single_item_within_budget() {
+    let env = Env::default();
+    let (admin, _vault, client) = setup(&env);
+    let dev = Address::generate(&env);
+    let token = Address::generate(&env);
+    // Configure USDC so the per-item withdrawal path is fully exercised
+    // (fails with InsufficientBalance instead of UsdcTokenNotConfigured).
+    client.set_usdc_token(&admin, &token);
+
+    let mut settles = Vec::new(&env);
+    settles.push_back(callora_settlement::batch::SettleInput {
+        developer: dev.clone(),
+        amount: 100,
+        to: None,
+    });
+
+    env.budget().reset_tracker();
+    let outcomes = client.batch_settle(&settles);
+    let used_cpu = env.budget().cpu_instruction_cost();
+    let used_mem = env.budget().memory_bytes_cost();
+
+    assert_eq!(outcomes.len(), 1);
+    assert_eq!(
+        outcomes.get(0).unwrap(),
+        callora_settlement::batch::SettleOutcome::InsufficientBalance,
+        "unfunded developer must report a bounded per-item outcome"
+    );
+    assert!(
+        used_cpu <= BS_ONE_CPU_CEILING,
+        "single-item batch_settle exceeded CPU ceiling: {used_cpu} > {BS_ONE_CPU_CEILING}"
+    );
+    assert!(
+        used_mem <= BS_ONE_MEM_CEILING,
+        "single-item batch_settle exceeded memory ceiling: {used_mem} > {BS_ONE_MEM_CEILING}"
+    );
+}
+
+#[test]
+fn batch_settle_over_cap_rejected_within_budget() {
+    let env = Env::default();
+    let (_admin, _vault, client) = setup(&env);
+
+    let mut settles = Vec::new(&env);
+    for _ in 0..65 {
+        settles.push_back(callora_settlement::batch::SettleInput {
+            developer: Address::generate(&env),
+            amount: 100,
+            to: None,
+        });
+    }
+
+    env.budget().reset_tracker();
+    let outcomes = client.batch_settle(&settles);
+    let used_cpu = env.budget().cpu_instruction_cost();
+    let used_mem = env.budget().memory_bytes_cost();
+
+    assert_eq!(outcomes.len(), 65, "outcome count must match input count");
+    for i in 0..65 {
+        assert_eq!(
+            outcomes.get(i).unwrap(),
+            callora_settlement::batch::SettleOutcome::OtherError,
+            "over-cap item {i} must be OtherError"
+        );
+    }
+    assert!(
+        used_cpu <= BS_OVER_CAP_CPU_CEILING,
+        "over-cap batch_settle exceeded CPU ceiling: {used_cpu} > {BS_OVER_CAP_CPU_CEILING}"
+    );
+    assert!(
+        used_mem <= BS_OVER_CAP_MEM_CEILING,
+        "over-cap batch_settle exceeded memory ceiling: {used_mem} > {BS_OVER_CAP_MEM_CEILING}"
+    );
+}
+
+// ─── Pagination ─────────────────────────────────────────────────────────────
+
+#[test]
+fn get_developer_balances_page_full_page_within_budget() {
+    let env = Env::default();
+    let (admin, vault, client) = setup(&env);
+    let token = Address::generate(&env);
+
+    for _ in 0..2 {
+        let mut items = Vec::new(&env);
+        for _ in 0..50 {
+            items.push_back((Address::generate(&env), 50_i128));
+        }
+        client.batch_receive_payment(&vault, &items, &token, &1);
+    }
+
+    env.budget().reset_tracker();
+    let page = client.get_developer_balances_page(&admin, &0, &100, &token);
+    let used_cpu = env.budget().cpu_instruction_cost();
+    let used_mem = env.budget().memory_bytes_cost();
+
+    assert_eq!(page.len(), 100);
+    assert!(
+        used_cpu <= PAGE_CPU_CEILING,
+        "full-page read exceeded CPU ceiling: {used_cpu} > {PAGE_CPU_CEILING}"
+    );
+    assert!(
+        used_mem <= PAGE_MEM_CEILING,
+        "full-page read exceeded memory ceiling: {used_mem} > {PAGE_MEM_CEILING}"
+    );
+}
+
+// ─── Explicit input-size limits ─────────────────────────────────────────────
+
+#[test]
+fn broadcast_message_length_is_capped() {
+    let env = Env::default();
+    let (admin, _vault, client) = setup(&env);
+
+    // Exactly at the cap: accepted.
+    let ok_msg = String::from_str(&env, &"x".repeat(1024));
+    client.broadcast(&admin, &callora_settlement::Severity::Info, &ok_msg);
+
+    // One byte over the cap: rejected before any event is emitted.
+    let too_long = String::from_str(&env, &"x".repeat(1025));
+    let res = client.try_broadcast(&admin, &callora_settlement::Severity::Info, &too_long);
+    assert!(res.is_err(), "over-length broadcast must be rejected");
+
+    // Non-admin callers are still rejected (auth unchanged).
+    let stranger = Address::generate(&env);
+    env.set_auths(&[]);
+    let res = client.try_broadcast(&stranger, &callora_settlement::Severity::Info, &ok_msg);
+    assert!(res.is_err(), "non-admin broadcast must be rejected");
+}
+
+#[test]
+fn batch_withdraw_balance_cursor_cap_enforced() {
+    let env = Env::default();
+    let (_admin, _vault, client) = setup(&env);
+
+    let mut developers = Vec::new(&env);
+    let mut amounts = Vec::new(&env);
+    for _ in 0..51 {
+        developers.push_back(Address::generate(&env));
+        amounts.push_back(100_i128);
+    }
+
+    let panicked = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        client.batch_withdraw_balance_cursor(&developers, &amounts, &0, &50);
+    }))
+    .is_err();
+    assert!(panicked, "over-cap batch_withdraw must be rejected");
+}

--- a/docs/ERROR_CODES.md
+++ b/docs/ERROR_CODES.md
@@ -97,6 +97,21 @@ must not be reassigned once released.
 | 25 | `ClaimWindowClosed` | Settlement | Developer claim window is not currently open |
 | 26 | `MinBalanceViolation` | Settlement | Withdrawal would leave balance below the minimum |
 | 27 | `ReplayDetected` | Settlement | Settlement request reused or regressed the replay-guard ledger sequence |
+| 28 | `BatchEmpty` | Settlement | Batch operation received an empty vector |
+| 29 | `BatchTooLarge` | Settlement | Batch operation exceeded the maximum allowed size |
+| 30 | `DeveloperFrozen` | Settlement | Developer is frozen and cannot withdraw |
+| 31 | `DeveloperNotFrozen` | Settlement | Developer is not frozen; cannot unfreeze |
+| 32 | `FreezeUnauthorized` | Settlement | Caller is not authorized to freeze/unfreeze |
+| 33 | `WriteRateLimitExceeded` | Settlement | Admin wrote prices too frequently |
+| 34 | `InvalidConfigDistinct` | Settlement | Init config requires distinct admin and vault |
+| 35 | `InvalidConfigAdminContract` | Settlement | Init config forbids the admin being the contract |
+| 36 | `InvalidConfigVaultContract` | Settlement | Init config forbids the vault being the contract |
+| 37 | `InvalidUsdcToken` | Settlement | USDC token address is invalid |
+| 38 | `InvalidRecipient` | Settlement | Withdrawal recipient cannot be the contract |
+| 39 | `NoAdminTransferPending` | Settlement | No admin transfer is pending |
+| 40 | `InvalidVault` | Settlement | Vault address is invalid |
+| 41 | `NoVaultRotationPending` | Settlement | No vault rotation is pending |
+| 42 | `BroadcastMessageTooLong` | Settlement | Admin broadcast message exceeds the maximum length |
 
 ## Revenue Pool
 


### PR DESCRIPTION
## What this fixes

Closes #1069 — "Add gas regression limits for settlement entry points". Resource consumption across settlement's batch/looping entry points must be bounded and predictable for normal, batch, and adversarial inputs, with explicit limits on input size, batch size, loops, and storage growth, enforced by regression tests.

## Root cause

Audit of the settlement entry points that loop over caller-supplied input:

| Entry point | Prior state | Bound |
|---|---|---|
| `batch_receive_payment` | ✅ already capped at `MAX_BATCH_SIZE` (50), validates all amounts + replay guards before any write | enforced |
| `batch_settle` | ✅ hardcoded 64-item cap | enforced |
| `get_developer_balances_page` / `_cursor` | ✅ capped at `MAX_DEVELOPER_BALANCES_PAGE_SIZE` (100) | enforced |
| `migrate_v1_to_v2_page` | ✅ capped at `MAX_BATCH_SIZE` | enforced |
| `archive_events` | ❌ **unbounded `batch_size`** — a caller-supplied value drove the archival loop and storage writes with no cap | **fixed** |
| `broadcast` | ❌ **unbounded message length** — admin-only but a public entry point with an unbounded input | **fixed** |
| `batch_withdraw_balance_cursor` | ❌ no batch-size check (placeholder entry point) | **fixed** |

The limits existed for the main batch paths but were neither complete (three gaps above) nor enforced by any test that would catch a future removal or an unbounded-input regression.

## The fix and why

1. **Close the three explicit-limit gaps** (smallest possible changes, matching the repo's existing `min(MAX_BATCH_SIZE)` style):
   - `archive_events` now caps `batch_size` at `MAX_BATCH_SIZE` — the loop and per-event storage writes are bounded regardless of the caller-supplied value.
   - `broadcast` rejects messages longer than the new `MAX_BROADCAST_MESSAGE_LEN` (1024 bytes) with a new `BroadcastMessageTooLong` error **before** any event is emitted.
   - `batch_withdraw_balance_cursor` rejects batches over `MAX_BATCH_SIZE` with the existing `BatchTooLarge` error.
2. **Regression tests** (`contracts/settlement/tests/gas_regression.rs`, 10 tests) that measure CPU instructions and memory via the host budget tracker and fail if a call exceeds its documented ceiling:
   - `batch_receive_payment` at 1 and 50 items — the max-size batch must fit inside a hard enforced budget (`reset_limits` panics if exceeded) and a documented ceiling;
   - `batch_settle` at 1 item and the 65-item over-cap rejection — bounded per-item cost;
   - a full 100-record paginated read — bounded page cost;
   - over-limit and invalid-amount rejections are **cheap** (bounded) and leave **no partial state** (balances/index untouched);
   - re-crediting existing developers does not grow the developer index (bounded storage growth);
   - the new input-size limits (`broadcast` at 1024/1025 bytes, `batch_withdraw` at 51) are enforced.
3. **Required correctness unblocks** (all in-crate, reported transparently):
   - `batch_settle` issued a redundant top-level `claimant.require_auth()` — per-item authorization already runs inside `withdraw_developer_balance` — and the duplicate auth call panics with `Auth, ExistingValue` under the SDK's mock auth, making the success path untestable and breaking `test_batch_settle_cross_tenant_fails`. Removed; authorization semantics are unchanged (every item still requires the claimant's auth).
   - Removed two pre-existing merge artifacts that prevented the crate from compiling at all (duplicate `pub mod errors;` and a redundant `use crate::errors::SettlementError;` shadowing the `pub use` re-export) — without them no settlement test could run.
   - Extends the error-code table (rows 28–42) consistently across `errors.rs`, `test_error_codes.rs`, and `docs/ERROR_CODES.md` for the new variant.

Why regression tests with measured budgets rather than only static caps: the caps guarantee bounded loops, but the issue's acceptance criteria also demand that normal and adversarial inputs stay within documented resource budgets and that failure paths don't consume unbounded resources. Budget-tracker assertions enforce exactly that, and they fail loudly if a future change multiplies per-item cost (e.g. a per-item scan re-introduced, a cap removed).

## How it was tested

- `cargo test -p callora-settlement --lib --test auth_snap --test rustdoc_entrypoints --test gas_regression` → **128 passed** (gas_regression: 10/10; new `archive_events_batch_size_is_capped` unit test; `test_batch_settle_cross_tenant_fails` now passes).
- Ceilings were calibrated from measured native-test cost with ~2x headroom (SDK documents native tests underestimate WASM cost) and are documented in the test file.
- Changed files pass `rustfmt --check`.
- **Pre-existing failures reported separately (not from this change):** 18 lib tests fail with `as_contract`-context rot in `test_ttl_bump`/`test_events`/`test_overflow_safe_math` on `main` (the crate never compiled on `main` due to the duplicate `pub mod errors;`, so this suite could not run at all before); `tests/proptest.rs` does not compile on `main` (stale `.unwrap()` on plain getter returns).
- One harness limitation documented: under the SDK's mock auth, repeated `require_auth` for the same claimant within one invocation errors with `Auth, ExistingValue`, so the multi-item same-claimant `batch_settle` path cannot be driven from tests with `mock_all_auths` (real-mode auth handles it via invocation trees — this is exactly what the removed redundant `require_auth` broke). That path is covered by the 1-item gas test, the over-cap test, and the in-crate unit tests; `fuzz/targets/settlement.rs` exercises it on-chain.

## Follow-ups worth filing separately

- The `settlement` fuzz target treats the `Auth, ExistingValue` panic as an acceptable rollback path; once the redundant `require_auth` removal lands, extend the fuzz harness to assert the per-outcome conservation invariants on the success path too.
- Repair-main-CI issue for the other pre-existing breakage (distribute generics-in-contract-fn, validators proptest import, settlement proptest `unwrap()`s) so the whole workspace builds and tests.