### PR TITLE
feat: allow only approved payment assets in escrow creation

### DIFF
--- a/contracts/escrow/src/errors.rs
+++ b/contracts/escrow/src/errors.rs
@@ -15,6 +15,9 @@ use soroban_sdk::contracterror;
 /// | 5    | InvalidCooldown     | Proposed cooldown value is outside the accepted range        |
 /// | 6    | NoPendingAdmin      | No admin transfer is currently pending                       |
 /// | 7    | Overflow            | Arithmetic overflow detected                                 |
+/// | 8    | AssetNotApproved    | Payment asset is not approved for escrow creation            |
+/// | 9    | InvalidInput        | A supplied input is malformed or forbidden                    |
+/// | 10   | EscrowExists        | Escrow already exists for the given payment asset and recipient |
 #[contracterror]
 #[derive(Clone, Copy, Debug, PartialEq)]
 #[repr(u32)]
@@ -33,4 +36,10 @@ pub enum EscrowError {
     NoPendingAdmin = 6,
     /// Arithmetic overflow detected (code 7).
     Overflow = 7,
+    /// Payment asset is not approved for escrow creation (code 8).
+    AssetNotApproved = 8,
+    /// A supplied input is malformed or forbidden (code 9).
+    InvalidInput = 9,
+    /// Escrow already exists for the given payment asset and recipient (code 10).
+    EscrowExists = 10,
 }

--- a/contracts/escrow/src/events.rs
+++ b/contracts/escrow/src/events.rs
@@ -47,6 +47,30 @@ pub fn event_admin_accepted(env: &Env) -> Symbol {
     Symbol::new(env, "admin_accepted")
 }
 
+/// Returns the Symbol for the `"asset_approved"` event topic.
+///
+/// Emitted when the admin marks a payment asset as approved for escrow
+/// creation via [`crate::CalloraEscrow::add_approved_asset`].
+pub fn event_asset_approved(env: &Env) -> Symbol {
+    Symbol::new(env, "asset_approved")
+}
+
+/// Returns the Symbol for the `"asset_removed"` event topic.
+///
+/// Emitted when the admin revokes a payment asset approval via
+/// [`crate::CalloraEscrow::remove_approved_asset`].
+pub fn event_asset_removed(env: &Env) -> Symbol {
+    Symbol::new(env, "asset_removed")
+}
+
+/// Returns the Symbol for the `"escrow_created"` event topic.
+///
+/// Emitted when a new escrow is successfully created against an approved
+/// payment asset via [`crate::CalloraEscrow::create_escrow`].
+pub fn event_escrow_created(env: &Env) -> Symbol {
+    Symbol::new(env, "escrow_created")
+}
+
 /// Returns the Symbol for the canonical event version marker used by Callora.
 pub fn event_version_v1(env: &Env) -> Symbol {
     Symbol::new(env, "callora.v1")
@@ -95,6 +119,36 @@ mod tests {
         assert_eq!(
             event_admin_accepted(&env),
             Symbol::new(&env, "admin_accepted")
+        );
+    }
+
+    /// Snapshot: proves event_asset_approved still maps to exactly the bytes for "asset_approved".
+    #[test]
+    fn test_event_asset_approved_bytes() {
+        let env = Env::default();
+        assert_eq!(
+            event_asset_approved(&env),
+            Symbol::new(&env, "asset_approved")
+        );
+    }
+
+    /// Snapshot: proves event_asset_removed still maps to exactly the bytes for "asset_removed".
+    #[test]
+    fn test_event_asset_removed_bytes() {
+        let env = Env::default();
+        assert_eq!(
+            event_asset_removed(&env),
+            Symbol::new(&env, "asset_removed")
+        );
+    }
+
+    /// Snapshot: proves event_escrow_created still maps to exactly the bytes for "escrow_created".
+    #[test]
+    fn test_event_escrow_created_bytes() {
+        let env = Env::default();
+        assert_eq!(
+            event_escrow_created(&env),
+            Symbol::new(&env, "escrow_created")
         );
     }
 }

--- a/contracts/escrow/src/lib.rs
+++ b/contracts/escrow/src/lib.rs
@@ -63,6 +63,28 @@ pub enum StorageKey {
     Paused,
     /// Instance: the currently-authorized escrow signer [`Address`].
     Signer,
+    /// Instance: approval flag for an escrow payment asset (`bool`).
+    /// Deny-by-default: absent means the asset is not approved.
+    ApprovedAsset(Address),
+    /// Instance: escrow record keyed by `(payment_asset, recipient)`.
+    Escrow(Address, Address),
+}
+
+/// A recorded escrow created under a specific approved payment asset.
+///
+/// Stored in instance storage, keyed by `(payment_asset, recipient)`, so a
+/// repeated creation attempt with the same inputs is rejected as a replay.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct EscrowRecord {
+    /// The payment asset contract bound to this escrow.
+    pub payment_asset: Address,
+    /// The designated recipient of the escrowed funds.
+    pub recipient: Address,
+    /// Escrow amount denominated in the payment asset micro-units.
+    pub amount: i128,
+    /// Ledger timestamp at which the escrow was created.
+    pub created_at: u64,
 }
 
 // ---------------------------------------------------------------------------
@@ -354,6 +376,178 @@ impl CalloraEscrow {
         env.events()
             .publish((events::event_action(&env), caller), action);
 
+        Ok(())
+    }
+
+    /// Return whether `asset` is approved for use as a payment asset when
+    /// creating an escrow.
+    ///
+    /// This is a deny-by-default boundary: any asset that has not been
+    /// explicitly approved by the admin returns `false` and is therefore not
+    /// accepted by [`CalloraEscrow::create_escrow`].
+    pub fn is_asset_approved(env: Env, asset: Address) -> bool {
+        env.storage()
+            .instance()
+            .get(&StorageKey::ApprovedAsset(asset))
+            .unwrap_or(false)
+    }
+
+    /// Return the escrow record for a `(payment_asset, recipient)` pair.
+    ///
+    /// Returns `None` when no escrow has been created for the pair. This is a
+    /// read-only view for on-chain auditability of created escrows.
+    pub fn get_escrow(
+        env: Env,
+        payment_asset: Address,
+        recipient: Address,
+    ) -> Option<EscrowRecord> {
+        env.storage()
+            .instance()
+            .get(&StorageKey::Escrow(payment_asset, recipient))
+    }
+
+    /// Approve `asset` as a payment asset for future escrow creation.
+    ///
+    /// Only the current admin may grant approval; the check runs before any
+    /// state is written. Approving an already-approved asset is idempotent.
+    ///
+    /// # Parameters
+    /// * `caller` -- Must be the current admin; must authorize.
+    /// * `asset` -- The payment asset contract to approve.
+    ///
+    /// # Errors
+    /// * [`EscrowError::Unauthorized`] -- caller is not the current admin.
+    /// * [`EscrowError::NotInitialized`] -- contract not initialized.
+    /// * [`EscrowError::InvalidInput`] -- `asset` resolves to the contract itself.
+    ///
+    /// # Events
+    /// Emits `asset_approved` with `caller` as topic and `asset` as data.
+    pub fn add_approved_asset(
+        env: Env,
+        caller: Address,
+        asset: Address,
+    ) -> Result<(), EscrowError> {
+        Self::require_admin(&env, &caller)?;
+        Self::validate_asset(&env, &asset)?;
+
+        env.storage()
+            .instance()
+            .set(&StorageKey::ApprovedAsset(asset.clone()), &true);
+
+        env.events()
+            .publish((events::event_asset_approved(&env), caller), asset);
+
+        Ok(())
+    }
+
+    /// Revoke approval for a previously approved payment asset.
+    ///
+    /// Only the current admin may revoke approval. After revocation the asset
+    /// can no longer be used to create new escrows, but existing escrows are
+    /// left intact. Revoking an asset that is not approved is a no-op.
+    ///
+    /// # Parameters
+    /// * `caller` -- Must be the current admin; must authorize.
+    /// * `asset` -- The payment asset contract to revoke.
+    ///
+    /// # Errors
+    /// * [`EscrowError::Unauthorized`] -- caller is not the current admin.
+    /// * [`EscrowError::NotInitialized`] -- contract not initialized.
+    /// * [`EscrowError::InvalidInput`] -- `asset` resolves to the contract itself.
+    ///
+    /// # Events
+    /// Emits `asset_removed` with `caller` as topic and `asset` as data.
+    pub fn remove_approved_asset(
+        env: Env,
+        caller: Address,
+        asset: Address,
+    ) -> Result<(), EscrowError> {
+        Self::require_admin(&env, &caller)?;
+        Self::validate_asset(&env, &asset)?;
+
+        let key = StorageKey::ApprovedAsset(asset.clone());
+        if env.storage().instance().has(&key) {
+            env.storage().instance().remove(&key);
+        }
+
+        env.events()
+            .publish((events::event_asset_removed(&env), caller), asset);
+
+        Ok(())
+    }
+
+    /// Create a new escrow bound to an approved payment asset.
+    ///
+    /// Authorization, validation, and least-privilege checks all run before any
+    /// state is written. The `payment_asset` must have been approved via
+    /// [`CalloraEscrow::add_approved_asset`]; unapproved, malformed, and replay
+    /// inputs fail closed without leaking protected detail.
+    ///
+    /// # Parameters
+    /// * `caller` -- Must be the current admin; must authorize.
+    /// * `payment_asset` -- The approved payment asset for this escrow.
+    /// * `recipient` -- The designated recipient of the escrowed funds.
+    /// * `amount` -- Escrow amount in payment asset micro-units; must be > 0.
+    ///
+    /// # Errors
+    /// * [`EscrowError::Unauthorized`] -- caller is not the current admin.
+    /// * [`EscrowError::NotInitialized`] -- contract not initialized.
+    /// * [`EscrowError::InvalidInput`] -- `payment_asset` or `recipient` resolve
+    ///   to the contract itself, or `amount` is not positive.
+    /// * [`EscrowError::AssetNotApproved`] -- `payment_asset` is not approved.
+    /// * [`EscrowError::EscrowExists`] -- an escrow for the same
+    ///   `(payment_asset, recipient)` already exists (replay).
+    ///
+    /// # Events
+    /// Emits `escrow_created` with `caller` as topic and the new
+    /// [`EscrowRecord`] as data.
+    pub fn create_escrow(
+        env: Env,
+        caller: Address,
+        payment_asset: Address,
+        recipient: Address,
+        amount: i128,
+    ) -> Result<(), EscrowError> {
+        Self::require_admin(&env, &caller)?;
+        Self::validate_asset(&env, &payment_asset)?;
+        if recipient == env.current_contract_address() {
+            return Err(EscrowError::InvalidInput);
+        }
+        if amount <= 0 {
+            return Err(EscrowError::InvalidInput);
+        }
+        if !Self::is_asset_approved(env.clone(), payment_asset.clone()) {
+            return Err(EscrowError::AssetNotApproved);
+        }
+
+        let key = StorageKey::Escrow(payment_asset.clone(), recipient.clone());
+        if env.storage().instance().has(&key) {
+            return Err(EscrowError::EscrowExists);
+        }
+
+        let record = EscrowRecord {
+            payment_asset: payment_asset.clone(),
+            recipient: recipient.clone(),
+            amount,
+            created_at: env.ledger().timestamp(),
+        };
+        env.storage().instance().set(&key, &record);
+
+        env.events()
+            .publish((events::event_escrow_created(&env), caller), record);
+
+        Ok(())
+    }
+
+    /// Reject `asset` when it resolves to the contract's own address.
+    ///
+    /// A payment asset must never be the escrow contract itself, which would
+    /// otherwise allow funds to be routed back into the escrow in an unintended
+    /// way. Returns [`EscrowError::InvalidInput`] when the asset is self.
+    fn validate_asset(env: &Env, asset: &Address) -> Result<(), EscrowError> {
+        if asset == &env.current_contract_address() {
+            return Err(EscrowError::InvalidInput);
+        }
         Ok(())
     }
 

--- a/contracts/escrow/src/test.rs
+++ b/contracts/escrow/src/test.rs
@@ -384,3 +384,239 @@ fn test_new_admin_can_perform_guarded_actions_after_rotation() {
     client.unpause(&new_admin);
     client.release(&new_admin, &recipient);
 }
+
+/// An approved-asset flag is never set by default (deny-by-default).
+#[test]
+fn test_is_asset_approved_deny_by_default() {
+    let (env, _admin, _signer, client) = setup(Some(60));
+    let asset = Address::generate(&env);
+    assert!(!client.is_asset_approved(&asset));
+}
+
+/// Approving an asset flips the deny-by-default flag to `true`.
+#[test]
+fn test_add_approved_asset_flips_flag() {
+    let (env, admin, _signer, client) = setup(Some(60));
+    let asset = Address::generate(&env);
+    assert!(!client.is_asset_approved(&asset));
+    client.add_approved_asset(&admin, &asset);
+    assert!(client.is_asset_approved(&asset));
+}
+
+/// Only the admin may approve an asset.
+#[test]
+fn test_add_approved_asset_requires_admin() {
+    let (env, _admin, _signer, client) = setup(Some(60));
+    let intruder = Address::generate(&env);
+    let asset = Address::generate(&env);
+    assert_eq!(
+        client.try_add_approved_asset(&intruder, &asset),
+        Err(Ok(EscrowError::Unauthorized))
+    );
+}
+
+/// Approving the contract's own address is rejected as malformed.
+#[test]
+fn test_add_approved_asset_rejects_self() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let signer = Address::generate(&env);
+    let contract_id = env.register(CalloraEscrow, ());
+    let client = CalloraEscrowClient::new(&env, &contract_id);
+    client.init(&admin, &signer, &Some(60));
+
+    assert_eq!(
+        client.try_add_approved_asset(&admin, &contract_id),
+        Err(Ok(EscrowError::InvalidInput))
+    );
+}
+
+/// Revoking an approved asset flips the flag back to `false`.
+#[test]
+fn test_remove_approved_asset_revokes() {
+    let (env, admin, _signer, client) = setup(Some(60));
+    let asset = Address::generate(&env);
+    client.add_approved_asset(&admin, &asset);
+    assert!(client.is_asset_approved(&asset));
+    client.remove_approved_asset(&admin, &asset);
+    assert!(!client.is_asset_approved(&asset));
+}
+
+/// Only the admin may revoke an asset approval.
+#[test]
+fn test_remove_approved_asset_requires_admin() {
+    let (env, _admin, _signer, client) = setup(Some(60));
+    let intruder = Address::generate(&env);
+    let asset = Address::generate(&env);
+    assert_eq!(
+        client.try_remove_approved_asset(&intruder, &asset),
+        Err(Ok(EscrowError::Unauthorized))
+    );
+}
+
+/// Revoking the contract's own address is rejected as malformed.
+#[test]
+fn test_remove_approved_asset_rejects_self() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let signer = Address::generate(&env);
+    let contract_id = env.register(CalloraEscrow, ());
+    let client = CalloraEscrowClient::new(&env, &contract_id);
+    client.init(&admin, &signer, &Some(60));
+
+    assert_eq!(
+        client.try_remove_approved_asset(&admin, &contract_id),
+        Err(Ok(EscrowError::InvalidInput))
+    );
+}
+
+/// Creating an escrow against an approved asset records it and emits an event.
+#[test]
+fn test_create_escrow_success_and_record() {
+    let (env, admin, _signer, client) = setup(Some(60));
+    let asset = Address::generate(&env);
+    let recipient = Address::generate(&env);
+    client.add_approved_asset(&admin, &asset);
+
+    let now = env.ledger().timestamp();
+    client.create_escrow(&admin, &asset, &recipient, &1000);
+
+    let record = client.get_escrow(&asset, &recipient).unwrap();
+    assert_eq!(record.payment_asset, asset);
+    assert_eq!(record.recipient, recipient);
+    assert_eq!(record.amount, 1000);
+    assert_eq!(record.created_at, now);
+}
+
+/// An unapproved asset is rejected and nothing is recorded (fail closed).
+#[test]
+fn test_create_escrow_unapproved_asset_fails_closed() {
+    let (env, admin, _signer, client) = setup(Some(60));
+    let asset = Address::generate(&env);
+    let recipient = Address::generate(&env);
+    assert_eq!(
+        client.try_create_escrow(&admin, &asset, &recipient, &1000),
+        Err(Ok(EscrowError::AssetNotApproved))
+    );
+    assert!(client.get_escrow(&asset, &recipient).is_none());
+}
+
+/// Only the admin may create an escrow.
+#[test]
+fn test_create_escrow_requires_admin() {
+    let (env, _admin, _signer, client) = setup(Some(60));
+    let intruder = Address::generate(&env);
+    let asset = Address::generate(&env);
+    let recipient = Address::generate(&env);
+    assert_eq!(
+        client.try_create_escrow(&intruder, &asset, &recipient, &1000),
+        Err(Ok(EscrowError::Unauthorized))
+    );
+}
+
+/// Using the contract itself as the payment asset is rejected as malformed.
+#[test]
+fn test_create_escrow_rejects_self_payment_asset() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let signer = Address::generate(&env);
+    let contract_id = env.register(CalloraEscrow, ());
+    let client = CalloraEscrowClient::new(&env, &contract_id);
+    client.init(&admin, &signer, &Some(60));
+
+    let recipient = Address::generate(&env);
+    assert_eq!(
+        client.try_create_escrow(&admin, &contract_id, &recipient, &1000),
+        Err(Ok(EscrowError::InvalidInput))
+    );
+}
+
+/// Using the contract itself as the recipient is rejected as malformed.
+#[test]
+fn test_create_escrow_rejects_self_recipient() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let signer = Address::generate(&env);
+    let contract_id = env.register(CalloraEscrow, ());
+    let client = CalloraEscrowClient::new(&env, &contract_id);
+    client.init(&admin, &signer, &Some(60));
+
+    let asset = Address::generate(&env);
+    client.add_approved_asset(&admin, &asset);
+    assert_eq!(
+        client.try_create_escrow(&admin, &asset, &contract_id, &1000),
+        Err(Ok(EscrowError::InvalidInput))
+    );
+}
+
+/// A non-positive amount is rejected before any state is written.
+#[test]
+fn test_create_escrow_rejects_non_positive_amount() {
+    let (env, admin, _signer, client) = setup(Some(60));
+    let asset = Address::generate(&env);
+    let recipient = Address::generate(&env);
+    client.add_approved_asset(&admin, &asset);
+    assert_eq!(
+        client.try_create_escrow(&admin, &asset, &recipient, &0),
+        Err(Ok(EscrowError::InvalidInput))
+    );
+    assert_eq!(
+        client.try_create_escrow(&admin, &asset, &recipient, &-1),
+        Err(Ok(EscrowError::InvalidInput))
+    );
+    assert!(client.get_escrow(&asset, &recipient).is_none());
+}
+
+/// Replaying the same creation inputs fails closed with `EscrowExists`.
+#[test]
+fn test_create_escrow_rejects_replay() {
+    let (env, admin, _signer, client) = setup(Some(60));
+    let asset = Address::generate(&env);
+    let recipient = Address::generate(&env);
+    client.add_approved_asset(&admin, &asset);
+    client.create_escrow(&admin, &asset, &recipient, &1000);
+    assert_eq!(
+        client.try_create_escrow(&admin, &asset, &recipient, &2000),
+        Err(Ok(EscrowError::EscrowExists))
+    );
+}
+
+/// A stale (revoked) approval is no longer honored for new escrows.
+#[test]
+fn test_create_escrow_after_revoke_fails_closed() {
+    let (env, admin, _signer, client) = setup(Some(60));
+    let asset = Address::generate(&env);
+    let recipient = Address::generate(&env);
+    client.add_approved_asset(&admin, &asset);
+    client.remove_approved_asset(&admin, &asset);
+    assert_eq!(
+        client.try_create_escrow(&admin, &asset, &recipient, &1000),
+        Err(Ok(EscrowError::AssetNotApproved))
+    );
+}
+
+/// Approval is scoped to each escrow instance (cross-tenant isolation).
+#[test]
+fn test_approval_registry_is_scoped_per_instance() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let signer = Address::generate(&env);
+    let asset = Address::generate(&env);
+
+    let c1 = env.register(CalloraEscrow, ());
+    let client1 = CalloraEscrowClient::new(&env, &c1);
+    client1.init(&admin, &signer, &Some(60));
+
+    let c2 = env.register(CalloraEscrow, ());
+    let client2 = CalloraEscrowClient::new(&env, &c2);
+    client2.init(&admin, &signer, &Some(60));
+
+    client1.add_approved_asset(&admin, &asset);
+    assert!(client1.is_asset_approved(&asset));
+    assert!(!client2.is_asset_approved(&asset));
+}


### PR DESCRIPTION
## Summary

Allow only approved payment assets in escrow creation for the `callora-escrow` contract. The contract now maintains a deny-by-default approved-asset registry and an admin-gated `create_escrow` entrypoint. Authorization and validation run before any sensitive mutation, and invalid or unauthorized inputs fail closed without leaking protected details.

## Changes

- Added `StorageKey::ApprovedAsset(Address)` and `StorageKey::Escrow(Address, Address)`.
- Added `EscrowRecord` with payment asset, recipient, amount, and creation time.
- Added `is_asset_approved`, `get_escrow`, `add_approved_asset`, `remove_approved_asset`, and `create_escrow`.
- `create_escrow` ordering:
  - `require_admin`
  - asset/recipient/amount validation
  - approved-asset check
  - replay check
  - state writes only after all checks pass
- Added stable error variants: `AssetNotApproved`, `InvalidInput`, `EscrowExists`.
- Added events: `asset_approved`, `asset_removed`, `escrow_created`.
- Added 16 regression tests covering deny-by-default, admin-only actions, malformed inputs, unapproved creation, replay protection, stale/revoked approvals, and cross-instance isolation.

## Security and failure-mode handling

- All authorization and validation checks run before any storage mutation.
- Default asset approval state is deny.
- Only admin can approve or revoke assets.
- Replay attempts are rejected with `EscrowExists`.
- Error messages are generic and do not expose asset addresses, recipients, amounts, or internal state.
- Secrets are not logged or emitted in events.

## Test Plan

- [x] `cargo test -p callora-escrow` — 51 passed, 0 failed.
- [x] `cargo clippy -p callora-escrow --all-targets --all-features -- -D warnings` — clean.
- [x] `cargo fmt -p callora-escrow -- --check` — clean.
- [x] `cargo build -p callora-escrow --target wasm32-unknown-unknown --release` — succeeds; WASM size 33,210 B, under the 102,400 B budget.

## Pre-existing failures reported separately

- `contracts/admin/src/test.rs` formatting diffs exist from earlier work (not touched in this PR).
- `callora-distribute` fails to compile under `cargo check --workspace` because of generics in contract functions and an unused env warning. This crate is unmodified.

## Related Issues

Closes #1049

## Checklist

- [x] Authorization, validation, and least-privilege checks run before sensitive mutation.
- [x] Invalid, stale, replayed, cross-tenant, and malformed inputs fail closed without protected-detail leakage.
- [x] Secrets are excluded from logs, errors, telemetry, exports, and client-visible state.
- [x] Negative and adversarial tests prove the security boundary.
- [x] Standard formatting, lint, build, and test commands run for the affected crate; unrelated pre-existing failures reported.
- [x] No unrelated refactors or dependency upgrades.